### PR TITLE
Default values for geopackage

### DIFF
--- a/projectgenerator/libqgsprojectgen/dataobjects/fields.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/fields.py
@@ -18,17 +18,20 @@
  ***************************************************************************/
 """
 
-from qgis.core import QgsEditorWidgetSetup
+from qgis.core import (
+    QgsEditorWidgetSetup,
+    QgsDefaultValue
+)
 
 
 class Field:
-
     def __init__(self, name):
         self.name = name
         self.alias = None
         self.read_only = False
         self.widget = None
         self.widget_config = dict()
+        self.default_value_expression = None
 
     def dump(self):
         definition = dict()
@@ -50,3 +53,7 @@ class Field:
         if self.widget:
             setup = QgsEditorWidgetSetup(self.widget, self.widget_config)
             layer.layer.setEditorWidgetSetup(field_idx, setup)
+
+        if self.default_value_expression:
+            default_value = QgsDefaultValue(self.default_value_expression)
+            layer.layer.setDefaultValueDefinition(field_idx, default_value)

--- a/projectgenerator/libqgsprojectgen/dataobjects/form.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/form.py
@@ -30,6 +30,9 @@ class Form(object):
 
     def __init__(self):
         self.__elements = list()
+        self.init_function = None
+        self.init_code = None
+        self.init_code_source = None
 
     def elements(self):
         return self.__elements
@@ -50,6 +53,24 @@ class Form(object):
                     if other_relation.referencing_field != relation.referencing_field and other_relation.referencing_layer == relation.referencing_layer and relation.referencing_layer.is_nmrel:
                         edit_form_config.setWidgetConfig(relation.id, {'nm-rel': other_relation.id})
                         break
+
+        if self.init_function:
+            edit_form_config.setInitFunction(self.init_function)
+
+        if self.init_code:
+            edit_form_config.setInitCode(self.init_code)
+
+        if self.init_code_source:
+            if self.init_code_source == 'CodeSourceNone':
+                edit_form_config.setInitCodeSource(QgsEditFormConfig.CodeSourceNone)
+            elif self.init_code_source == 'CodeSourceFile':
+                edit_form_config.setInitCodeSource(QgsEditFormConfig.CodeSourceFile)
+            elif self.init_code_source == 'CodeSourceDialog':
+                edit_form_config.setInitCodeSource(QgsEditFormConfig.CodeSourceDialog)
+            elif self.init_code_source == 'CodeSourceEnvironment':
+                edit_form_config.setInitCodeSource(QgsEditFormConfig.CodeSourceEnvironment)
+
+
         return edit_form_config
 
     def add_element(self, element):

--- a/projectgenerator/libqgsprojectgen/dataobjects/layers.py
+++ b/projectgenerator/libqgsprojectgen/dataobjects/layers.py
@@ -112,6 +112,10 @@ class Layer(object):
                     self.__form.add_element(widget)
 
     @property
+    def form(self):
+        return self.__form
+
+    @property
     def layer(self):
         return self.__layer
 

--- a/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
+++ b/projectgenerator/libqgsprojectgen/dbconnector/db_connector.py
@@ -119,6 +119,16 @@ class DBConnector:
         '''
         return []
 
+    def post_process_layer(self, layer):
+        """
+        Data source specific post processing for layers.
+        Receives a fully populated layer object. Relations are
+        still missing.
+        Can be used for example to add custom default value logic
+        as done in the gpkg_connector
+        """
+        pass
+
     def get_domainili_domaindb_mapping(self, domains):
         """TODO: remove when ili2db issue #19 is solved"""
         return {}

--- a/projectgenerator/libqgsprojectgen/generator/generator.py
+++ b/projectgenerator/libqgsprojectgen/generator/generator.py
@@ -174,7 +174,12 @@ class Generator:
                     elif data_type == self._db_connector.QGIS_DATE_TYPE:
                         field.widget_config['display_format'] = dateFormat
 
+                if 'default_value_expression' in fielddef:
+                    field.default_value_expression = fielddef['default_value_expression']
+
                 layer.fields.append(field)
+
+            self.post_process_layer(layer)
 
             layers.append(layer)
 
@@ -265,6 +270,9 @@ class Generator:
 
     def get_fields_info(self, table_name):
         return self._db_connector.get_fields_info(table_name)
+
+    def post_process_layer(self, layer):
+        self._db_connector.post_process_layer(layer)
 
     def get_tables_info_without_ignored_tables(self):
         tables_info = self.get_tables_info()

--- a/projectgenerator/templates/get_t_id.py
+++ b/projectgenerator/templates/get_t_id.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+import sqlite3
+import qgis
+from qgis.core import (
+    qgsfunction,
+    QgsExpression,
+    QgsProject
+)
+
+def on_form_open(dialog, layer, feature):
+    """
+    Whenever the form opens, check if the get_ili2gpkg_t_id
+    function already exists and add it if not.
+    """
+
+    if not hasattr(qgis, '__ili2gpkg_t_id_generator'):
+        @qgsfunction(args='auto', group='custom', usesgeometry=False, register=False)
+        def get_ili2gpkg_t_id(feature, parent, context):
+            """
+            Gets a new unique t_id for ili2gpkg created geopackages.
+            The value is managed via the T_KEY_OBJECT table within the geopackage
+            and is compatible with the internal counter managed by ili2gpkg for
+            import and export.
+            """
+            layer = QgsProject.instance().mapLayer(context.variable('layer_id'))
+            gpkg = layer.dataProvider().dataSourceUri().split('|')[0]
+            conn = sqlite3.connect(gpkg)
+            c = conn.cursor()
+            c.execute('''
+              SELECT
+                T_Key,
+                T_LastChange
+              FROM T_KEY_OBJECT
+              WHERE
+              T_LastUniqueId = "T_Id"''')
+            res = c.fetchone()
+
+            if res:
+                t_key = res[0]
+                unique_id = res[1] + 1
+            else:
+                unique_id = 0
+                c.execute('''SELECT max(T_Key)+1 FROM T_KEY_OBJECT''')
+                res = c.fetchone()
+                if res:
+                    t_key = res[0]
+
+                if not t_key:
+                    t_key = 0
+
+            c.execute(r'''INSERT OR REPLACE INTO T_KEY_OBJECT
+              (T_Key, T_LastUniqueId, T_LastChange, T_CreateDate, T_User)
+              VALUES
+              (
+                ?,
+                ?,
+                ?,
+                ?,
+                ''
+              )''', (t_key, 'T_Id', unique_id, 'date(\'now\')'))
+            conn.commit()
+            conn.close()
+
+            return unique_id
+
+
+        qgis.__ili2gpkg_t_id_generator = dict()
+        # Increase this if improved versions are shipped
+        # and unregister the previously registered one before registering
+        # the new version
+        qgis.__ili2gpkg_t_id_generator['version'] = 1
+        qgis.__ili2gpkg_t_id_generator['function'] = get_ili2gpkg_t_id
+
+        QgsExpression.registerFunction(qgis.__ili2gpkg_t_id_generator['function'])


### PR DESCRIPTION
Sqlite does not allow the definition of function based default values, so there is no `nextval` or similar that could be used to predict upcoming serial values on form opening.

Client side default values to the rescue, we manage things via the same `T_KEY_OBJECT` table as ili2gpkg does.

Two issues remain for the moment:

 * The expression function is defined on first form opening, so the very first time, it's not yet there. Project macros or requiring clients to install a plugin are a way around that but they both come at an expense. Macros give warnings, having to install a plugin makes the project less portable.
Or we try to use the form API to inject the value into a hidden widget.

 * There seems to be a timeout (due to locking?) on the database when acquiring more serial values in subsequent digitizing within a single transaction. Needs some investigation.