### PR TITLE
Avoid duplicating fields (with units) in forms

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -273,7 +273,7 @@ class PGConnector(DBConnector):
                                         """.format(self.schema, table_name)
 
             fields_cur.execute("""
-                SELECT
+                SELECT DISTINCT
                   c.column_name,
                   c.data_type,
                   c.numeric_scale,


### PR DESCRIPTION
Acknowledging that the underlying issue comes from ili2db ([the issue](https://github.com/claeis/ili2db/issues/255) is reported there already), this PR solves the problem in QGIS Model Baker.

This is the result using the same example reported in #286:

![image](https://user-images.githubusercontent.com/652785/52965575-1fd7c200-3373-11e9-9da8-fb1c46d52585.png)



Fix #286 