### PR TITLE
Use global env to find java path on Windows

### DIFF
--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -25,9 +25,11 @@ import re
 
 from QgisModelBaker.gui.options import OptionsDialog, ModelListView
 from QgisModelBaker.gui.multiple_models import MultipleModelsDialog
-from QgisModelBaker.libili2db.iliexporter import JavaNotFoundError
 from QgisModelBaker.libili2db.ilicache import IliCache, ModelCompleterDelegate
-from QgisModelBaker.libili2db.ili2dbutils import color_log_text
+from QgisModelBaker.libili2db.ili2dbutils import (
+    color_log_text,
+    JavaNotFoundError
+)
 from QgisModelBaker.utils.qt_utils import (
     make_save_file_selector,
     Validators,
@@ -305,11 +307,10 @@ class ExportDialog(QDialog, DIALOG_UI):
                     self.enable()
                     self.progress_bar.hide()
                     return
-            except JavaNotFoundError:
+            except JavaNotFoundError as e:
                 self.txtStdout.setTextColor(QColor('#000000'))
                 self.txtStdout.clear()
-                self.txtStdout.setText(self.tr(
-                    'Java could not be found. Please <a href="https://java.com/en/download/">install Java</a> and or <a href="#configure">configure a custom java path</a>. We also support the JAVA_HOME environment variable in case you prefer this.'))
+                self.txtStdout.setText(e.error_string)
                 self.enable()
                 self.progress_bar.hide()
                 return

--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -243,11 +243,10 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
                         self.enable()
                         self.progress_bar.hide()
                         return
-                except JavaNotFoundError:
+                except JavaNotFoundError as e:
                     self.txtStdout.setTextColor(QColor('#000000'))
                     self.txtStdout.clear()
-                    self.txtStdout.setText(self.tr(
-                        'Java could not be found. Please <a href="https://java.com/en/download/">install Java</a> and or <a href="#configure">configure a custom java path</a>. We also support the JAVA_HOME environment variable in case you prefer this.'))
+                    self.txtStdout.setText(e.error_string)
                     self.enable()
                     self.progress_bar.hide()
                     return

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -23,9 +23,11 @@ import webbrowser
 from QgisModelBaker.gui.ili2db_options import Ili2dbOptionsDialog
 from QgisModelBaker.gui.options import OptionsDialog, CompletionLineEdit
 from QgisModelBaker.gui.multiple_models import MultipleModelsDialog
-from QgisModelBaker.libili2db.iliimporter import JavaNotFoundError
 from QgisModelBaker.libili2db.ilicache import IliCache, ModelCompleterDelegate
-from QgisModelBaker.libili2db.ili2dbutils import color_log_text
+from QgisModelBaker.libili2db.ili2dbutils import (
+    color_log_text,
+    JavaNotFoundError
+)
 from QgisModelBaker.libqgsprojectgen.dbconnector import pg_connector
 from QgisModelBaker.utils.qt_utils import (
     make_file_selector,
@@ -209,11 +211,10 @@ class ImportDataDialog(QDialog, DIALOG_UI):
                     self.enable()
                     self.progress_bar.hide()
                     return
-            except JavaNotFoundError:
+            except JavaNotFoundError as e:
                 self.txtStdout.setTextColor(QColor('#000000'))
                 self.txtStdout.clear()
-                self.txtStdout.setText(self.tr(
-                    'Java could not be found. Please <a href="https://java.com/en/download/">install Java</a> and or <a href="#configure">configure a custom java path</a>. We also support the JAVA_HOME environment variable in case you prefer this.'))
+                self.txtStdout.setText(e.error_string)
                 self.enable()
                 self.progress_bar.hide()
                 return

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -21,6 +21,7 @@
 from QgisModelBaker.libili2db.ili2dbutils import get_all_modeldir_in_path
 from qgis.PyQt.QtNetwork import QNetworkProxy
 from qgis.core import QgsNetworkAccessManager
+
 import os
 
 ili2db_tools = {
@@ -300,7 +301,3 @@ class ImportDataConfiguration(SchemaImportConfiguration):
         args += SchemaImportConfiguration.to_ili2db_args(self, hide_password=hide_password, with_action=False)
 
         return args
-
-
-class JavaNotFoundError(FileNotFoundError):
-    pass

--- a/QgisModelBaker/libili2db/ili2dbutils.py
+++ b/QgisModelBaker/libili2db/ili2dbutils.py
@@ -21,6 +21,9 @@ import os
 import tempfile
 import zipfile
 import glob
+import platform
+import re
+import subprocess
 
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtGui import QColor
@@ -90,6 +93,7 @@ def get_all_modeldir_in_path(path, lambdafunction=None):
             modeldir += subdir + ';'
     return modeldir[:-1]  # remove last ';'
 
+
 def color_log_text(text, txt_edit):
     textlines = text.splitlines()
     for textline in textlines:
@@ -102,3 +106,123 @@ def color_log_text(text, txt_edit):
         else:
             txt_edit.setTextColor(QColor('#2a2a2a'))
             txt_edit.append(textline)
+
+
+def get_java_path(base_configuration):
+    '''
+    Delivers the path to a Java 8 installation or raises a JavaNotFoundError
+
+    1. If the java path is set by the user, this one will be taken. No other paths are returned.
+    2. Finds additional java paths in the enfironment variable JAVA_HOME (suffised with and without bin/java
+    3. On Windows looks up the global system environment variable for PATH because this is mangled by
+       the QGIS startup script.
+    '''
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    # This function is like the linux which command
+    def which(program):
+
+        fpath, fname = os.path.split(program)
+        if fpath:
+            if is_exe(program):
+                return program
+        else:
+            # for path in os.environ["PATH"].split(os.pathsep):
+            for path in getenv_system("PATH").split(os.pathsep):
+                path = path.strip('"')
+                exe_file = os.path.join(path, program)
+                if is_exe(exe_file):
+                    return exe_file
+        return None
+
+    # This function gets a system variable
+    # it was necessary to use this instead of os.environ["PATH"] because QGIS overwrites the path variable
+    # the win32 libraries appear not to be part of the standard python install, but they are included in the
+    # python version that comes with QGIS
+    def getenv_system(varname, default=''):
+        import winreg
+
+        v = default
+        try:
+            rkey = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
+                                  'SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment')
+            try:
+                v = str(winreg.QueryValueEx(rkey, varname)[0])
+                v = winreg.ExpandEnvironmentStrings(v)
+            except:
+                pass
+        finally:
+            winreg.CloseKey(rkey)
+        return v
+
+    if base_configuration.java_path:
+        # A java path is configured: respect it no mather what
+        return [base_configuration.java_path]
+    else:
+        # By default try JAVA_HOME and PATH
+        java_paths = []
+        if 'JAVA_HOME' in os.environ:
+            paths = os.environ['JAVA_HOME'].split(";")
+            for path in paths:
+                # Include double check as java can be found on different paths
+                # /usr/lib/jvm/java8oracle/bin/java
+                java_paths += [os.path.join(path.replace("\"",
+                                                         "").replace("'", ""), 'bin', 'java')]
+                # C:\ProgramData\Oracle\Java\javapath\java
+                java_paths += [os.path.join(path.replace("\"",
+                                                         "").replace("'", ""), 'java')]
+
+        if platform.system() == 'Windows':
+            java_paths += [which('java.exe')]
+        else:
+            java_paths += ['java']
+
+        err = None
+        java_version_re = re.compile(r'.*version "([0-9\.]+)_.*')
+        for java_path in java_paths:
+            try:
+                startupinfo = None
+                if platform.system() == 'Windows':
+                    startupinfo = subprocess.STARTUPINFO()
+                    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                p = subprocess.Popen([java_path, '-version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=startupinfo)
+                output, err = p.communicate()
+                java_version = java_version_re.match(err.decode('utf-8'))
+                if java_version.group(1) == '1.8.0':
+                    return java_path
+            except FileNotFoundError:
+                pass
+
+        raise JavaNotFoundError(err.decode('utf-8'))
+
+
+class JavaNotFoundError(FileNotFoundError):
+    """
+    This error is raised when java could not be detected on the system.
+    When the java_version variable is set, java (or any executable) was found
+    but in the wrong version.
+    If not, no executable was found at all.
+    """
+
+    def __init__(self, java_version=None):
+        super().__init__()
+
+        if java_version:
+            self.java_version = java_version
+        else:
+            self.java_version = None
+
+    @property
+    def html_java_version(self):
+        if self.java_version:
+            return '<br/>'.join(self.java_version.splitlines())
+        else:
+            return ''
+
+    @property
+    def error_string(self):
+        if self.java_version:
+            return QCoreApplication.translate('ili2dbutils', 'Wrong java version found. Qgis Model Baker requires java version 8. Please <a href="https://java.com/en/download/">install Java</a> and or <a href="#configure">configure a custom java path</a>.<br/><br/>Java Version:<br/>{}').format(self.html_java_version)
+        else:
+            return QCoreApplication.translate('ili2dbutils', 'Java 8 could not be found. Please <a href="https://java.com/en/download/">install Java</a> and or <a href="#configure">configure a custom java path</a>.')

--- a/QgisModelBaker/libili2db/ili2dbutils.py
+++ b/QgisModelBaker/libili2db/ili2dbutils.py
@@ -174,11 +174,13 @@ def get_java_path(base_configuration):
                                                          "").replace("'", ""), 'java')]
 
         if platform.system() == 'Windows':
-            java_paths += [which('java.exe')]
+            java_path = which('java.exe')
+            if java_path:
+                java_paths += [java_path]
         else:
             java_paths += ['java']
 
-        err = None
+        version_output = None
         java_version_re = re.compile(r'.*version "([0-9\.]+)_.*')
         for java_path in java_paths:
             try:
@@ -188,13 +190,14 @@ def get_java_path(base_configuration):
                     startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
                 p = subprocess.Popen([java_path, '-version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=startupinfo)
                 output, err = p.communicate()
-                java_version = java_version_re.match(err.decode('utf-8'))
+                version_output = err.decode('utf-8')
+                java_version = java_version_re.match(version_output)
                 if java_version.group(1) == '1.8.0':
                     return java_path
             except FileNotFoundError:
                 pass
 
-        raise JavaNotFoundError(err.decode('utf-8'))
+        raise JavaNotFoundError(version_output)
 
 
 class JavaNotFoundError(FileNotFoundError):

--- a/QgisModelBaker/libili2db/iliexporter.py
+++ b/QgisModelBaker/libili2db/iliexporter.py
@@ -17,16 +17,19 @@
  *                                                                         *
  ***************************************************************************/
 """
-import os
 
 import re
 import functools
 import locale
 
-from QgisModelBaker.libili2db.ili2dbutils import get_ili2db_bin
+from QgisModelBaker.libili2db.ili2dbutils import (
+    get_ili2db_bin,
+    get_java_path,
+    JavaNotFoundError
+)
 from qgis.PyQt.QtCore import QObject, pyqtSignal, QProcess, QEventLoop
 
-from QgisModelBaker.libili2db.ili2dbconfig import ExportConfiguration, JavaNotFoundError, ili2db_tools
+from QgisModelBaker.libili2db.ili2dbconfig import ExportConfiguration, ili2db_tools
 
 
 class Exporter(QObject):
@@ -64,38 +67,18 @@ class Exporter(QObject):
 
         args = self.configuration.to_ili2db_args()
 
-        if self.configuration.base_configuration.java_path:
-            # A java path is configured: respect it no mather what
-            java_paths = [self.configuration.base_configuration.java_path]
-        else:
-            # By default try JAVA_HOME and PATH
-            java_paths = []
-            if 'JAVA_HOME' in os.environ:
-                paths = os.environ['JAVA_HOME'].split(";")
-                for path in paths:
-                    # Include double check as java can be found on different paths
-                    # /usr/lib/jvm/java8oracle/bin/java
-                    java_paths += [os.path.join(path.replace("\"",
-                                                             "").replace("'", ""), 'bin', 'java')]
-                    # C:\ProgramData\Oracle\Java\javapath\java
-                    java_paths += [os.path.join(path.replace("\"",
-                                                             "").replace("'", ""), 'java')]
-            java_paths += ['java']
+        java_path = get_java_path(self.configuration.base_configuration)
 
-        proc = None
-        for java_path in java_paths:
-            proc = QProcess()
-            proc.readyReadStandardError.connect(
-                functools.partial(self.stderr_ready, proc=proc))
-            proc.readyReadStandardOutput.connect(
-                functools.partial(self.stdout_ready, proc=proc))
+        proc = QProcess()
+        proc.readyReadStandardError.connect(
+            functools.partial(self.stderr_ready, proc=proc))
+        proc.readyReadStandardOutput.connect(
+            functools.partial(self.stdout_ready, proc=proc))
 
-            proc.start(java_path, ili2db_jar_arg + args)
+        proc.start(java_path, ili2db_jar_arg + args)
 
-            if not proc.waitForStarted():
-                proc = None
-            else:
-                break
+        if not proc.waitForStarted():
+            proc = None
 
         if not proc:
             raise JavaNotFoundError()

--- a/QgisModelBaker/libili2db/iliimporter.py
+++ b/QgisModelBaker/libili2db/iliimporter.py
@@ -23,13 +23,16 @@ import re
 import locale
 import functools
 
-from QgisModelBaker.libili2db.ili2dbutils import get_ili2db_bin
+from QgisModelBaker.libili2db.ili2dbutils import (
+    get_ili2db_bin,
+    get_java_path,
+    JavaNotFoundError
+)
 from qgis.PyQt.QtCore import QObject, pyqtSignal, QProcess, QEventLoop
 
 from QgisModelBaker.libili2db.ili2dbconfig import (
         SchemaImportConfiguration,
         ImportDataConfiguration,
-        JavaNotFoundError,
         ili2db_tools
 )
 
@@ -76,38 +79,18 @@ class Importer(QObject):
         if self.dataImport:
             args += [self.configuration.xtffile]
 
-        if self.configuration.base_configuration.java_path:
-            # A java path is configured: respect it no mather what
-            java_paths = [self.configuration.base_configuration.java_path]
-        else:
-            # By default try JAVA_HOME and PATH
-            java_paths = []
-            if 'JAVA_HOME' in os.environ:
-                paths = os.environ['JAVA_HOME'].split(os.pathsep)
-                for path in paths:
-                    # Include double check as java can be found on different paths
-                    # /usr/lib/jvm/java8oracle/bin/java
-                    java_paths += [os.path.join(path.replace("\"",
-                                                             "").replace("'", ""), 'bin', 'java')]
-                    # C:\ProgramData\Oracle\Java\javapath\java
-                    java_paths += [os.path.join(path.replace("\"",
-                                                             "").replace("'", ""), 'java')]
-            java_paths += ['java']
+        java_path = get_java_path(self.configuration.base_configuration)
 
-        proc = None
-        for java_path in java_paths:
-            proc = QProcess()
-            proc.readyReadStandardError.connect(
-                functools.partial(self.stderr_ready, proc=proc))
-            proc.readyReadStandardOutput.connect(
-                functools.partial(self.stdout_ready, proc=proc))
+        proc = QProcess()
+        proc.readyReadStandardError.connect(
+            functools.partial(self.stderr_ready, proc=proc))
+        proc.readyReadStandardOutput.connect(
+            functools.partial(self.stdout_ready, proc=proc))
 
-            proc.start(java_path, ili2db_jar_arg + args)
+        proc.start(java_path, ili2db_jar_arg + args)
 
-            if not proc.waitForStarted():
-                proc = None
-            else:
-                break
+        if not proc.waitForStarted():
+            proc = None
 
         if not proc:
             raise JavaNotFoundError()


### PR DESCRIPTION
Because the QGIS startup script overwrites the env variables they need to be accessed in a different way.

This pull request:

 * Deduplicates code and puts common code blocks into ili2dbutils.
 * Extracts the original Windows `PATH` variable to look for the java executable
 * Checks the java version and raises an error if people have installed an incompatible version

Fix #283