### PR TITLE
Avoid critical message that always appears when installing Model Baker

### DIFF
--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -27,7 +27,10 @@ from QgisModelBaker.gui.import_data import ImportDataDialog
 from QgisModelBaker.libqgsprojectgen.dataobjects.project import Project
 from QgisModelBaker.libqgsprojectgen.generator.generator import Generator
 
-from qgis.core import QgsProject
+from qgis.core import (QgsProject,
+                       QgsMessageLog)
+
+from qgis.utils import available_plugins
 
 from qgis.PyQt.QtWidgets import QAction, QMenu, QMessageBox
 from qgis.PyQt.QtCore import QObject, QTranslator, QSettings, QLocale, QCoreApplication, Qt
@@ -70,9 +73,11 @@ class QgisModelBakerPlugin(QObject):
     def initGui(self):
         pyplugin_installer.installer.initPluginInstaller()
         pyplugin_installer.installer_data.plugins.rebuild()
-        if 'projectgenerator' in pyplugin_installer.installer_data.plugins.all().keys():
+        if 'projectgenerator' in available_plugins:
             import qgis
             pyplugin_installer.instance().uninstallPlugin('projectgenerator', quiet=True)
+        else: 
+            QgsMessageLog.logMessage(self.tr('The plugin Project Generator is not installed, so it was not removed.'), self.tr('QGIS Model Baker'))
 
         self.__generate_action = QAction( QIcon(os.path.join(os.path.dirname(__file__), 'images/QgisModelBaker-icon.svg')),
             self.tr('Generate'), None)


### PR DESCRIPTION
This pull requests aims to avoid displaying this message

![image](https://user-images.githubusercontent.com/27906888/60827665-51acc200-a176-11e9-9f17-5536b05d31a2.png)

Instead, it displays this message: "The plugin Project Generator is not installed, so it was not removed." to the QGIS log.
