### PR TITLE
Adjust Java version parsing

### DIFF
--- a/QgisModelBaker/libili2db/ili2dbutils.py
+++ b/QgisModelBaker/libili2db/ili2dbutils.py
@@ -193,7 +193,7 @@ def get_java_path(base_configuration):
             java_paths += ['java']
 
         version_output = None
-        java_version_re = re.compile(r'.*version "([0-9\.]+)_.*')
+        java_version_re = re.compile(r'.*version "([0-9\.]+).*')
         for java_path in java_paths:
             try:
                 startupinfo = None


### PR DESCRIPTION
This solves the following issue:

![image](https://user-images.githubusercontent.com/652785/60907767-f3e4ac80-a23f-11e9-9244-e4ac45495272.png)

by taking into account also Java version strings like: 

 + openjdk version "10.0.2" 2018-07-17
OpenJDK Runtime Environment (build 10.0.2+13-Ubuntu-1ubuntu0.18.04.4)
OpenJDK 64-Bit Server VM (build 10.0.2+13-Ubuntu-1ubuntu0.18.04.4, mixed mode)

For backwards compatibility, it has also been tested against strings like: 

 + java version "1.8.0_201"
Java(TM) SE Runtime Environment (build 1.8.0_201-b09)
Java HotSpot(TM) 64-Bit Server VM (build 25.201-b09, mixed mode)

And continues working well. 