### PR TITLE
Check that ili file exists before refreshing cache

### DIFF
--- a/QgisModelBaker/libili2db/ilicache.py
+++ b/QgisModelBaker/libili2db/ilicache.py
@@ -70,7 +70,8 @@ class IliCache(QObject):
             for directory in self.base_configuration.model_directories:
                 self.process_model_directory(directory)
         if not self.single_ili_file is None:
-            self.process_single_ili_file()
+            if os.path.exists(self.single_ili_file):
+                self.process_single_ili_file()
 
     def process_model_directory(self, path):
         if path[0] == '%':


### PR DESCRIPTION
There is an issue when the user has a .xtf loaded in the menu (Import Interlis Transfer File .xtf), but the file does not exist anymore.

![image](https://user-images.githubusercontent.com/27906888/62168391-10c64a00-b2eb-11e9-9698-5816e56ef375.png)

Gif of the issue:

![gif_issue](https://user-images.githubusercontent.com/27906888/62168407-1e7bcf80-b2eb-11e9-9ca8-1a4478087e75.gif)
