### PR TITLE
Add "import/export without validating" button

### DIFF
--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -318,7 +318,7 @@ class ExportDialog(QDialog, DIALOG_UI):
                 self.remove_export_without_validate_button()
 
                 self.buttonBox.addButton(self.tr('Export without validating'),
-                                         QDialogButtonBox.AcceptRole).setStyleSheet("color: aa2222;")
+                                         QDialogButtonBox.AcceptRole).setStyleSheet("color: #aa2222;")
                 self.buttonBox.addButton(self.tr('Export'), QDialogButtonBox.AcceptRole)
             self.enable()
 
@@ -327,8 +327,8 @@ class ExportDialog(QDialog, DIALOG_UI):
         Valid if an error occurred that prevents executing the export without validations
         :return: True if you can execute the export without validations, False in other case
         """
-        log = self.txtStdout.toPlainText()
-        if "Permission denied" in log:
+        log = self.txtStdout.toPlainText().lower()
+        if "permission denied" in log or "access is denied" in log:
             return False
         return True
 

--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -115,11 +115,14 @@ class ExportDialog(QDialog, DIALOG_UI):
         self.db_simple_factory = DbSimpleFactory()
         QgsGui.instance().enableAutoGeometryRestore(self);
         self.buttonBox.accepted.disconnect()
-        self.buttonBox.clicked.connect(self.accepted_export_data)
+        self.buttonBox.clicked.connect(self.button_box_clicked)
         self.buttonBox.clear()
         self.buttonBox.addButton(QDialogButtonBox.Cancel)
-        self.buttonBox.addButton(
-            self.tr('Export'), QDialogButtonBox.AcceptRole)
+
+        self.export_button_name = self.tr('Export')
+        self.export_without_validate_button_name = self.tr('Export without validation')
+
+        self.buttonBox.addButton(self.export_button_name, QDialogButtonBox.AcceptRole)
         self.buttonBox.addButton(QDialogButtonBox.Help)
         self.buttonBox.helpRequested.connect(self.help_requested)
         self.xtf_file_browse_button.clicked.connect(
@@ -202,11 +205,11 @@ class ExportDialog(QDialog, DIALOG_UI):
 
         self.export_models_model.refresh_models(db_connector)
 
-    def accepted_export_data(self, button):
+    def button_box_clicked(self, button):
         if self.buttonBox.buttonRole(button) == QDialogButtonBox.AcceptRole:
-            if button.text() == self.tr('Export'):
+            if button.text() == self.export_button_name:
                 self.validate_data = True
-            elif button.text() == self.tr('Export without validating'):
+            elif button.text() == self.export_without_validate_button_name:
                 self.validate_data = False
             self.accepted()
 
@@ -312,14 +315,14 @@ class ExportDialog(QDialog, DIALOG_UI):
 
                 # button is removed to define order in GUI
                 for button in self.buttonBox.buttons():
-                    if button.text() == self.tr('Export'):
+                    if button.text() == self.export_button_name:
                         self.buttonBox.removeButton(button)
                 # Check if button was previously added
                 self.remove_export_without_validate_button()
 
-                self.buttonBox.addButton(self.tr('Export without validating'),
+                self.buttonBox.addButton(self.export_without_validate_button_name,
                                          QDialogButtonBox.AcceptRole).setStyleSheet("color: #aa2222;")
-                self.buttonBox.addButton(self.tr('Export'), QDialogButtonBox.AcceptRole)
+                self.buttonBox.addButton(self.export_button_name, QDialogButtonBox.AcceptRole)
             self.enable()
 
     def export_without_validate(self):
@@ -334,7 +337,7 @@ class ExportDialog(QDialog, DIALOG_UI):
 
     def remove_export_without_validate_button(self):
         for button in self.buttonBox.buttons():
-            if button.text() == self.tr('Export without validating'):
+            if button.text() == self.export_without_validate_button_name:
                 self.buttonBox.removeButton(button)
                 self.validate_data = True
 

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -28,7 +28,6 @@ from QgisModelBaker.libili2db.ili2dbutils import (
     color_log_text,
     JavaNotFoundError
 )
-from QgisModelBaker.libqgsprojectgen.dbconnector import pg_connector
 from ..libqgsprojectgen.db_factory.db_simple_factory import DbSimpleFactory
 from QgisModelBaker.libili2db.globals import DbIliMode, displayDbIliMode, DbActionType
 
@@ -72,7 +71,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         QgsGui.instance().enableAutoGeometryRestore(self);
         self.db_simple_factory = DbSimpleFactory()
         self.buttonBox.accepted.disconnect()
-        self.buttonBox.accepted.connect(self.accepted)
+        self.buttonBox.clicked.connect(self.accepted_import_data)
         self.buttonBox.clear()
         self.buttonBox.addButton(QDialogButtonBox.Cancel)
         self.buttonBox.addButton(
@@ -104,6 +103,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.multiple_models_dialog.accepted.connect(
             self.fill_models_line_edit)
 
+        self.validate_data = True # validates imported data by default, We use --disableValidation when is False
         self.base_configuration = base_config
         self.restore_configuration()
 
@@ -122,11 +122,23 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.xtf_file_line_edit.textChanged.emit(
             self.xtf_file_line_edit.text())
 
+        # Remove import without validate button when xtf change
+        self.xtf_file_line_edit.textChanged.connect(
+            self.remove_import_without_validate_button)
+
         settings = QSettings()
         ilifile = settings.value('QgisModelBaker/ili2db/ilifile')
         self.ilicache = IliCache(base_config, ilifile or None)
         self.update_models_completer()
         self.ilicache.refresh()
+
+    def accepted_import_data(self, button):
+        if self.buttonBox.buttonRole(button) == QDialogButtonBox.AcceptRole:
+            if button.text() == self.tr('Import Data'):
+                self.validate_data = True
+            elif button.text() == self.tr('Import without validating'):
+                self.validate_data = False
+            self.accepted()
 
     def accepted(self):
         configuration = self.updated_configuration()
@@ -217,7 +229,38 @@ class ImportDataDialog(QDialog, DIALOG_UI):
             self.buttonBox.setEnabled(True)
             self.buttonBox.addButton(QDialogButtonBox.Close)
         else:
+            if self.import_without_validate():
+
+                # button is removed to define order in GUI
+                for button in self.buttonBox.buttons():
+                    if button.text() == self.tr('Import Data'):
+                        self.buttonBox.removeButton(button)
+                # Check if button was previously added
+                self.remove_import_without_validate_button()
+
+                self.buttonBox.addButton(self.tr('Import without validating'),
+                                         QDialogButtonBox.AcceptRole).setStyleSheet("color: #aa2222;")
+                self.buttonBox.addButton(self.tr('Import Data'), QDialogButtonBox.AcceptRole)
+
             self.enable()
+
+    def import_without_validate(self):
+        """
+        Valid if an error occurred that prevents executing the import without validations
+        :return: True if you can execute the import without validations, False in other case
+        """
+        log = self.txtStdout.toPlainText()
+        if "no models given" in log:
+            return False
+        if "Attribute BID missing in basket" in log:
+            return False
+        return True
+
+    def remove_import_without_validate_button(self):
+        for button in self.buttonBox.buttons():
+            if button.text() == self.tr('Import without validating'):
+                self.buttonBox.removeButton(button)
+                self.validate_data = True
 
     def updated_configuration(self):
         """
@@ -239,6 +282,8 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         configuration.stroke_arcs = self.ili2db_options.stroke_arcs()
         configuration.base_configuration = self.base_configuration
 
+        if not self.validate_data:
+            configuration.disable_validation = True
         return configuration
 
     def save_configuration(self, configuration):
@@ -291,7 +336,9 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.buttonBox.setEnabled(True)
 
     def type_changed(self):
+        self.remove_import_without_validate_button()
         self.progress_bar.hide()
+        self.txtStdout.clear()
 
         db_id = self.type_combo_box.currentData()
         self.db_wrapper_group_box.setTitle(displayDbIliMode[db_id])

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -71,11 +71,14 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         QgsGui.instance().enableAutoGeometryRestore(self);
         self.db_simple_factory = DbSimpleFactory()
         self.buttonBox.accepted.disconnect()
-        self.buttonBox.clicked.connect(self.accepted_import_data)
+        self.buttonBox.clicked.connect(self.button_box_clicked)
         self.buttonBox.clear()
         self.buttonBox.addButton(QDialogButtonBox.Cancel)
-        self.buttonBox.addButton(
-            self.tr('Import Data'), QDialogButtonBox.AcceptRole)
+
+        self.import_button_name = self.tr('Import Data')
+        self.import_without_validate_button_name = self.tr('Import without validation')
+
+        self.buttonBox.addButton(self.import_button_name, QDialogButtonBox.AcceptRole)
         self.buttonBox.addButton(QDialogButtonBox.Help)
         self.buttonBox.helpRequested.connect(self.help_requested)
         self.xtf_file_browse_button.clicked.connect(
@@ -122,7 +125,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.xtf_file_line_edit.textChanged.emit(
             self.xtf_file_line_edit.text())
 
-        # Remove import without validate button when xtf change
+        # Remove import without validate button when xtf changes
         self.xtf_file_line_edit.textChanged.connect(
             self.remove_import_without_validate_button)
 
@@ -132,11 +135,11 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.update_models_completer()
         self.ilicache.refresh()
 
-    def accepted_import_data(self, button):
+    def button_box_clicked(self, button):
         if self.buttonBox.buttonRole(button) == QDialogButtonBox.AcceptRole:
-            if button.text() == self.tr('Import Data'):
+            if button.text() == self.import_button_name:
                 self.validate_data = True
-            elif button.text() == self.tr('Import without validating'):
+            elif button.text() == self.import_without_validate_button_name:
                 self.validate_data = False
             self.accepted()
 
@@ -233,14 +236,14 @@ class ImportDataDialog(QDialog, DIALOG_UI):
 
                 # button is removed to define order in GUI
                 for button in self.buttonBox.buttons():
-                    if button.text() == self.tr('Import Data'):
+                    if button.text() == self.import_button_name:
                         self.buttonBox.removeButton(button)
                 # Check if button was previously added
                 self.remove_import_without_validate_button()
 
-                self.buttonBox.addButton(self.tr('Import without validating'),
+                self.buttonBox.addButton(self.import_without_validate_button_name,
                                          QDialogButtonBox.AcceptRole).setStyleSheet("color: #aa2222;")
-                self.buttonBox.addButton(self.tr('Import Data'), QDialogButtonBox.AcceptRole)
+                self.buttonBox.addButton(self.import_button_name, QDialogButtonBox.AcceptRole)
 
             self.enable()
 
@@ -258,7 +261,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
 
     def remove_import_without_validate_button(self):
         for button in self.buttonBox.buttons():
-            if button.text() == self.tr('Import without validating'):
+            if button.text() == self.import_without_validate_button_name:
                 self.buttonBox.removeButton(button)
                 self.validate_data = True
 
@@ -338,7 +341,6 @@ class ImportDataDialog(QDialog, DIALOG_UI):
     def type_changed(self):
         self.remove_import_without_validate_button()
         self.progress_bar.hide()
-        self.txtStdout.clear()
 
         db_id = self.type_combo_box.currentData()
         self.db_wrapper_group_box.setTitle(displayDbIliMode[db_id])

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -249,10 +249,10 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         Valid if an error occurred that prevents executing the import without validations
         :return: True if you can execute the import without validations, False in other case
         """
-        log = self.txtStdout.toPlainText()
+        log = self.txtStdout.toPlainText().lower()
         if "no models given" in log:
             return False
-        if "Attribute BID missing in basket" in log:
+        if "attribute bid missing in basket" in log:
             return False
         return True
 


### PR DESCRIPTION
When you import/export data and an error occurs, a new button is enabled that allows you to execute data import/export using `--disableValidation`.

We did our best trying to isolate errors that come from other sources, in fact, Model Baker already handles JAVA-related issues (no Java installed/given, no proper version) and connection issues very well.


![init_ui_import_data](https://user-images.githubusercontent.com/8827336/62546360-f2030e80-b828-11e9-8bfe-20a435002197.png)

![import_with_validating](https://user-images.githubusercontent.com/8827336/62545400-41483f80-b827-11e9-95f7-1e8e20f60374.png)

![import_with_disable_validation](https://user-images.githubusercontent.com/8827336/62546026-612c3300-b828-11e9-8b5c-de1bb736c982.png)

References https://github.com/opengisch/QgisModelBaker/issues/318