### PR TITLE
Model Baker release for FOSS4G workshop (update ili2db version)

### DIFF
--- a/QgisModelBaker/libili2db/ili2dbutils.py
+++ b/QgisModelBaker/libili2db/ili2dbutils.py
@@ -51,7 +51,8 @@ def get_ili2db_bin(tool, stdout, stderr):
     ili2db_dir = '{}-{}'.format(tool_name, ili_tool_version)
 
     ili2db_file = os.path.join(
-        dir_path, 'bin', ili2db_dir, '{}.jar'.format(tool_name))
+        dir_path, 'bin', ili2db_dir, '{}-{}.jar'.format(tool_name, ili_tool_version))
+
     if not os.path.isfile(ili2db_file):
         try:
             os.mkdir(os.path.join(dir_path, 'bin'))
@@ -78,8 +79,15 @@ def get_ili2db_bin(tool, stdout, stderr):
             return None
 
         try:
+            extract_path = os.path.join(dir_path, 'bin')
             with zipfile.ZipFile(tmpfile.name, "r") as z:
-                z.extractall(os.path.join(dir_path, 'bin'))
+                if not ili2db_dir in [name.strip(os.sep) for name in z.namelist()]:  # Removing trailing slashes
+                    extract_path = os.path.join(extract_path, ili2db_dir)
+                    try:
+                        os.mkdir(extract_path)
+                    except FileExistsError:
+                        pass
+                z.extractall(extract_path)
         except zipfile.BadZipFile:
             # We will realize soon enough that the files were not extracted
             pass

--- a/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
@@ -49,7 +49,7 @@ class GpkgFactory(DbFactory):
 
         :return: str ili2gpkg version.
         """
-        return '3.11.3'
+        return '3.12.3'
 
     def get_tool_url(self):
         """Returns download url of ili2gpkg.

--- a/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
@@ -83,7 +83,7 @@ class PgFactory(DbFactory):
 
         :return: str ili2pg version.
         """
-        return '3.11.2'
+        return '3.12.2'
 
     def get_tool_url(self):
         """Returns download url of ili2pg.


### PR DESCRIPTION
This ili2gpkg version will be used in a FOSS4G workshop along with Model Baker