### PR TITLE
Refresh panels when switching modes in Generate Project dialog

### DIFF
--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -426,9 +426,13 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.ili_config.setVisible(interlis_mode)
         self.db_wrapper_group_box.setTitle(displayDbIliMode[db_id])
 
+        # Refresh panels
         for key, value in self._lst_panel.items():
             value.interlis_mode = interlis_mode
-            value.setVisible(db_id == key)
+            is_current_panel_selected = db_id == key
+            value.setVisible(is_current_panel_selected)
+            if is_current_panel_selected:
+                value._show_panel()
 
     def on_model_changed(self, text):
         if not text:

--- a/QgisModelBaker/gui/panel/db_config_panel.py
+++ b/QgisModelBaker/gui/panel/db_config_panel.py
@@ -79,5 +79,3 @@ class DbConfigPanel(QWidget, metaclass=AbstractQWidgetMeta):
         """
         pass
 
-    def showEvent(self, event):
-        self._show_panel()

--- a/QgisModelBaker/gui/panel/gpkg_config_panel.py
+++ b/QgisModelBaker/gui/panel/gpkg_config_panel.py
@@ -68,10 +68,8 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
         except:
             pass
 
-        self.gpkg_file_line_edit.textChanged.emit(
-                self.gpkg_file_line_edit.text())
-
         self.gpkg_file_line_edit.setValidator(validator)
+        self.gpkg_file_line_edit.textChanged.emit(self.gpkg_file_line_edit.text())
         self.gpkg_file_browse_button.clicked.connect(file_selector)
 
     def get_fields(self, configuration):


### PR DESCRIPTION
Also refresh validators.

Fix #325 