### PR TITLE
Support uppercase file extensions

### DIFF
--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -107,7 +107,7 @@ class ExportModels(QStringListModel):
 
 
 class ExportDialog(QDialog, DIALOG_UI):
-    ValidExtensions = ['xtf', 'itf', 'gml', 'xml']
+    ValidExtensions = ['xtf', 'XTF', 'itf', 'ITF', 'gml', 'GML', 'xml', 'XML']
 
     def __init__(self, base_config, parent=None):
         QDialog.__init__(self, parent)
@@ -127,7 +127,8 @@ class ExportDialog(QDialog, DIALOG_UI):
         self.buttonBox.helpRequested.connect(self.help_requested)
         self.xtf_file_browse_button.clicked.connect(
             make_save_file_selector(self.xtf_file_line_edit, title=self.tr('Save in XTF Transfer File'),
-                                    file_filter=self.tr('XTF Transfer File (*.xtf);;Interlis 1 Transfer File (*.itf);;XML (*.xml);;GML (*.gml)'), extension='.xtf', extensions=['.' + ext for ext in self.ValidExtensions]))
+                                    file_filter=self.tr('XTF Transfer File (*.xtf *XTF);;Interlis 1 Transfer File (*.itf *ITF);;XML (*.xml *XML);;GML (*.gml *GML)'),
+                                    extensions=['.' + ext for ext in self.ValidExtensions]))
         self.xtf_file_browse_button.clicked.connect(
             self.xtf_browser_opened_to_true)
         self.xtf_browser_was_opened = False

--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -79,6 +79,8 @@ DIALOG_UI = get_ui_class('generate_project.ui')
 
 class GenerateProjectDialog(QDialog, DIALOG_UI):
 
+    ValidExtensions = ['ili', 'ILI']
+
     def __init__(self, iface, base_config, parent=None):
         QDialog.__init__(self, parent)
         self.setupUi(self)
@@ -94,7 +96,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         create_button.setDefault(True)
         self.ili_file_browse_button.clicked.connect(
             make_file_selector(self.ili_file_line_edit, title=self.tr('Open Interlis Model'),
-                               file_filter=self.tr('Interlis Model File (*.ili)')))
+                               file_filter=self.tr('Interlis Model File (*.ili *.ILI)')))
         self.buttonBox.addButton(QDialogButtonBox.Help)
         self.buttonBox.helpRequested.connect(self.help_requested)
         self.crs = QgsCoordinateReferenceSystem()
@@ -132,7 +134,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
 
         self.validators = Validators()
         nonEmptyValidator = NonEmptyStringValidator()
-        fileValidator = FileValidator(pattern='*.ili', allow_empty=True)
+        fileValidator = FileValidator(pattern=['*.' + ext for ext in self.ValidExtensions], allow_empty=True)
 
         self.restore_configuration()
 

--- a/QgisModelBaker/gui/ili2db_options.py
+++ b/QgisModelBaker/gui/ili2db_options.py
@@ -33,6 +33,8 @@ DIALOG_UI = get_ui_class('ili2db_options.ui')
 
 class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
 
+    ValidExtensions = ['toml', 'TOML']
+
     def __init__(self, parent=None):
         QDialog.__init__(self, parent)
         self.setupUi(self)
@@ -45,9 +47,9 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         self.buttonBox.rejected.connect(self.rejected)
         self.toml_file_browse_button.clicked.connect(
             make_file_selector(self.toml_file_line_edit, title=self.tr('Open Extra Model Information File (*.toml)'),
-                               file_filter=self.tr('Extra Model Info File (*.toml)')))
+                               file_filter=self.tr('Extra Model Info File (*.toml *.TOML)')))
         self.validators = Validators()
-        self.fileValidator = FileValidator(pattern='*.toml', allow_empty=True)
+        self.fileValidator = FileValidator(pattern=['*.' + ext for ext in self.ValidExtensions], allow_empty=True)
         self.toml_file_line_edit.setValidator(self.fileValidator)
 
         self.restore_configuration()

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -65,6 +65,8 @@ DIALOG_UI = get_ui_class('import_data.ui')
 
 class ImportDataDialog(QDialog, DIALOG_UI):
 
+    ValidExtensions = ['xtf', 'XTF', 'itf', 'ITF', 'pdf', 'PDF', 'xml', 'XML', 'xls', 'XLS', 'xlsx', 'XLSX']
+
     def __init__(self, base_config, parent=None):
         QDialog.__init__(self, parent)
         self.setupUi(self)
@@ -83,7 +85,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.buttonBox.helpRequested.connect(self.help_requested)
         self.xtf_file_browse_button.clicked.connect(
             make_file_selector(self.xtf_file_line_edit, title=self.tr('Open Transfer or Catalog File'),
-                               file_filter=self.tr('Transfer File (*.xtf *.itf);;Catalogue File (*.xml *.xls *.xlsx)')))
+                               file_filter=self.tr('Transfer File (*.xtf *.itf *.XTF *.ITF);;Catalogue File (*.xml *.XML *.xls *.XLS *.xlsx *.XLSX)')))
 
         self.type_combo_box.clear()
         self._lst_panel = dict()
@@ -111,8 +113,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.restore_configuration()
 
         self.validators = Validators()
-        fileValidator = FileValidator(
-            pattern=['*.xtf', '*.itf', '*.pdf', '*.xml', '*.xls', '*.xlsx'])
+        fileValidator = FileValidator(pattern=['*.' + ext for ext in self.ValidExtensions])
 
         self.xtf_file_line_edit.setValidator(fileValidator)
 

--- a/QgisModelBaker/gui/panel/gpkg_config_panel.py
+++ b/QgisModelBaker/gui/panel/gpkg_config_panel.py
@@ -39,6 +39,8 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
     """
     notify_fields_modified = pyqtSignal(str)
 
+    ValidExtensions = ['gpkg', 'GPKG']
+
     def __init__(self, parent, db_action_type):
         DbConfigPanel.__init__(self, parent, db_action_type)
         self.setupUi(self)
@@ -47,8 +49,8 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
         self.validators = Validators()
 
         self.gpkgSaveFileValidator = FileValidator(
-            pattern='*.gpkg', allow_non_existing=True)
-        self.gpkgOpenFileValidator = FileValidator(pattern='*.gpkg')
+            pattern=['*.' + ext for ext in self.ValidExtensions], allow_non_existing=True)
+        self.gpkgOpenFileValidator = FileValidator(pattern=['*.' + ext for ext in self.ValidExtensions])
         self.gpkg_file_line_edit.textChanged.connect(
             self.validators.validate_line_edits)
 
@@ -58,11 +60,12 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
         if self.interlis_mode:
             validator = self.gpkgSaveFileValidator
             file_selector = make_save_file_selector(self.gpkg_file_line_edit, title=self.tr("Open GeoPackage database file"),
-                                        file_filter=self.tr("GeoPackage Database (*.gpkg)"), extension='.gpkg')
+                                        file_filter=self.tr("GeoPackage Database (*.gpkg *.GPKG)"),
+                                                    extensions=['.' + ext for ext in self.ValidExtensions])
         else:
             validator = self.gpkgOpenFileValidator
             file_selector = make_file_selector(self.gpkg_file_line_edit, title=self.tr("Open GeoPackage database file"),
-                                        file_filter=self.tr("GeoPackage Database (*.gpkg)"))
+                                        file_filter=self.tr("GeoPackage Database (*.gpkg *.GPKG)"))
         try:
             self.gpkg_file_browse_button.clicked.disconnect()
         except:


### PR DESCRIPTION
Uppercase extensions are valid now.

Otherwise it's hard to find the file, when its extension is written in uppercase letters.
The general validation is still case-sensitive if the local file system is case sensitive (e.g. unix afaik).