### PR TITLE
Try with getdefaultlocale() if getlocale() fails

### DIFF
--- a/QgisModelBaker/libili2db/iliimporter.py
+++ b/QgisModelBaker/libili2db/iliimporter.py
@@ -61,7 +61,7 @@ class Importer(QObject):
             self.configuration = SchemaImportConfiguration()
         self.encoding = locale.getlocale()[1]
 
-        # Let's python try to determine the default locale
+        # Lets python try to determine the default locale
         if not self.encoding:
             self.encoding = locale.getdefaultlocale()[1]
 

--- a/QgisModelBaker/libili2db/iliimporter.py
+++ b/QgisModelBaker/libili2db/iliimporter.py
@@ -60,6 +60,11 @@ class Importer(QObject):
         else:
             self.configuration = SchemaImportConfiguration()
         self.encoding = locale.getlocale()[1]
+
+        # Let's python try to determine the default locale
+        if not self.encoding:
+            self.encoding = locale.getdefaultlocale()[1]
+
         # This might be unset
         # (https://stackoverflow.com/questions/1629699/locale-getlocale-problems-on-osx)
         if not self.encoding:


### PR DESCRIPTION
Fix importing error on Windows if the current locale is different than `UTF-8` and `locale.gelocale()` returns `None`.
Seems that `locale.getdefaultlocale()` (that let python try to determine the correct locale) works on these situations.

