### PR TITLE
Refresh layers (including feature count) after data import

### DIFF
--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -213,7 +213,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
     def refresh_layers(self):
         # refresh layers
         for layer in self.iface.mapCanvas().layers():
-            layer.setDataSource(layer.source(), layer.name(), layer.providerType())
+            layer.dataProvider().forceReload()
         self.iface.layerTreeView().layerTreeModel().recursivelyEmitDataChanged()
 
     def print_info(self, text, text_color='#000000'):

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -214,8 +214,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         # refresh layers
         for layer in self.iface.mapCanvas().layers():
             layer.setDataSource(layer.source(), layer.name(), layer.providerType())
-            self.iface.layerTreeView().setCurrentLayer(layer)
-        self.iface.layerTreeView().setCurrentLayer(None)
+        self.iface.layerTreeView().layerTreeModel().recursivelyEmitDataChanged()
 
     def print_info(self, text, text_color='#000000'):
         self.txtStdout.setTextColor(QColor(text_color))

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -65,8 +65,9 @@ DIALOG_UI = get_ui_class('import_data.ui')
 
 class ImportDataDialog(QDialog, DIALOG_UI):
 
-    def __init__(self, base_config, parent=None):
+    def __init__(self, iface, base_config, parent=None):
         QDialog.__init__(self, parent)
+        self.iface = iface
         self.setupUi(self)
         QgsGui.instance().enableAutoGeometryRestore(self);
         self.db_simple_factory = DbSimpleFactory()
@@ -206,6 +207,15 @@ class ImportDataDialog(QDialog, DIALOG_UI):
             self.buttonBox.setEnabled(True)
             self.buttonBox.addButton(QDialogButtonBox.Close)
             self.progress_bar.setValue(100)
+
+            self.refresh_layers()
+
+    def refresh_layers(self):
+        # refresh layers
+        for layer in self.iface.mapCanvas().layers():
+            layer.setDataSource(layer.source(), layer.name(), layer.providerType())
+            self.iface.layerTreeView().setCurrentLayer(layer)
+        self.iface.layerTreeView().setCurrentLayer(None)
 
     def print_info(self, text, text_color='#000000'):
         self.txtStdout.setTextColor(QColor(text_color))

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -214,9 +214,12 @@ class ImportDataDialog(QDialog, DIALOG_UI):
 
     def refresh_layers(self):
         # refresh layers
-        for layer in self.iface.mapCanvas().layers():
-            layer.dataProvider().reloadData()
-        self.iface.layerTreeView().layerTreeModel().recursivelyEmitDataChanged()
+        try:
+            for layer in self.iface.mapCanvas().layers():
+                layer.dataProvider().reloadData()
+            self.iface.layerTreeView().layerTreeModel().recursivelyEmitDataChanged()
+        except AttributeError:
+            pass
 
     def print_info(self, text, text_color='#000000'):
         self.txtStdout.setTextColor(QColor(text_color))

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -213,7 +213,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
     def refresh_layers(self):
         # refresh layers
         for layer in self.iface.mapCanvas().layers():
-            layer.dataProvider().forceReload()
+            layer.dataProvider().dataReload()
         self.iface.layerTreeView().layerTreeModel().recursivelyEmitDataChanged()
 
     def print_info(self, text, text_color='#000000'):

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -215,7 +215,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
     def refresh_layers(self):
         # refresh layers
         for layer in self.iface.mapCanvas().layers():
-            layer.dataProvider().dataReload()
+            layer.dataProvider().reloadData()
         self.iface.layerTreeView().layerTreeModel().recursivelyEmitDataChanged()
 
     def print_info(self, text, text_color='#000000'):

--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -154,7 +154,7 @@ class QgisModelBakerPlugin(QObject):
         dlg.exec_()
 
     def show_importdata_dialog(self):
-        dlg = ImportDataDialog(self.ili2db_configuration)
+        dlg = ImportDataDialog(self.iface, self.ili2db_configuration)
         dlg.exec_()
 
     def show_help_documentation(self):


### PR DESCRIPTION
After a data import it goes through all the layers, resets the data source and featureCount with the QGIS method `reloadData()` https://github.com/qgis/QGIS/pull/33259 and reloads the layer in the legend (to trigger the getter of the feature count).



**Before:**
After data import, canvas are not refreshed (still empty until first zoom or whatever) and the feature count has been - even after the features are loaded on the canvas - the same like before the data import...