### PR TITLE
Try with getdefaultlocale() if getlocale() fails in iliexport

### DIFF
--- a/QgisModelBaker/libili2db/iliexporter.py
+++ b/QgisModelBaker/libili2db/iliexporter.py
@@ -52,6 +52,11 @@ class Exporter(QObject):
         self.tool = None
         self.configuration = ExportConfiguration()
         self.encoding = locale.getlocale()[1]
+
+        # Lets python try to determine the default locale
+        if not self.encoding:
+            self.encoding = locale.getdefaultlocale()[1]
+
         # This might be unset
         # (https://stackoverflow.com/questions/1629699/locale-getlocale-problems-on-osx)
         if not self.encoding:


### PR DESCRIPTION
Fix importing error on Windows if the current locale is different than UTF-8 and locale.gelocale() returns None.
Seems that locale.getdefaultlocale() (that let python try to determine the correct locale) works on these situations.

**This is exactly the same change as in #353 but on iliexporter instead of iliimporter**