### PR TITLE
Bag Of creating Value Relations with ili2db 4.4.0

### DIFF
--- a/QgisModelBaker/libili2db/ili2dbutils.py
+++ b/QgisModelBaker/libili2db/ili2dbutils.py
@@ -57,7 +57,12 @@ def get_ili2db_bin(tool, db_ili_version, stdout, stderr):
         ili2db_file = os.path.join(dir_path, 'bin', ili2db_dir, '{tool}-{version}/{tool}.jar'
                                    .format(tool=tool_name, version=ili_tool_version))
     else:
-        ili2db_file = os.path.join(dir_path, 'bin', ili2db_dir, '{tool}-{version}.jar'
+        # remove this if when 4.4.0 is released
+        if version.Version(ili_tool_version) >= version.Version('4.4.0'):
+            ili2db_file = os.path.join(dir_path, 'bin', ili2db_dir, '{tool}-{version}-SNAPSHOT.jar'
+                                   .format(tool=tool_name, version=ili_tool_version))
+        else:
+            ili2db_file = os.path.join(dir_path, 'bin', ili2db_dir, '{tool}-{version}.jar'
                                    .format(tool=tool_name, version=ili_tool_version))
 
     if not os.path.isfile(ili2db_file):

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
@@ -139,27 +139,28 @@ class Project(QObject):
                 key_field = bag_of_enum_info[3]
                 value_field = bag_of_enum_info[4]
 
-                allow_null = cardinality.startswith('0')
-                allow_multi = cardinality.endswith('*')
+                minimal_selection = cardinality.startswith('1')
 
                 current_layer = layer_obj.create()
 
                 field_widget = 'ValueRelation'
                 field_widget_config = {
-                    'AllowMulti': allow_multi,
+                    'AllowMulti': True,
                     'UseCompleter': False,
                     'Value': value_field,
                     'OrderByValue': False,
-                    'AllowNull': allow_null,
+                    'AllowNull': True,
                     'Layer': domain_table.create().id(),
                     'FilterExpression': '',
                     'Key': key_field,
                     'NofColumns': 1
                 }
-
                 field_idx = current_layer.fields().indexOf(attribute)
                 setup = QgsEditorWidgetSetup(field_widget, field_widget_config)
                 current_layer.setEditorWidgetSetup(field_idx, setup)
+                if minimal_selection:
+                    constraint_expression = 'array_length("{}")>0'.format(attribute)
+                    current_layer.setConstraintExpression(field_idx, constraint_expression, 'The minimal selection is 1')
 
         for layer in self.layers:
             layer.create_form(self)

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
@@ -160,7 +160,7 @@ class Project(QObject):
                 current_layer.setEditorWidgetSetup(field_idx, setup)
                 if minimal_selection:
                     constraint_expression = 'array_length("{}")>0'.format(attribute)
-                    current_layer.setConstraintExpression(field_idx, constraint_expression, 'The minimal selection is 1')
+                    current_layer.setConstraintExpression(field_idx, constraint_expression, self.tr('The minimal selection is 1'))
 
         for layer in self.layers:
             layer.create_form(self)

--- a/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
@@ -62,7 +62,7 @@ class GpkgFactory(DbFactory):
         """
         # remove this if when 4.4.0 is released
         if self.get_tool_version(db_ili_version) == '4.4.0':
-            return 'http://jars.interlis.ch/ch/interlis/ili2gpkg/4.4.0-SNAPSHOT/ili2gpkg-4.4.0-20200127.103509-7-bindist.zip'
+            return 'http://jars.interlis.ch/ch/interlis/ili2gpkg/4.4.0-SNAPSHOT/ili2gpkg-4.4.0-20200127.103444-7-bindist.zip'
         else:
             return 'http://www.eisenhutinformatik.ch/interlis/ili2gpkg/ili2gpkg-{version}.zip'.format(version=self.get_tool_version(db_ili_version))
 

--- a/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
@@ -53,14 +53,18 @@ class GpkgFactory(DbFactory):
         if db_ili_version == 3:
             return '3.11.3'
         else:
-            return '4.3.2'
+            return '4.4.0'
 
     def get_tool_url(self, db_ili_version):
         """Returns download url of ili2gpkg.
 
         :return str A download url.
         """
-        return 'http://www.eisenhutinformatik.ch/interlis/ili2gpkg/ili2gpkg-{version}.zip'.format(version=self.get_tool_version(db_ili_version))
+        # remove this if when 4.4.0 is released
+        if self.get_tool_version(db_ili_version) == '4.4.0':
+            return 'http://jars.interlis.ch/ch/interlis/ili2gpkg/4.4.0-SNAPSHOT/ili2gpkg-4.4.0-20200127.103509-7-bindist.zip'
+        else:
+            return 'http://www.eisenhutinformatik.ch/interlis/ili2gpkg/ili2gpkg-{version}.zip'.format(version=self.get_tool_version(db_ili_version))
 
     def get_specific_messages(self):
         messages = {

--- a/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
@@ -53,7 +53,7 @@ class GpkgFactory(DbFactory):
         if db_ili_version == 3:
             return '3.11.3'
         else:
-            return '4.4.0'
+            return '4.3.2'
 
     def get_tool_url(self, db_ili_version):
         """Returns download url of ili2gpkg.

--- a/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
@@ -53,7 +53,7 @@ class GpkgFactory(DbFactory):
         if db_ili_version == 3:
             return '3.11.3'
         else:
-            return '4.3.2'
+            return '4.4.0'
 
     def get_tool_url(self, db_ili_version):
         """Returns download url of ili2gpkg.

--- a/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
@@ -86,11 +86,15 @@ class PgFactory(DbFactory):
         if db_ili_version == 3:
             return '3.11.2'
         else:
-            return '4.3.2'
+            return '4.4.0'
 
     def get_tool_url(self, db_ili_version):
         """Returns download url of ili2pg.
 
         :return str A download url.
         """
-        return 'http://www.eisenhutinformatik.ch/interlis/ili2pg/ili2pg-{version}.zip'.format(version=self.get_tool_version(db_ili_version))
+        # remove this if when 4.4.0 is released
+        if self.get_tool_version(db_ili_version) == '4.4.0':
+            return 'http://jars.interlis.ch/ch/interlis/ili2pg/4.4.0-SNAPSHOT/ili2pg-4.4.0-20200127.103509-7-bindist.zip'
+        else:
+            return 'http://www.eisenhutinformatik.ch/interlis/ili2pg/ili2pg-{version}.zip'.format(version=self.get_tool_version(db_ili_version))

--- a/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
@@ -86,7 +86,7 @@ class PgFactory(DbFactory):
         if db_ili_version == 3:
             return '3.11.2'
         else:
-            return '4.4.0'
+            return '4.3.2'
 
     def get_tool_url(self, db_ili_version):
         """Returns download url of ili2pg.

--- a/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
@@ -86,7 +86,7 @@ class PgFactory(DbFactory):
         if db_ili_version == 3:
             return '3.11.2'
         else:
-            return '4.3.2'
+            return '4.4.0'
 
     def get_tool_url(self, db_ili_version):
         """Returns download url of ili2pg.

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
@@ -131,6 +131,22 @@ class DBConnector(QObject):
         '''
         return []
 
+    def get_bags_of_info(self):
+        '''
+        Info about bags_of found in a database (or database schema).
+
+        Return:
+            Iterable allowing to access rows, each row should allow to access
+            specific columns by name (e.g., a list of dicts {column_name:value})
+            Expected columns are:
+                current_layer_name
+                attribute
+                target_layer_name
+                cardinality_max
+                cardinality_min
+        '''
+        return []
+
     def get_iliname_dbname_mapping(self, sqlnames):
         """Used for ili2db version 3 relation creation"""
         return {}

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
@@ -31,6 +31,7 @@ class DBConnector(QObject):
         self.QGIS_TIME_TYPE = 'time'
         self.QGIS_DATE_TIME_TYPE = 'datetime'
         self.iliCodeName = ''  # For Domain-Class relations, specific for each DB
+        self.tid = ''  # For BAG OF config, specific for each DB
         self.dispName = ''  # For BAG OF config, specific for each DB
 
     def map_data_types(self, data_type):

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -307,19 +307,20 @@ class GPKGConnector(DBConnector):
 
     def get_bags_of_info(self):
         cursor = self.conn.cursor()
-        cursor.execute("""SELECT cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name, 
-                        meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max
-                        FROM t_ili2db_column_prop as cprop
-                        LEFT JOIN t_ili2db_classname as cname
-                        ON cname.sqlname = cprop.tablename 
-                        LEFT JOIN t_ili2db_meta_attrs as meta_attrs_array
-                        ON LOWER(meta_attrs_array.ilielement) = LOWER(cname.iliname||'.'||cprop.columnname) AND meta_attrs_array.attr_name = 'ili2db.mapping'
-                        LEFT JOIN t_ili2db_meta_attrs as meta_attrs_cardinality_min
-                        ON LOWER(meta_attrs_cardinality_min.ilielement) = LOWER(cname.iliname||'.'||cprop.columnname) AND meta_attrs_cardinality_min.attr_name = 'ili2db.ili.attrCardinalityMin'
-                        LEFT JOIN t_ili2db_meta_attrs as meta_attrs_cardinality_max
-                        ON LOWER(meta_attrs_cardinality_max.ilielement) = LOWER(cname.iliname||'.'||cprop.columnname) AND meta_attrs_cardinality_max.attr_name = 'ili2db.ili.attrCardinalityMax'
-                        WHERE cprop.tag = 'ch.ehi.ili2db.foreignKey' AND meta_attrs_array.attr_value = 'ARRAY'
-                        """)
+        if self.metadata_exists():
+            cursor.execute("""SELECT cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name, 
+                            meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max
+                            FROM t_ili2db_column_prop as cprop
+                            LEFT JOIN t_ili2db_classname as cname
+                            ON cname.sqlname = cprop.tablename 
+                            LEFT JOIN t_ili2db_meta_attrs as meta_attrs_array
+                            ON LOWER(meta_attrs_array.ilielement) = LOWER(cname.iliname||'.'||cprop.columnname) AND meta_attrs_array.attr_name = 'ili2db.mapping'
+                            LEFT JOIN t_ili2db_meta_attrs as meta_attrs_cardinality_min
+                            ON LOWER(meta_attrs_cardinality_min.ilielement) = LOWER(cname.iliname||'.'||cprop.columnname) AND meta_attrs_cardinality_min.attr_name = 'ili2db.ili.attrCardinalityMin'
+                            LEFT JOIN t_ili2db_meta_attrs as meta_attrs_cardinality_max
+                            ON LOWER(meta_attrs_cardinality_max.ilielement) = LOWER(cname.iliname||'.'||cprop.columnname) AND meta_attrs_cardinality_max.attr_name = 'ili2db.ili.attrCardinalityMax'
+                            WHERE cprop.tag = 'ch.ehi.ili2db.foreignKey' AND meta_attrs_array.attr_value = 'ARRAY'
+                            """)
         return cursor
 
     def get_iliname_dbname_mapping(self, sqlnames):

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -41,6 +41,7 @@ class PGConnector(DBConnector):
         self.schema = schema
         self._bMetadataTable = self._metadata_exists()
         self.iliCodeName = 'ilicode'
+        self.tid = 't_id'
         self.dispName = 'dispname'
 
     def map_data_types(self, data_type):

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -359,6 +359,25 @@ class PGConnector(DBConnector):
 
         return []
 
+    def get_bags_of_info(self):
+        if self.schema:
+            cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+            cur.execute("""SELECT cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name, 
+                            meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max
+                            FROM {schema}.t_ili2db_column_prop as cprop
+                            LEFT JOIN {schema}.t_ili2db_classname as cname
+                            ON cname.sqlname = cprop.tablename 
+                            LEFT JOIN {schema}.t_ili2db_meta_attrs as meta_attrs_array
+                            ON meta_attrs_array.ilielement ILIKE cname.iliname||'.'||cprop.columnname AND meta_attrs_array.attr_name = 'ili2db.mapping'
+                            LEFT JOIN {schema}.t_ili2db_meta_attrs as meta_attrs_cardinality_min
+                            ON meta_attrs_cardinality_min.ilielement ILIKE cname.iliname||'.'||cprop.columnname AND meta_attrs_cardinality_min.attr_name = 'ili2db.ili.attrCardinalityMin'
+                            LEFT JOIN {schema}.t_ili2db_meta_attrs as meta_attrs_cardinality_max
+                            ON meta_attrs_cardinality_max.ilielement ILIKE cname.iliname||'.'||cprop.columnname AND meta_attrs_cardinality_max.attr_name = 'ili2db.ili.attrCardinalityMax'
+                            WHERE cprop.tag = 'ch.ehi.ili2db.foreignKey' AND meta_attrs_array.attr_value = 'ARRAY'
+                            """.format(schema=self.schema))
+            return cur
+        return []
+
     def get_iliname_dbname_mapping(self, sqlnames):
         """Used for ili2db version 3 relation creation"""
         # Map domain ili name with its correspondent pg name

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -361,7 +361,7 @@ class PGConnector(DBConnector):
         return []
 
     def get_bags_of_info(self):
-        if self.schema:
+        if self.schema and self.metadata_exists():
             cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
             cur.execute("""SELECT cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name, 
                             meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -243,8 +243,8 @@ class Generator(QObject):
                 new_item_list = [layer_map[record['current_layer_name']][0],
                                  record['cardinality_min'] + '..' + record['cardinality_max'],
                                  layer_map[record['target_layer_name']][0],
-                                 't_id',
-                                 'dispname']
+                                 self._db_connector.tid,
+                                 self._db_connector.dispName]
                 if record['current_layer_name'] in bags_of_enum.keys():
                     bags_of_enum[record['current_layer_name']][record['attribute']] = new_item_list
                 else:

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -229,14 +229,14 @@ class Generator(QObject):
                         relations.append(relation)
 
         if self._db_connector.ili_version() == 3:
-            """Used for ili2db version 3 relation creation"""
+            # Used for ili2db version 3 relation creation
             domain_relations_generator = DomainRelationGenerator(
                 self._db_connector, self.inheritance)
             domain_relations, bags_of_enum = domain_relations_generator.get_domain_relations_info(
                 layers)
             relations = relations + domain_relations
         else:
-            """Create the bags_of_enum structure"""
+            # Create the bags_of_enum structure
             bags_of_info = self.get_bags_of_info()
             bags_of_enum = {}
             for record in bags_of_info:

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -236,17 +236,12 @@ class Generator(QObject):
                 layers)
             relations = relations + domain_relations
         else:
-            """Create the bags_of_enum structure
-            record['cardinality_min'] + '..' + record['cardinality_max'] provided from >= ili2db 4.4.0
-            still they are not really used in the creation of the Value Relation Widget since:
-            - When it's a bag of here, it's always multi-selection (otherwise it's no ARRAY and created as a Relation Reference)
-            - multi-selection Value Relations are never null (just empty list []), so a minimum 0 is not yet implemented in QGIS
-            """
+            """Create the bags_of_enum structure"""
             bags_of_info = self.get_bags_of_info()
             bags_of_enum = {}
             for record in bags_of_info:
                 new_item_list = [layer_map[record['current_layer_name']][0],
-                                 '0..*',
+                                 record['cardinality_min'] + '..' + record['cardinality_max'],
                                  layer_map[record['target_layer_name']][0],
                                  self._db_connector.tid,
                                  self._db_connector.dispName]

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -236,12 +236,17 @@ class Generator(QObject):
                 layers)
             relations = relations + domain_relations
         else:
-            """Create the bags_of_enum structure"""
+            """Create the bags_of_enum structure
+            record['cardinality_min'] + '..' + record['cardinality_max'] provided from >= ili2db 4.4.0
+            still they are not really used in the creation of the Value Relation Widget since:
+            - When it's a bag of here, it's always multi-selection (otherwise it's no ARRAY and created as a Relation Reference)
+            - multi-selection Value Relations are never null (just empty list []), so a minimum 0 is not yet implemented in QGIS
+            """
             bags_of_info = self.get_bags_of_info()
             bags_of_enum = {}
             for record in bags_of_info:
                 new_item_list = [layer_map[record['current_layer_name']][0],
-                                 record['cardinality_min'] + '..' + record['cardinality_max'],
+                                 '0..*',
                                  layer_map[record['target_layer_name']][0],
                                  self._db_connector.tid,
                                  self._db_connector.dispName]

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -240,16 +240,18 @@ class Generator(QObject):
             bags_of_info = self.get_bags_of_info()
             bags_of_enum = {}
             for record in bags_of_info:
-                new_item_list = [layer_map[record['current_layer_name']][0],
-                                 record['cardinality_min'] + '..' + record['cardinality_max'],
-                                 layer_map[record['target_layer_name']][0],
-                                 self._db_connector.tid,
-                                 self._db_connector.dispName]
-                unique_current_layer_name = record['current_layer_name']+'_'+layer_map[record['current_layer_name']][0].geometry_column
-                if unique_current_layer_name in bags_of_enum.keys():
-                    bags_of_enum[unique_current_layer_name][record['attribute']] = new_item_list
-                else:
-                    bags_of_enum[unique_current_layer_name] = {record['attribute']: new_item_list}
+                for layer in layers:
+                    if record['current_layer_name'] == layer.name:
+                        new_item_list = [layer,
+                                         record['cardinality_min'] + '..' + record['cardinality_max'],
+                                         layer_map[record['target_layer_name']][0],
+                                         self._db_connector.tid,
+                                         self._db_connector.dispName]
+                        unique_current_layer_name = '{}_{}'.format(record['current_layer_name'],layer.geometry_column)
+                        if unique_current_layer_name in bags_of_enum.keys():
+                            bags_of_enum[unique_current_layer_name][record['attribute']] = new_item_list
+                        else:
+                            bags_of_enum[unique_current_layer_name] = {record['attribute']: new_item_list}
         return (relations, bags_of_enum)
 
     def legend(self, layers, ignore_node_names=None):

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -236,8 +236,19 @@ class Generator(QObject):
                 layers)
             relations = relations + domain_relations
         else:
+            """Create the bags_of_enum structure"""
+            bags_of_info = self.get_bags_of_info()
             bags_of_enum = {}
-
+            for record in bags_of_info:
+                new_item_list = [layer_map[record['current_layer_name']][0],
+                                 record['cardinality_min'] + '..' + record['cardinality_max'],
+                                 layer_map[record['target_layer_name']][0],
+                                 't_id',
+                                 'dispname']
+                if record['current_layer_name'] in bags_of_enum.keys():
+                    bags_of_enum[record['current_layer_name']][record['attribute']] = new_item_list
+                else:
+                    bags_of_enum[record['current_layer_name']] = {record['attribute']: new_item_list}
         return (relations, bags_of_enum)
 
     def legend(self, layers, ignore_node_names=None):
@@ -317,3 +328,6 @@ class Generator(QObject):
 
     def get_relations_info(self, filter_layer_list=[]):
         return self._db_connector.get_relations_info(filter_layer_list)
+
+    def get_bags_of_info(self):
+        return self._db_connector.get_bags_of_info()

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -245,10 +245,11 @@ class Generator(QObject):
                                  layer_map[record['target_layer_name']][0],
                                  self._db_connector.tid,
                                  self._db_connector.dispName]
-                if record['current_layer_name'] in bags_of_enum.keys():
-                    bags_of_enum[record['current_layer_name']][record['attribute']] = new_item_list
+                unique_current_layer_name = record['current_layer_name']+'_'+layer_map[record['current_layer_name']][0].geometry_column
+                if unique_current_layer_name in bags_of_enum.keys():
+                    bags_of_enum[unique_current_layer_name][record['attribute']] = new_item_list
                 else:
-                    bags_of_enum[record['current_layer_name']] = {record['attribute']: new_item_list}
+                    bags_of_enum[unique_current_layer_name] = {record['attribute']: new_item_list}
         return (relations, bags_of_enum)
 
     def legend(self, layers, ignore_node_names=None):

--- a/QgisModelBaker/tests/test_domain_class_relations.py
+++ b/QgisModelBaker/tests/test_domain_class_relations.py
@@ -807,7 +807,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 value_field = bag_of_enum_info[4]
                 self.assertIn([layer_name, attribute, cardinality, domain_table.name, key_field, value_field], expected_bags_of_enum)
 
-        self.assertEqual(count, 0)  # 9
+        self.assertEqual(count, 9)
 
     def test_ili2db3_domain_structure_relations_ZG_Naturschutz_und_Erholung_V1_0_postgis(self):
         # Schema Import
@@ -1040,7 +1040,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 value_field = bag_of_enum_info[4]
                 self.assertIn([layer_name, attribute, cardinality, domain_table.name, key_field, value_field], expected_bags_of_enum)
 
-        self.assertEqual(count, 0)  # 9
+        self.assertEqual(count, 9)
 
     def test_ili2db3_domain_structure_relations_ZG_Naturschutz_und_Erholung_V1_0_geopackage(self):
         # Schema Import
@@ -1232,7 +1232,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 value_field = bag_of_enum_info[4]
                 self.assertIn([layer_name, attribute, cardinality, domain_table.name, key_field, value_field], expected_bags_of_enum)
 
-        self.assertEqual(count, 0)  # 4
+        self.assertEqual(count, 4)
 
     def test_ili2db3_domain_structure_relations_KbS_LV95_V1_3_postgis(self):
         # Schema Import
@@ -1383,7 +1383,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 value_field = bag_of_enum_info[4]
                 self.assertIn([layer_name, attribute, cardinality, domain_table.name, key_field, value_field], expected_bags_of_enum)
 
-        self.assertEqual(count, 0)  # 2
+        self.assertEqual(count, 2)
 
     def test_ili2db3_domain_structure_relations_KbS_LV95_V1_3_geopackage(self):
         # Schema Import

--- a/QgisModelBaker/tests/testdata/ilimodels/CardinalityBag.ili
+++ b/QgisModelBaker/tests/testdata/ilimodels/CardinalityBag.ili
@@ -1,0 +1,33 @@
+INTERLIS 2.3;
+
+MODEL CardinalityBag
+  AT "mailto:david@opengis.ch" VERSION "2015-09-23" =
+  
+  DOMAIN
+    EI_Typen = (Fischers, Fritz, Fischt, Frische, Fische);
+
+  TOPIC Topic =
+  
+    STRUCTURE StructText=
+       text : TEXT*10;
+    END StructText;
+    
+    STRUCTURE EI_Typ =
+      EI_Typen: EI_Typen;
+    END EI_Typ;
+
+    CLASS Fische =
+       Name : TEXT*10;
+       !!@ili2db.mapping=ARRAY
+       TextList_0 : BAG {0..*} OF StructText;
+       !!@ili2db.mapping=ARRAY
+       TextList_1 : BAG {1..*} OF StructText;
+       !!@ili2db.mapping=ARRAY
+       ValueRelation_0: BAG {0..*} OF EI_Typ;
+       !!@ili2db.mapping=ARRAY
+       ValueRelation_1: BAG {1..*} OF EI_Typ;
+    END Fische;
+
+  END Topic;
+END CardinalityBag.
+


### PR DESCRIPTION
Information for Bag-Of-Structures are read from the meta tables:
- t_ili2db_column_prop
- t_ili2db_meta_attrs
- t_ili2db_classname

The cardinality influences the Value Relation settings like this:
- Minimum Value: if 1 the constraint expression is set like `array_length("valuerelation_1")>0` means at least one item should be selected
- Maximum Value: no influece since it should be always * If not, then it's not an ARRAY and not created as a value relation

`Allow Null` and `Multi Selection` are always true, since the list is never NULL and if it should not be a multi selection the widget will be a Relation Reference.

- [x] Simple tests to check if the expression is created regarding the cardinality

Fix #359 
Fix #182 