### PR TITLE
Fix models without space

### DIFF
--- a/QgisModelBaker/libili2db/ilicache.py
+++ b/QgisModelBaker/libili2db/ilicache.py
@@ -213,7 +213,7 @@ class IliCache(QObject):
         Parses an ili file returning models and version data
         """
         models = list()
-        re_model = re.compile(r'\s*MODEL\s*([\w\d_-]+)\s.*')
+        re_model = re.compile(r'\s*MODEL\s*([\w\d_-]+)\s*[\(].*')
         re_model_version = re.compile(r'VERSION "([ \w\d\._-]+)".*')
         with open(ilipath, 'r', encoding=encoding) as file:
             for line in file:

--- a/QgisModelBaker/libili2db/ilicache.py
+++ b/QgisModelBaker/libili2db/ilicache.py
@@ -213,7 +213,7 @@ class IliCache(QObject):
         Parses an ili file returning models and version data
         """
         models = list()
-        re_model = re.compile(r'\s*MODEL\s*([\w\d_-]+)\s*[\(].*')
+        re_model = re.compile(r'\s*MODEL\s*([\w\d_-]+)\s*\(.*')
         re_model_version = re.compile(r'VERSION "([ \w\d\._-]+)".*')
         with open(ilipath, 'r', encoding=encoding) as file:
             model = None

--- a/QgisModelBaker/libili2db/ilicache.py
+++ b/QgisModelBaker/libili2db/ilicache.py
@@ -216,7 +216,8 @@ class IliCache(QObject):
         re_model = re.compile(r'\s*MODEL\s*([\w\d_-]+)\s*[\(].*')
         re_model_version = re.compile(r'VERSION "([ \w\d\._-]+)".*')
         with open(ilipath, 'r', encoding=encoding) as file:
-            for line in file:
+            model = None
+            for lineno, line in enumerate(file):
                 result = re_model.search(line)
                 if result:
                     model = dict()
@@ -227,7 +228,10 @@ class IliCache(QObject):
 
                 result = re_model_version.search(line)
                 if result:
+                    if not model:
+                        raise RuntimeError('VERSION tag found in file {}:{} without previous MODEL definition.'.format(ilipath, lineno))
                     model['version'] = result.group(1)
+                    model = None
 
         return models
 

--- a/QgisModelBaker/tests/test_ilicache.py
+++ b/QgisModelBaker/tests/test_ilicache.py
@@ -14,9 +14,13 @@ class IliCacheTest(unittest.TestCase):
         models = ilicache.parse_ili_file(os.path.join(test_path, 'testdata', 'ilimodels', 'RoadsSimpleNoSpace.ili'), 'utf-8')
         self.assertEqual(models[0]['name'], 'RoadsSimple')
         self.assertEqual(models[0]['version'], '2016-08-11')
+
         models = ilicache.parse_ili_file(os.path.join(test_path, 'testdata', 'ilimodels', 'RoadsSimple.ili'), 'utf-8')
         self.assertEqual(models[0]['name'], 'RoadsSimple')
         self.assertEqual(models[0]['version'], '2016-08-11')
+
+        with self.assertRaises(RuntimeError):
+            ilicache.parse_ili_file(os.path.join(test_path, 'testdata', 'ilimodels', 'RoadsInvalid.ili'), 'utf-8')
 
 
 if __name__ == '__main__':

--- a/QgisModelBaker/tests/test_ilicache.py
+++ b/QgisModelBaker/tests/test_ilicache.py
@@ -1,0 +1,23 @@
+import nose2
+import pathlib
+import os
+from qgis.testing import unittest
+
+from QgisModelBaker.libili2db.ilicache import IliCache
+
+
+test_path = pathlib.Path(__file__).parent.absolute()
+class IliCacheTest(unittest.TestCase):
+
+    def test_modelparser(self):
+        ilicache = IliCache([])
+        models = ilicache.parse_ili_file(os.path.join(test_path, 'testdata', 'ilimodels', 'RoadsSimpleNoSpace.ili'), 'utf-8')
+        self.assertEqual(models[0]['name'], 'RoadsSimple')
+        self.assertEqual(models[0]['version'], '2016-08-11')
+        models = ilicache.parse_ili_file(os.path.join(test_path, 'testdata', 'ilimodels', 'RoadsSimple.ili'), 'utf-8')
+        self.assertEqual(models[0]['name'], 'RoadsSimple')
+        self.assertEqual(models[0]['version'], '2016-08-11')
+
+
+if __name__ == '__main__':
+    nose2.main()

--- a/QgisModelBaker/tests/testdata/ilimodels/RoadsInvalid.ili
+++ b/QgisModelBaker/tests/testdata/ilimodels/RoadsInvalid.ili
@@ -1,0 +1,66 @@
+
+INTERLIS 2.3;
+
+MODL RoadsSimple (en) AT "http://www.interlis.ch/models"
+  VERSION "2016-08-11" =
+
+  UNIT
+    Angle_Degree = 180 / PI [INTERLIS.rad];
+
+  DOMAIN
+    Point2D = COORD
+      0.000 .. 200.000 [INTERLIS.m], !! Min_East  Max_East
+      0.000 .. 200.000 [INTERLIS.m], !! Min_North Max_North
+      ROTATION 2 -> 1;
+    Orientation = 0.0 .. 359.9 CIRCULAR [Angle_Degree];
+
+
+  TOPIC Roads =
+
+    CLASS LandCover =
+      Type: MANDATORY (
+        building,
+        street,
+        water,
+        other);
+      Geometry: MANDATORY SURFACE WITH (STRAIGHTS)
+        VERTEX Point2D WITHOUT OVERLAPS > 0.100;
+    END LandCover;
+
+    CLASS Street =
+      Name: MANDATORY TEXT*32;
+    END Street;
+
+    CLASS StreetAxis =
+      Geometry: MANDATORY POLYLINE WITH (STRAIGHTS)
+        VERTEX Point2D;
+    END StreetAxis;
+
+    ASSOCIATION StreetAxisAssoc =
+      Street -- {1} Street;
+      StreetAxis -- StreetAxis;
+    END StreetAxisAssoc;
+
+    CLASS StreetNamePosition =
+      NamPos: MANDATORY Point2D;
+      NamOri: MANDATORY Orientation;
+    END StreetNamePosition;
+
+    ASSOCIATION StreetNamePositionAssoc =
+      Street -- {0..1} Street;
+      StreetNamePosition -- StreetNamePosition;
+    END StreetNamePositionAssoc;
+
+    CLASS RoadSign =
+      Type: MANDATORY (
+        prohibition, 
+        indication, 
+        danger,
+        velocity);
+      Position: MANDATORY Point2D;
+    END RoadSign;
+
+  END Roads; !! of TOPIC
+
+END RoadsSimple. !! of MODEL
+

--- a/QgisModelBaker/tests/testdata/ilimodels/RoadsSimpleNoSpace.ili
+++ b/QgisModelBaker/tests/testdata/ilimodels/RoadsSimpleNoSpace.ili
@@ -1,0 +1,66 @@
+
+INTERLIS 2.3;
+
+MODEL RoadsSimple(en) AT "http://www.interlis.ch/models"
+  VERSION "2016-08-11" =
+
+  UNIT
+    Angle_Degree = 180 / PI [INTERLIS.rad];
+
+  DOMAIN
+    Point2D = COORD
+      0.000 .. 200.000 [INTERLIS.m], !! Min_East  Max_East
+      0.000 .. 200.000 [INTERLIS.m], !! Min_North Max_North
+      ROTATION 2 -> 1;
+    Orientation = 0.0 .. 359.9 CIRCULAR [Angle_Degree];
+
+
+  TOPIC Roads =
+
+    CLASS LandCover =
+      Type: MANDATORY (
+        building,
+        street,
+        water,
+        other);
+      Geometry: MANDATORY SURFACE WITH (STRAIGHTS)
+        VERTEX Point2D WITHOUT OVERLAPS > 0.100;
+    END LandCover;
+
+    CLASS Street =
+      Name: MANDATORY TEXT*32;
+    END Street;
+
+    CLASS StreetAxis =
+      Geometry: MANDATORY POLYLINE WITH (STRAIGHTS)
+        VERTEX Point2D;
+    END StreetAxis;
+
+    ASSOCIATION StreetAxisAssoc =
+      Street -- {1} Street;
+      StreetAxis -- StreetAxis;
+    END StreetAxisAssoc;
+
+    CLASS StreetNamePosition =
+      NamPos: MANDATORY Point2D;
+      NamOri: MANDATORY Orientation;
+    END StreetNamePosition;
+
+    ASSOCIATION StreetNamePositionAssoc =
+      Street -- {0..1} Street;
+      StreetNamePosition -- StreetNamePosition;
+    END StreetNamePositionAssoc;
+
+    CLASS RoadSign =
+      Type: MANDATORY (
+        prohibition, 
+        indication, 
+        danger,
+        velocity);
+      Position: MANDATORY Point2D;
+    END RoadSign;
+
+  END Roads; !! of TOPIC
+
+END RoadsSimple. !! of MODEL
+


### PR DESCRIPTION
Problem so far, the parser wasn't robust against no space between model name and language

```
NOT OK:
MODEL SZ_Lebensraum_Krebs_V2_Erfassung(de)
OK:
MODEL SZ_Lebensraum_Krebs_V2_Erfassung (de)
```