### PR TITLE
Fix get extension when try to export .xtf file

### DIFF
--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -130,6 +130,7 @@ class ExportDialog(QDialog, DIALOG_UI):
         self.xtf_file_browse_button.clicked.connect(
             make_save_file_selector(self.xtf_file_line_edit, title=self.tr('Save in XTF Transfer File'),
                                     file_filter=self.tr('XTF Transfer File (*.xtf *XTF);;Interlis 1 Transfer File (*.itf *ITF);;XML (*.xml *XML);;GML (*.gml *GML)'),
+                                    extension='.xtf',
                                     extensions=['.' + ext for ext in self.ValidExtensions]))
         self.xtf_file_browse_button.clicked.connect(
             self.xtf_browser_opened_to_true)


### PR DESCRIPTION
When we try to export a XTF file the path does not get the extension. This PR fix this.

Solution: 
![image](https://user-images.githubusercontent.com/27906888/74770991-5df41400-525b-11ea-8ae8-69cd966730c4.png)

![image](https://user-images.githubusercontent.com/27906888/74771125-9ac00b00-525b-11ea-825d-4cbb9bdb038a.png)

