### PR TITLE
Support for other SRS authorities

### DIFF
--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -496,7 +496,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         if  srs_auth == 'USER':
             self.crs_label.setStyleSheet('color: orange')
             self.crs_label.setToolTip(
-                self.tr('Please select a valid Coordinate Reference System.\nCRSs from USER are valid for a single computer and therefore, not recommended.\nA default EPSG:21781 will be used.'))
+                self.tr('Please select a valid Coordinate Reference System.\nCRSs from USER are valid for a single computer and therefore, a default EPSG:21781 will be used instead.'))
         else:
             self.crs_label.setStyleSheet('')
             self.crs_label.setToolTip(self.tr('Coordinate Reference System'))

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -174,7 +174,8 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         self.inheritance = 'smart1'
         self.create_basket_col = False
         self.create_import_tid = True
-        self.epsg = 21781  # Default EPSG code in ili2pg
+        self.srs_auth = 'EPSG'  # Default SRS auth in ili2db
+        self.srs_code = 21781  # Default SRS code in ili2db
         self.stroke_arcs = True
         self.db_ili_version = None
 
@@ -225,8 +226,11 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         if self.create_basket_col:
             args += ["--createBasketCol"]
 
-        if self.epsg != 21781:
-            args += ["--defaultSrsCode", "{}".format(self.epsg)]
+        if self.srs_auth != 'EPSG':
+            args += ["--defaultSrsAuth", self.srs_auth]
+
+        if self.srs_code != 21781:
+            args += ["--defaultSrsCode", "{}".format(self.srs_code)]
 
         args += Ili2DbCommandConfiguration.to_ili2db_args(self)
 

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -229,8 +229,7 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         if self.srs_auth != 'EPSG':
             args += ["--defaultSrsAuth", self.srs_auth]
 
-        if self.srs_code != 21781:
-            args += ["--defaultSrsCode", "{}".format(self.srs_code)]
+        args += ["--defaultSrsCode", "{}".format(self.srs_code)]
 
         args += Ili2DbCommandConfiguration.to_ili2db_args(self)
 

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
@@ -96,7 +96,10 @@ class Layer(object):
             settings.setValue("/Projections/defaultBehavior", old_proj_value)
 
             if self.srid is not None and not self.__layer.crs().authid() == "EPSG:{}".format(self.srid):
-                self.__layer.setCrs(QgsCoordinateReferenceSystem().fromEpsgId(self.srid))
+                crs = QgsCoordinateReferenceSystem().fromEpsgId(self.srid)
+                if not crs.isValid():
+                    crs = QgsCoordinateReferenceSystem(self.srid)  # Fallback
+                self.__layer.setCrs(crs)
             if self.is_domain:
                 self.__layer.setReadOnly()
             if self.display_expression:

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
@@ -94,8 +94,10 @@ class Project(QObject):
             if isinstance(self.crs, QgsCoordinateReferenceSystem):
                 qgis_project.setCrs(self.crs)
             else:
-                qgis_project.setCrs(
-                    QgsCoordinateReferenceSystem.fromEpsgId(self.crs))
+                crs = QgsCoordinateReferenceSystem.fromEpsgId(self.crs)
+                if not crs.isValid():
+                    crs = QgsCoordinateReferenceSystem(self.crs)  # Fallback
+                qgis_project.setCrs(crs)
 
         qgis_relations = list(
             qgis_project.relationManager().relations().values())

--- a/QgisModelBaker/tests/test_domain_class_relations.py
+++ b/QgisModelBaker/tests/test_domain_class_relations.py
@@ -49,7 +49,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -125,7 +125,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -200,7 +200,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_gpkg_{:%Y%m%d%H%M%S%f}.gpkg'.format(
                 datetime.datetime.now()))
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -279,7 +279,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_{:%Y%m%d%H%M%S%f}.gpkg'.format(
                 datetime.datetime.now()))
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -356,7 +356,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -436,7 +436,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -518,7 +518,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'Abfallsammelstellen_ZEBA_LV03_V1'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -604,7 +604,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'Abfallsammelstellen_ZEBA_LV03_V1'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -689,7 +689,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_gpkg_2_{:%Y%m%d%H%M%S%f}.gpkg'.format(
                 datetime.datetime.now()))
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -778,7 +778,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_gpkg_2_{:%Y%m%d%H%M%S%f}.gpkg'.format(
                 datetime.datetime.now()))
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -864,7 +864,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'ZG_Naturschutz_und_Erholung_V1_0'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -980,7 +980,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'ZG_Naturschutz_und_Erholung_V1_0'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -1095,7 +1095,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_bags_of_enum_gpkg_{:%Y%m%d%H%M%S%f}.gpkg'.format(
                 datetime.datetime.now()))
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -1214,7 +1214,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_bags_of_enum_gpkg_{:%Y%m%d%H%M%S%f}.gpkg'.format(
                 datetime.datetime.now()))
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -1330,7 +1330,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'KbS_LV95_V1_3'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -1405,7 +1405,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'KbS_LV95_V1_3'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -1479,7 +1479,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_bags_of_enum_kbs_lv95_v1_3_{:%Y%m%d%H%M%S%f}.gpkg'.format(
                 datetime.datetime.now()))
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -1557,7 +1557,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_bags_of_enum_kbs_lv95_v1_3_{:%Y%m%d%H%M%S%f}.gpkg'.format(
                 datetime.datetime.now()))
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -1635,7 +1635,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'Hazard_Mapping_LV95_V1_2'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 2056
+        importer.configuration.srs_code = 2056
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -1925,7 +1925,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'Hazard_Mapping_LV95_V1_2'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 2056
+        importer.configuration.srs_code = 2056
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -2210,7 +2210,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'ZG_Naturschutz_und_Erholungsinfrastruktur_V1'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -2283,7 +2283,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.ilimodels = 'ZG_Naturschutz_und_Erholungsinfrastruktur_V1'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)

--- a/QgisModelBaker/tests/test_export.py
+++ b/QgisModelBaker/tests/test_export.py
@@ -90,7 +90,7 @@ class TestExport(unittest.TestCase):
         importer_e.configuration.ilimodels = 'CIAF_LADM'
         importer_e.configuration.dbschema = 'ciaf_ladm_e_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer_e.configuration.epsg = 3116
+        importer_e.configuration.srs_code = 3116
         importer_e.configuration.inheritance = 'smart2'
         importer_e.stdout.connect(self.print_info)
         importer_e.stderr.connect(self.print_error)
@@ -119,7 +119,7 @@ class TestExport(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -174,7 +174,7 @@ class TestExport(unittest.TestCase):
         importer.configuration.ilimodels = 'Catastro_COL_ES_V2_1_6;CIAF_LADM;ISO19107_V1_MAGNABOG'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -250,7 +250,7 @@ class TestExport(unittest.TestCase):
         importer.configuration.ilimodels = 'RoadsSimple'
         importer.configuration.dbschema = 'roads_simple_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
@@ -298,7 +298,7 @@ class TestExport(unittest.TestCase):
         importer.configuration.ilimodels = 'RoadsSimple'
         importer.configuration.dbschema = 'roads_simple_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -342,7 +342,7 @@ class TestExport(unittest.TestCase):
         importer.configuration.ilimodels = 'Catastro_COL_ES_V2_1_6;CIAF_LADM;ISO19107_V1_MAGNABOG'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -386,7 +386,7 @@ class TestExport(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)

--- a/QgisModelBaker/tests/test_gpkg_pk.py
+++ b/QgisModelBaker/tests/test_gpkg_pk.py
@@ -53,7 +53,7 @@ class TestGpkgPrimaryKey(unittest.TestCase):
             importer.tool, 'ilimodels')
         importer.configuration.ilimodels = 'ExceptionalLoadsRoute_LV95_V1'
         importer.configuration.dbfile = gpkg_path
-        importer.configuration.epsg = 2056
+        importer.configuration.srs_code = 2056
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         self.assertEqual(importer.run(), iliimporter.Importer.SUCCESS)

--- a/QgisModelBaker/tests/test_import.py
+++ b/QgisModelBaker/tests/test_import.py
@@ -52,7 +52,7 @@ class TestImport(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -123,7 +123,7 @@ class TestImport(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_gpkg.gpkg')
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -188,7 +188,7 @@ class TestImport(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)

--- a/QgisModelBaker/tests/test_projectgen.py
+++ b/QgisModelBaker/tests/test_projectgen.py
@@ -378,7 +378,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -419,7 +419,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_gpkg.gpkg')
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -462,7 +462,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -510,7 +510,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -536,7 +536,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_extent_gpkg.gpkg')
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -569,7 +569,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -639,7 +639,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.ilimodels = 'CoordSys'
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_gpkg.gpkg')
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -720,7 +720,7 @@ class TestProjectGen(unittest.TestCase):
 
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_gpkg.gpkg')
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -896,7 +896,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration = iliimporter_config(importer.tool, 'ilimodels')
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.tomlfile = testdata_path('toml/hidden_fields.toml')
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
@@ -941,7 +941,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.ilimodels = 'CIAF_LADM'
         importer.configuration.tomlfile = testdata_path('toml/hidden_fields.toml')
         importer.configuration.inheritance = 'smart2'
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.dbschema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
         importer.stdout.connect(self.print_info)
@@ -993,7 +993,7 @@ class TestProjectGen(unittest.TestCase):
 
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_gpkg.gpkg')
-        importer.configuration.epsg = 3116
+        importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -1041,7 +1041,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.ilimodels = 'CardinalityBag'
         importer.configuration.dbschema = 'any_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 2056
+        importer.configuration.srs_code = 2056
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -1106,7 +1106,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, 'tmp_import_bags_of_enum_CardinalityBag_{:%Y%m%d%H%M%S%f}.gpkg'.format(
                 datetime.datetime.now()))
-        importer.configuration.epsg = 2056
+        importer.configuration.srs_code = 2056
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -1170,7 +1170,7 @@ class TestProjectGen(unittest.TestCase):
 
         importer.configuration.dbschema = 'nue_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
-        importer.configuration.epsg = 21781
+        importer.configuration.srs_code = 21781
         importer.configuration.inheritance = 'smart2'
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)

--- a/QgisModelBaker/tests/test_z_geom.py
+++ b/QgisModelBaker/tests/test_z_geom.py
@@ -39,7 +39,7 @@ class TestGeomZ(unittest.TestCase):
             importer.tool, 'ilimodels')
         importer.configuration.ilimodels = 'ExceptionalLoadsRoute_LV95_V1'
         importer.configuration.dbschema = 'exceptional_loads_route'
-        importer.configuration.epsg = 2056
+        importer.configuration.srs_code = 2056
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         self.assertEqual(importer.run(), iliimporter.Importer.SUCCESS)


### PR DESCRIPTION
and pass --defaultSrsAuth parameter to ili2db. 

Handles ili2db non-valid SRSs like USER:1234 (only valid for a single machine running QGIS) or srs codes that are not integers.
