### PR TITLE
Update ili2db tool versions to v4.4.3

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_factory.py
@@ -53,14 +53,14 @@ class GpkgFactory(DbFactory):
         if db_ili_version == 3:
             return '3.11.3'
         else:
-            return '4.4.2'
+            return '4.4.3'
 
     def get_tool_url(self, db_ili_version):
         """Returns download url of ili2gpkg.
 
         :return str A download url.
         """
-        return 'http://www.eisenhutinformatik.ch/interlis/ili2gpkg/ili2gpkg-{version}.zip'.format(version=self.get_tool_version(db_ili_version))
+        return 'https://downloads.interlis.ch/ili2gpkg/ili2gpkg-{version}.zip'.format(version=self.get_tool_version(db_ili_version))
 
     def get_specific_messages(self):
         messages = {

--- a/QgisModelBaker/libqgsprojectgen/db_factory/mssql_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/mssql_factory.py
@@ -51,14 +51,14 @@ class MssqlFactory(DbFactory):
         if db_ili_version == 3:
             return '3.12.2'
         else:
-            return '4.4.1'
+            return '4.4.3'
 
     def get_tool_url(self, db_ili_version):
         """Returns download url of ili2gpkg.
 
         :return str A download url.
         """
-        return 'http://jars.interlis.ch/ch/interlis/ili2mssql/{version}/ili2mssql-{version}-bindist.zip'.format(version=self.get_tool_version(db_ili_version))
+        return 'https://downloads.interlis.ch/ili2mssql/ili2mssql-{version}.zip'.format(version=self.get_tool_version(db_ili_version))
 
     def customize_widget_editor(self, field: Field, data_type: str):
         if 'bit' in data_type:

--- a/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
@@ -86,11 +86,11 @@ class PgFactory(DbFactory):
         if db_ili_version == 3:
             return '3.11.2'
         else:
-            return '4.4.2'
+            return '4.4.3'
 
     def get_tool_url(self, db_ili_version):
         """Returns download url of ili2pg.
 
         :return str A download url.
         """
-        return 'http://www.eisenhutinformatik.ch/interlis/ili2pg/ili2pg-{version}.zip'.format(version=self.get_tool_version(db_ili_version))
+        return 'https://downloads.interlis.ch/ili2pg/ili2pg-{version}.zip'.format(version=self.get_tool_version(db_ili_version))

--- a/QgisModelBaker/tests/test_import.py
+++ b/QgisModelBaker/tests/test_import.py
@@ -85,7 +85,7 @@ class TestImport(unittest.TestCase):
             """.format(importer.configuration.dbschema))
         record = next(cursor)
         self.assertIsNotNone(record)
-        self.assertEqual(record[0], 38)  # t_id for 'Unidad_Derecho'
+        self.assertEqual(record[0], 6)  # t_id for 'Unidad_Derecho'
         self.assertEqual(record[1], 'POLYGON((1000257.426 1002020.376,1000437.688 1002196.495,1000275.472 1002428.19,1000072.25 1002291.539,1000158.572 1002164.914,1000159.942 1002163.128,1000257.426 1002020.376))')
         self.assertEqual(record[2], 3116)
         predio_id = record[3]
@@ -110,7 +110,7 @@ class TestImport(unittest.TestCase):
             """.format(importer.configuration.dbschema))
         record = next(cursor)
         self.assertIsNotNone(record)
-        self.assertEqual(record[0], 5)  # t_id for 'Posesion'
+        self.assertEqual(record[0], 20)  # t_id for 'Posesion'
         self.assertEqual(record[1], persona_id)  # FK persona
         self.assertEqual(record[2], predio_id)  # FK predio
 

--- a/QgisModelBaker/tests/testdata/ilimodels/CHBase_Part4_ADMINISTRATIVEUNITS_20110830.ili
+++ b/QgisModelBaker/tests/testdata/ilimodels/CHBase_Part4_ADMINISTRATIVEUNITS_20110830.ili
@@ -2,7 +2,7 @@
    CHBASE - BASE MODULES OF THE SWISS FEDERATION FOR MINIMAL GEODATA MODELS
    ======
    BASISMODULE DES BUNDES           MODULES DE BASE DE LA CONFEDERATION
-   FÜR MINIMALE GEODATENMODELLE     POUR LES MODELES DE GEODONNEES MINIMAUX
+   FÃœR MINIMALE GEODATENMODELLE     POUR LES MODELES DE GEODONNEES MINIMAUX
    
    PROVIDER: GKG/KOGIS - GCS/COSIG             CONTACT: models@geo.admin.ch
    PUBLISHED: 2011-08-30
@@ -19,15 +19,20 @@ INTERLIS 2.3;
    - Package AdministrativeUnitsCH
 */
 
+!! Version    | Who   | Modification
+!!------------------------------------------------------------------------------
+!! 2018-02-19 | KOGIS | Enumeration CHCantonCode adapted (FL and CH added)
+!! 2020-04-24 | KOGIS | Constraint in Association Hierarchy in Model AdministrativeUnitsCH_V1 corrected (#CHE)
+
 !! ########################################################################
 !!@technicalContact=models@geo.admin.ch
-!!@furtherInformation=http://www.geo.admin.ch/internet/geoportal/de/home/topics/geobasedata/models.html
+!!@furtherInformation=https://www.geo.admin.ch/de/geoinformation-schweiz/geobasisdaten/geodata-models.html
 TYPE MODEL CHAdminCodes_V1 (en)
-  AT "http://www.geo.admin.ch" VERSION "2011-08-30" =
+  AT "http://www.geo.admin.ch" VERSION "2018-02-19" =
 
   DOMAIN
     CHCantonCode = (ZH,BE,LU,UR,SZ,OW,NW,GL,ZG,FR,SO,BS,BL,SH,AR,AI,SG,
-                    GR,AG,TG,TI,VD,VS,NE,GE,JU);
+                    GR,AG,TG,TI,VD,VS,NE,GE,JU,FL,CH);
 
     CHMunicipalityCode = 1..9999;  !! BFS-Nr
 
@@ -114,10 +119,10 @@ MODEL AdministrativeUnits_V1 (en)
 END AdministrativeUnits_V1.
 
 !! ########################################################################
-!!@technicalContact=models@geo.admin.ch
-!!@furtherInformation=http://www.geo.admin.ch/internet/geoportal/de/home/topics/geobasedata/models.html
+!!@technicalContact=mailto:models@geo.admin.ch
+!!@furtherInformation=https://www.geo.admin.ch/de/geoinformation-schweiz/geobasisdaten/geodata-models.html
 MODEL AdministrativeUnitsCH_V1 (en)
-  AT "http://www.geo.admin.ch" VERSION "2011-08-30" =
+  AT "http://www.geo.admin.ch" VERSION "2020-04-24" =
 
   IMPORTS UNQUALIFIED INTERLIS;
   IMPORTS UNQUALIFIED CHAdminCodes_V1;
@@ -139,7 +144,7 @@ MODEL AdministrativeUnitsCH_V1 (en)
       UpperLevelUnit (EXTENDED, EXTERNAL) -<> {1..1} AdministrativeUnits_V1.Countries.Country;
       LowerLevelUnit (EXTENDED) -- CHCanton;
     MANDATORY CONSTRAINT
-      UpperLevelUnit->Code == "CHE";
+      UpperLevelUnit->Code == #CHE;
     END Hierarchy;
 
   END CHCantons;


### PR DESCRIPTION
Notes: 
 + The URL to download ili2db tools has changed to a more standard URL that is going to be maintained.
 + t_ids in a test have been adjusted. I guess that sometimes new ili2db versions impose those adjustments, since it's not the first time it happens in some tests.

--------------

:warning:  8 tests fail due to stronger constraint data type checks in ili2c (see https://github.com/claeis/ili2c/issues/17). 

All 8 tests fail when using the model `ExceptionalLoadsRoute_LV95_V1`, throwing the following error: 

> ERROR    root:test_gpkg_pk.py:95 Error: /usr/src/QgisModelBaker/tests/testdata/ilimodels/CHBase_Part4_ADMINISTRATIVEUNITS_20110830.ili:142:incompatible datatypes

It's a Swiss model, so I wouldn't like to adjust the .ili file before bringing this topic here for some discussion.

