### PR TITLE
Add support for authentication configuration

### DIFF
--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -178,7 +178,7 @@ class ExportDialog(QDialog, DIALOG_UI):
         self.export_models_view.setModel(self.export_models_model)
         self.export_models_view.clicked.connect(self.export_models_model.check)
         self.export_models_view.space_pressed.connect(self.export_models_model.check)
-        self.refresh_models()
+        self.request_for_refresh_models()
 
         self.type_combo_box.currentIndexChanged.connect(self.type_changed)
 

--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -115,7 +115,7 @@ class ExportDialog(QDialog, DIALOG_UI):
         QDialog.__init__(self, parent)
         self.setupUi(self)
         self.db_simple_factory = DbSimpleFactory()
-        QgsGui.instance().enableAutoGeometryRestore(self);
+        QgsGui.instance().enableAutoGeometryRestore(self)
         self.buttonBox.accepted.disconnect()
         self.buttonBox.clicked.connect(self.button_box_clicked)
         self.buttonBox.clear()

--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -203,7 +203,7 @@ class ExportDialog(QDialog, DIALOG_UI):
 
         db_factory = self.db_simple_factory.create_factory(tool)
         config_manager = db_factory.get_db_command_config_manager(configuration)
-        uri_string = config_manager.get_uri()
+        uri_string = config_manager.get_uri(configuration.db_use_super_login)
 
         db_connector = None
 
@@ -224,7 +224,7 @@ class ExportDialog(QDialog, DIALOG_UI):
 
         db_factory = self.db_simple_factory.create_factory(configuration.tool)
         config_manager = db_factory.get_db_command_config_manager(configuration)
-        uri_string = config_manager.get_uri()
+        uri_string = config_manager.get_uri(configuration.db_use_super_login)
 
         db_connector = None
 

--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -232,8 +232,9 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             try:
                 config_manager = db_factory.get_db_command_config_manager(configuration)
                 uri = config_manager.get_uri()
+                mgmt_uri = config_manager.get_uri(configuration.db_use_super_login)
                 generator = Generator(configuration.tool, uri,
-                                      configuration.inheritance, configuration.dbschema)
+                                      configuration.inheritance, configuration.dbschema, mgmt_uri=mgmt_uri)
                 generator.stdout.connect(self.print_info)
                 generator.new_message.connect(self.show_message)
                 self.progress_bar.setValue(50)
@@ -348,9 +349,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
 
         db_factory = self.db_simple_factory.create_factory(configuration.tool)
         config_manager = db_factory.get_db_command_config_manager(configuration)
-        uri_string = config_manager.get_uri()
-
-        db_connector = None
+        uri_string = config_manager.get_uri(configuration.db_use_super_login)
 
         try:
             db_connector = db_factory.get_db_connector(uri_string, schema)

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -318,7 +318,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
 
         db_factory = self.db_simple_factory.create_factory(configuration.tool)
         config_manager = db_factory.get_db_command_config_manager(configuration)
-        uri_string = config_manager.get_uri()
+        uri_string = config_manager.get_uri(configuration.db_use_super_login)
 
         db_connector = None
 

--- a/QgisModelBaker/gui/panel/pg_config_panel.py
+++ b/QgisModelBaker/gui/panel/pg_config_panel.py
@@ -59,7 +59,6 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
 
         self.pg_host_line_edit.setValidator(nonEmptyValidator)
         self.pg_database_line_edit.setValidator(nonEmptyValidator)
-        self.pg_user_line_edit.setValidator(nonEmptyValidator)
 
         self.pg_host_line_edit.textChanged.connect(
             self.validators.validate_line_edits)
@@ -68,16 +67,11 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
             self.validators.validate_line_edits)
         self.pg_database_line_edit.textChanged.emit(
             self.pg_database_line_edit.text())
-        self.pg_user_line_edit.textChanged.connect(
-            self.validators.validate_line_edits)
-        self.pg_user_line_edit.textChanged.emit(self.pg_user_line_edit.text())
 
         self.pg_host_line_edit.textChanged.connect(self.notify_fields_modified)
         self.pg_port_line_edit.textChanged.connect(self.notify_fields_modified)
         self.pg_database_line_edit.textChanged.connect(self.notify_fields_modified)
         self.pg_schema_line_edit.textChanged.connect(self.notify_fields_modified)
-        self.pg_user_line_edit.textChanged.connect(self.notify_fields_modified)
-        self.pg_password_line_edit.textChanged.connect(self.notify_fields_modified)
 
     def _show_panel(self):
         if self.interlis_mode:
@@ -94,10 +88,11 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
     def get_fields(self, configuration):
         configuration.dbhost = self.pg_host_line_edit.text().strip()
         configuration.dbport = self.pg_port_line_edit.text().strip()
-        configuration.dbusr = self.pg_user_line_edit.text().strip()
+        configuration.dbusr = self.pg_auth_settings.username()
         configuration.database = self.pg_database_line_edit.text().strip()
         configuration.dbschema = self.pg_schema_line_edit.text().strip().lower()
-        configuration.dbpwd = self.pg_password_line_edit.text()
+        configuration.dbpwd = self.pg_auth_settings.password()
+        configuration.dbauthid = self.pg_auth_settings.configId()
 
         if self._db_action_type != DbActionType.EXPORT:
             configuration.db_use_super_login = self.pg_use_super_login.isChecked()
@@ -105,10 +100,11 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
     def set_fields(self, configuration):
         self.pg_host_line_edit.setText(configuration.dbhost)
         self.pg_port_line_edit.setText(configuration.dbport)
-        self.pg_user_line_edit.setText(configuration.dbusr)
+        self.pg_auth_settings.setUsername(configuration.dbusr)
         self.pg_database_line_edit.setText(configuration.database)
         self.pg_schema_line_edit.setText(configuration.dbschema)
-        self.pg_password_line_edit.setText(configuration.dbpwd)
+        self.pg_auth_settings.setPassword(configuration.dbpwd)
+        self.pg_auth_settings.setConfigId(configuration.dbauthid)
 
         if self._db_action_type != DbActionType.EXPORT:
             self.pg_use_super_login.setChecked(configuration.db_use_super_login)
@@ -119,12 +115,13 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
         if not self.pg_host_line_edit.text().strip():
             message = self.tr("Please set a host before creating the project.")
             self.pg_host_line_edit.setFocus()
-        elif not "{}".format(self.pg_database_line_edit.text().strip()):
+        elif not self.pg_database_line_edit.text().strip():
             message = self.tr("Please set a database before creating the project.")
             self.pg_database_line_edit.setFocus()
-        elif not self.pg_user_line_edit.text().strip():
-            message = self.tr("Please set a database user before creating the project.")
-            self.pg_user_line_edit.setFocus()
+        elif not self.pg_auth_settings.username() and not self.pg_auth_settings.configId():
+            message = self.tr("Please set a username or select an authentication configuration before creating the "
+                              "project.")
+            self.pg_auth_settings.setFocus()
         else:
             result = True
 

--- a/QgisModelBaker/gui/panel/pg_config_panel.py
+++ b/QgisModelBaker/gui/panel/pg_config_panel.py
@@ -43,7 +43,8 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
 
         from QgisModelBaker.libili2db.ili2dbconfig import BaseConfiguration
         self.pg_use_super_login.setText(
-            self.tr("Generate schema with superuser login from settings ({})").format(BaseConfiguration().super_pg_user))
+            self.tr("Execute data management tasks with superuser login from settings ({})").format(BaseConfiguration().super_pg_user))
+        self.pg_use_super_login.setToolTip(self.tr("Data management tasks are <ul><li>Create the schema</li><li>Read meta information</li><li>Import data from XTF</li><li>Export data to XTF</li></ul>"))
 
         if self._db_action_type == DbActionType.GENERATE:
             self.pg_schema_line_edit.setPlaceholderText(self.tr("[Leave empty to create a default schema]"))
@@ -51,7 +52,6 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
             self.pg_schema_line_edit.setPlaceholderText(self.tr("[Leave empty to import data into a default schema]"))
         elif self._db_action_type == DbActionType.EXPORT:
             self.pg_schema_line_edit.setPlaceholderText(self.tr("[Leave empty to load all schemas in the database]"))
-            self.pg_use_super_login.hide()
 
         # define validators
         self.validators = Validators()
@@ -94,8 +94,7 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
         configuration.dbpwd = self.pg_auth_settings.password()
         configuration.dbauthid = self.pg_auth_settings.configId()
 
-        if self._db_action_type != DbActionType.EXPORT:
-            configuration.db_use_super_login = self.pg_use_super_login.isChecked()
+        configuration.db_use_super_login = self.pg_use_super_login.isChecked()
 
     def set_fields(self, configuration):
         self.pg_host_line_edit.setText(configuration.dbhost)
@@ -106,8 +105,7 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
         self.pg_auth_settings.setPassword(configuration.dbpwd)
         self.pg_auth_settings.setConfigId(configuration.dbauthid)
 
-        if self._db_action_type != DbActionType.EXPORT:
-            self.pg_use_super_login.setChecked(configuration.db_use_super_login)
+        self.pg_use_super_login.setChecked(configuration.db_use_super_login)
 
     def is_valid(self):
         result = False

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -102,6 +102,7 @@ class Ili2DbCommandConfiguration(object):
         self.dbhost = ''
         self.dbpwd = ''
         self.dbusr = ''
+        self.dbauthid = ''
         self.db_use_super_login = False
         self.database = ''
         self.dbschema = ''

--- a/QgisModelBaker/libqgsprojectgen/db_factory/db_command_config_manager.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/db_command_config_manager.py
@@ -47,10 +47,11 @@ class DbCommandConfigManager(ABC):
         pass
 
     @abstractmethod
-    def get_db_args(self, hide_password=False):
+    def get_db_args(self, hide_password=False, su=False):
         """Gets a list of ili2db arguments related to database.
 
         :param bool hide_password: *True* to mask the password, *False* otherwise.
+        :param bool su: *True* to use super user password, *False* otherwise. Default is False.
         :return: ili2db arguments list.
         :rtype: list
         """
@@ -71,7 +72,7 @@ class DbCommandConfigManager(ABC):
         :return: ili2db arguments list.
         :rtype: list
         """
-        db_args = self.get_db_args(hide_password)
+        db_args = self.get_db_args(hide_password, self.configuration.db_use_super_login)
 
         if type(self.configuration) is SchemaImportConfiguration:
             db_args += self.get_schema_import_args()

--- a/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_command_config_manager.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/gpkg_command_config_manager.py
@@ -36,7 +36,7 @@ class GpkgCommandConfigManager(DbCommandConfigManager):
     def get_uri(self, su=False):
         return self.configuration.dbfile
 
-    def get_db_args(self, hide_password=False):
+    def get_db_args(self, hide_password=False, su=False):
         return ["--dbfile", self.configuration.dbfile]
 
     def save_config_in_qsettings(self):

--- a/QgisModelBaker/libqgsprojectgen/db_factory/mssql_command_config_manager.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/mssql_command_config_manager.py
@@ -44,7 +44,7 @@ class MssqlCommandConfigManager(DbCommandConfigManager):
 
         return separator.join(uri)
 
-    def get_db_args(self, hide_password=False):
+    def get_db_args(self, hide_password=False, su=False):
         db_args = list()
         db_args += ["--dbhost", self.configuration.dbhost]
         if self.configuration.dbport:

--- a/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/pg_factory.py
@@ -67,7 +67,7 @@ class PgFactory(DbFactory):
         message = ''
 
         config_manager = self.get_db_command_config_manager(configuration)
-        uri = config_manager.get_uri()
+        uri = config_manager.get_uri(configuration.db_use_super_login)
 
         connector = self.get_db_connector(uri, configuration.dbschema)
 

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -81,9 +81,13 @@ class PGConnector(DBConnector):
 
     def create_db_or_schema(self, usr):
         cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        if usr:
+            authorization_string = ' AUTHORIZATION {}'.format(usr)
+        else:
+            authorization_string = ''
         cur.execute("""
-                    CREATE SCHEMA {} AUTHORIZATION {};
-        """.format(self.schema, usr))
+                    CREATE SCHEMA {schema}{authorization};
+        """.format(schema=self.schema, authorization=authorization_string))
         self.conn.commit()
 
     def metadata_exists(self):

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -44,7 +44,8 @@ class Generator(QObject):
     def __init__(self, tool, uri, inheritance, schema=None, pg_estimated_metadata=False, parent=None, mgmt_uri=None):
         """
         Creates a new Generator objects.
-        :param mgmt_uri:
+        :param uri: The uri that should be used in the resulting project. If authcfg is used, make sure the mgmt_uri is set as well.
+        :param mgmt_uri: The uri that should be used to create schemas, tables and query meta information. Does not support authcfg.
         """
         QObject.__init__(self, parent)
         self.tool = tool
@@ -56,7 +57,7 @@ class Generator(QObject):
 
         self.db_simple_factory = DbSimpleFactory()
         db_factory = self.db_simple_factory.create_factory(self.tool)
-        self._db_connector = db_factory.get_db_connector(mgmt_uri, schema)
+        self._db_connector = db_factory.get_db_connector(mgmt_uri or uri, schema)
         self._db_connector.stdout.connect(self.print_info)
         self._db_connector.new_message.connect(self.append_print_message)
 

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -34,23 +34,29 @@ from .config import IGNORED_SCHEMAS, IGNORED_TABLES, IGNORED_FIELDNAMES, READONL
 from ..db_factory.db_simple_factory import DbSimpleFactory
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 
+
 class Generator(QObject):
     """Builds Model Baker objects from data extracted from databases."""
 
     stdout = pyqtSignal(str)
     new_message = pyqtSignal(int, str)
 
-    def __init__(self, tool, uri, inheritance, schema=None, pg_estimated_metadata=False, parent=None):
+    def __init__(self, tool, uri, inheritance, schema=None, pg_estimated_metadata=False, parent=None, mgmt_uri=None):
+        """
+        Creates a new Generator objects.
+        :param mgmt_uri:
+        """
         QObject.__init__(self, parent)
         self.tool = tool
         self.uri = uri
+        self.mgmt_uri = mgmt_uri
         self.inheritance = inheritance
         self.schema = schema or None
         self.pg_estimated_metadata = pg_estimated_metadata
 
         self.db_simple_factory = DbSimpleFactory()
         db_factory = self.db_simple_factory.create_factory(self.tool)
-        self._db_connector = db_factory.get_db_connector(uri, schema)
+        self._db_connector = db_factory.get_db_connector(mgmt_uri, schema)
         self._db_connector.stdout.connect(self.print_info)
         self._db_connector.new_message.connect(self.append_print_message)
 

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -74,7 +74,7 @@ class Generator(QObject):
         message = {'level': level, 'text': text}
 
         if message not in self.collected_print_messages:
-          self.collected_print_messages.append(message)
+            self.collected_print_messages.append(message)
 
     def layers(self, filter_layer_list=[]):
         tables_info = self.get_tables_info()
@@ -261,7 +261,7 @@ class Generator(QObject):
                                          layer_map[record['target_layer_name']][0],
                                          self._db_connector.tid,
                                          self._db_connector.dispName]
-                        unique_current_layer_name = '{}_{}'.format(record['current_layer_name'],layer.geometry_column)
+                        unique_current_layer_name = '{}_{}'.format(record['current_layer_name'], layer.geometry_column)
                         if unique_current_layer_name in bags_of_enum.keys():
                             bags_of_enum[unique_current_layer_name][record['attribute']] = new_item_list
                         else:

--- a/QgisModelBaker/ui/export.ui
+++ b/QgisModelBaker/ui/export.ui
@@ -151,7 +151,7 @@
            </widget>
           </item>
           <item row="1" column="2">
-           <widget class="ModelListView" name="export_models_view"/>
+           <widget class="ModelListView" name="export_models_view" native="true"/>
           </item>
          </layout>
         </widget>

--- a/QgisModelBaker/ui/export.ui
+++ b/QgisModelBaker/ui/export.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Export Interlis</string>
+   <string>Export Interlis Data</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">

--- a/QgisModelBaker/ui/pg_settings_panel.ui
+++ b/QgisModelBaker/ui/pg_settings_panel.ui
@@ -14,6 +14,23 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="5" column="0" colspan="2">
+    <widget class="QCheckBox" name="pg_use_super_login">
+     <property name="text">
+      <string>Use logins from settings (superuser) for schema generation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QgsAuthSettingsWidget" name="pg_auth_settings" native="true"/>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="pg_schema_line_edit">
+     <property name="placeholderText">
+      <string/>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_9">
      <property name="text">
@@ -31,27 +48,6 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>Port</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="pg_port_line_edit">
-     <property name="placeholderText">
-      <string>[Leave empty to use standard port 5432]</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Database</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="1">
     <widget class="QLineEdit" name="pg_database_line_edit">
      <property name="placeholderText">
@@ -66,53 +62,37 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="pg_schema_line_edit">
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="pg_port_line_edit">
      <property name="placeholderText">
-      <string/>
+      <string>[Leave empty to use standard port 5432]</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_4">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_8">
      <property name="text">
-      <string>User</string>
+      <string>Port</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QLineEdit" name="pg_user_line_edit">
-     <property name="placeholderText">
-      <string>Database Username</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_5">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_6">
      <property name="text">
-      <string>Password</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QLineEdit" name="pg_password_line_edit">
-     <property name="echoMode">
-      <enum>QLineEdit::Password</enum>
-     </property>
-     <property name="placeholderText">
-      <string>[Leave empty to use system password]</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QCheckBox" name="pg_use_super_login">
-     <property name="text">
-      <string>Use logins from settings (superuser) for schema generation</string>
+      <string>Database</string>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsAuthSettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This pull requests adds compatibility for the auth management framework in QGIS. It will only store an authid in the QGIS project. The same authid will need to be configured on every QGIS profile that the project is opened.

![Peek 2020-06-06 15-25](https://user-images.githubusercontent.com/588407/83945278-f82b9800-a809-11ea-82b9-7d200b504220.gif)

Fixes #391

TODO:

 - [ ] Auth config **requires** a super user password to be configured in settings. Make this clear and straightforward to configure.
 - [ ] Unit tests (if possible?)
 - [ ] Check the UX with geopackage
 - [ ] Validate import