### PR TITLE
Show single column form for few attributes

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
@@ -126,7 +126,12 @@ class Layer(object):
                 break
 
         if has_tabs:
-            tab = FormTab(QCoreApplication.translate('FormTab', 'General'), 2)
+            num_fields = len([f for f in self.fields if not f.hidden])
+            if num_fields > 5:
+                num_tabs = 2
+            else:
+                num_tabs = 1
+            tab = FormTab(QCoreApplication.translate('FormTab', 'General'), num_tabs)
             for field in self.fields:
                 if not field.hidden:
                     widget = FormFieldWidget(field.alias, field.name)


### PR DESCRIPTION
If a layer has <6 visible attributes the form will be shown in single column mode.
With more in 2 column mode.

Fixes #196