### PR TITLE
Import data: Delete checkbox optimization

### DIFF
--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -372,12 +372,11 @@ class ImportDataDialog(QDialog, DIALOG_UI):
 
     def restore_configuration(self):
         settings = QSettings()
-
         self.fill_toml_file_info_label()
         self.xtf_file_line_edit.setText(settings.value(
             'QgisModelBaker/ili2pg/xtffile_import'))
-        self.chk_delete_data.setChecked(settings.value(
-            'QgisModelBaker/ili2pg/deleteData', False, bool))
+        # set chk_delete_data always to unchecked
+        self.chk_delete_data.setChecked(False)
 
         for db_id in self.db_simple_factory.get_db_list(False):
             configuration = iliimporter.ImportDataConfiguration()

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -375,7 +375,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         self.fill_toml_file_info_label()
         self.xtf_file_line_edit.setText(settings.value(
             'QgisModelBaker/ili2pg/xtffile_import'))
-        # set chk_delete_data always to unchecked
+        # set chk_delete_data always to unchecked because otherwise the user could delete the data accidentally
         self.chk_delete_data.setChecked(False)
 
         for db_id in self.db_simple_factory.get_db_list(False):

--- a/QgisModelBaker/ui/import_data.ui
+++ b/QgisModelBaker/ui/import_data.ui
@@ -129,6 +129,9 @@
             <property name="text">
              <string>Delete existing data in affected tables</string>
             </property>
+            <property name="toolTip">
+             <string>Delete existing data including dependencies like catalogues etc.</string>
+            </property>
            </widget>
           </item>
           <item row="2" column="2">


### PR DESCRIPTION
It's about this:
![image](https://user-images.githubusercontent.com/28384354/85832658-ca929880-b790-11ea-8355-95d5357b9ee7.png)

- having the checkbox unchecked on open of the dialog to avoid unintended overwriting and mostly you don't need it on second import.

- tooltip to get informed that catalogues are deleted as well

fixes #361