### PR TITLE
use `--models` instead of `--exportModels` to list the selected model…

### DIFF
--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -250,7 +250,7 @@ class ExportDialog(QDialog, DIALOG_UI):
                 self.tr('Please set a valid INTERLIS XTF file before exporting data.'))
             self.xtf_file_line_edit.setFocus()
             return
-        if not configuration.iliexportmodels:
+        if not configuration.ilimodels:
             self.txtStdout.setText(
                 self.tr('Please set a model before exporting data.'))
             self.export_models_view.setFocus()
@@ -400,8 +400,7 @@ class ExportDialog(QDialog, DIALOG_UI):
 
         configuration.tool = mode
         configuration.xtffile = self.xtf_file_line_edit.text().strip()
-        configuration.iliexportmodels = ';'.join(self.export_models_model.checked_models())
-        configuration.ilimodels = ';'.join(self.export_models_model.stringList())
+        configuration.ilimodels = ';'.join(self.export_models_model.checked_models())
         configuration.base_configuration = self.base_configuration
         configuration.db_ili_version = self.db_ili_version(configuration)
 

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -141,6 +141,7 @@ class ExportConfiguration(Ili2DbCommandConfiguration):
         self.xtffile = ''
         self.disable_validation = False
         self.with_exporttid = False
+        self.iliexportmodels = ''
         self.db_ili_version = None
 
     def to_ili2db_args(self, extra_args=[], with_action=True):
@@ -156,6 +157,9 @@ class ExportConfiguration(Ili2DbCommandConfiguration):
 
         if self.with_exporttid:
             args += ["--exportTid"]
+
+        if self.iliexportmodels:
+            args += ["--exportModels", self.iliexportmodels]
 
         if self.db_ili_version == 3:
             args += ["--export3"]

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -139,7 +139,6 @@ class ExportConfiguration(Ili2DbCommandConfiguration):
     def __init__(self):
         super().__init__()
         self.xtffile = ''
-        self.iliexportmodels = ''
         self.disable_validation = False
         self.with_exporttid = False
         self.db_ili_version = None
@@ -157,9 +156,6 @@ class ExportConfiguration(Ili2DbCommandConfiguration):
 
         if self.with_exporttid:
             args += ["--exportTid"]
-
-        if self.iliexportmodels:
-            args += ["--exportModels", self.iliexportmodels]
 
         if self.db_ili_version == 3:
             args += ["--export3"]


### PR DESCRIPTION
To export a model we need the `--export` and the `--models` like described in the [documentation](https://github.com/claeis/ili2db/blob/master/docs/ili2db.rst):
> `--export`
> Exportiert Daten aus der Datenbank in eine Transferdatei.
> Mit dem Parameter --models, --topics, --baskets oder --dataset wird definiert, welche Daten exportiert werden.

fixes #342

### Additional info about `--exportModels`
The discussion is in the issue. The `--exportModels` should be used when we want to export the date not in the format of the Model (e.g. a cantonal model like `Nutzungsplanung_SH_LV95_V4_0`) but in the format of the model it bases on (e.g. a national model like `Nutzungsplanung_LV95_V1_1`). This is described in the documentation:

> `--exportModels`
> Beim Export/Prüfen werden die Daten gem. dem gegebenen Export-Modell exportiert/geprüft. Ohne die Option --exportModels werden die Daten so wie sie erfasst sind (bzw. importiert wurden), exportiert/validiert.
> `--exportModels` : Als Export-Modelle sind Basis-Modelle (also z.B. Bundes-Modell statt Kantons-Modell) oder übersetzte Modelle (also z.B. DM_IT statt DM_DE) zulässig).

This means this is a special functionality, that is not yet implemented. To implement it we need to integrate a possibility to recognize and list the base model.

