### PR TITLE
Keep QGIS enabled on generate, import and export dialog open

### DIFF
--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -44,6 +44,11 @@ class QgisModelBakerPlugin(QObject):
         QObject.__init__(self)
         self.iface = iface
         self.plugin_dir = os.path.dirname(__file__)
+
+        self.generate_dlg = None
+        self.export_dlg = None
+        self.importdata_dlg = None
+
         self.__generate_action = None
         self.__export_action = None
         self.__importdata_action = None
@@ -51,6 +56,7 @@ class QgisModelBakerPlugin(QObject):
         self.__help_action = None
         self.__about_action = None
         self.__separator = None
+
         if locale.getlocale() == (None, None):
             locale.setlocale(locale.LC_ALL, '')
 
@@ -139,8 +145,37 @@ class QgisModelBakerPlugin(QObject):
         del self.__about_action
 
     def show_generate_dialog(self):
-        dlg = GenerateProjectDialog(self.iface, self.ili2db_configuration)
-        dlg.exec_()
+        self.generate_dlg = GenerateProjectDialog(self.iface, self.ili2db_configuration)
+        self.generate_dlg.setAttribute(Qt.WA_DeleteOnClose)
+        self.generate_dlg.setWindowFlags(self.generate_dlg.windowFlags() | Qt.Tool)
+        self.generate_dlg.show()
+        self.generate_dlg.finished.connect(self.generate_dialog_finished)
+        self.__generate_action.setEnabled(False)
+
+    def generate_dialog_finished(self):
+        self.__generate_action.setEnabled(True)
+
+    def show_export_dialog(self):
+        self.export_dlg = ExportDialog(self.ili2db_configuration)
+        self.export_dlg.setAttribute(Qt.WA_DeleteOnClose)
+        self.export_dlg.setWindowFlags(self.export_dlg.windowFlags() | Qt.Tool)
+        self.export_dlg.show()
+        self.export_dlg.finished.connect(self.export_dialog_finished)
+        self.__export_action.setEnabled(False)
+
+    def export_dialog_finished(self):
+        self.__export_action.setEnabled(True)
+
+    def show_importdata_dialog(self):
+        self.importdata_dlg = ImportDataDialog(self.iface, self.ili2db_configuration)
+        self.importdata_dlg.setAttribute(Qt.WA_DeleteOnClose)
+        self.importdata_dlg.setWindowFlags(self.importdata_dlg.windowFlags() | Qt.Tool)
+        self.importdata_dlg.show()
+        self.importdata_dlg.finished.connect(self.importdata_dialog_finished)
+        self.__importdata_action.setChecked(False)
+
+    def importdata_dialog_finished(self):
+        self.__importdata_action.setChecked(True)
 
     def show_options_dialog(self):
         dlg = OptionsDialog(self.ili2db_configuration)
@@ -148,14 +183,6 @@ class QgisModelBakerPlugin(QObject):
             settings = QSettings()
             settings.beginGroup('QgisModelBaker/ili2db')
             self.ili2db_configuration.save(settings)
-
-    def show_export_dialog(self):
-        dlg = ExportDialog(self.ili2db_configuration)
-        dlg.exec_()
-
-    def show_importdata_dialog(self):
-        dlg = ImportDataDialog(self.iface, self.ili2db_configuration)
-        dlg.exec_()
 
     def show_help_documentation(self):
         os_language = QLocale(QSettings().value(

--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -154,7 +154,7 @@ class QgisModelBakerPlugin(QObject):
             self.generate_dlg.reject()
         else:
             print('generate dialog')
-            self.generate_dlg = GenerateProjectDialog(self.iface, self.ili2db_configuration)
+            self.generate_dlg = GenerateProjectDialog(self.iface, self.ili2db_configuration, self.iface.mainWindow())
             self.generate_dlg.setAttribute(Qt.WA_DeleteOnClose)
             self.generate_dlg.setWindowFlags(self.generate_dlg.windowFlags() | Qt.Tool)
             print('show dialog')
@@ -170,7 +170,7 @@ class QgisModelBakerPlugin(QObject):
         if self.export_dlg:
             self.export_dlg.reject()
         else:
-            self.export_dlg = ExportDialog(self.ili2db_configuration)
+            self.export_dlg = ExportDialog(self.ili2db_configuration, self.iface.mainWindow())
             self.export_dlg.setAttribute(Qt.WA_DeleteOnClose)
             self.export_dlg.setWindowFlags(self.export_dlg.windowFlags() | Qt.Tool)
             self.export_dlg.show()
@@ -185,7 +185,7 @@ class QgisModelBakerPlugin(QObject):
         if self.importdata_dlg:
             self.importdata_dlg.reject()
         else:
-            self.importdata_dlg = ImportDataDialog(self.iface, self.ili2db_configuration)
+            self.importdata_dlg = ImportDataDialog(self.iface, self.ili2db_configuration, self.iface.mainWindow())
             self.importdata_dlg.setAttribute(Qt.WA_DeleteOnClose)
             self.importdata_dlg.setWindowFlags(self.importdata_dlg.windowFlags() | Qt.Tool)
             self.importdata_dlg.show()

--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -158,11 +158,9 @@ class QgisModelBakerPlugin(QObject):
         if self.generate_dlg:
             self.generate_dlg.reject()
         else:
-            print('generate dialog')
             self.generate_dlg = GenerateProjectDialog(self.iface, self.ili2db_configuration, self.iface.mainWindow())
             self.generate_dlg.setAttribute(Qt.WA_DeleteOnClose)
             self.generate_dlg.setWindowFlags(self.generate_dlg.windowFlags() | Qt.Tool)
-            print('show dialog')
             self.generate_dlg.show()
             self.generate_dlg.finished.connect(self.generate_dialog_finished)
             self.__generate_action.setChecked(True)

--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -95,6 +95,11 @@ class QgisModelBakerPlugin(QObject):
         self.__separator = QAction(None)
         self.__separator.setSeparator(True)
 
+        # set these actions checkable to visualize that the dialog is open
+        self.__generate_action.setCheckable(True)
+        self.__export_action.setCheckable(True)
+        self.__importdata_action.setCheckable(True)
+
         self.__generate_action.triggered.connect(self.show_generate_dialog)
         self.__configure_action.triggered.connect(self.show_options_dialog)
         self.__importdata_action.triggered.connect(self.show_importdata_dialog)
@@ -145,37 +150,51 @@ class QgisModelBakerPlugin(QObject):
         del self.__about_action
 
     def show_generate_dialog(self):
-        self.generate_dlg = GenerateProjectDialog(self.iface, self.ili2db_configuration)
-        self.generate_dlg.setAttribute(Qt.WA_DeleteOnClose)
-        self.generate_dlg.setWindowFlags(self.generate_dlg.windowFlags() | Qt.Tool)
-        self.generate_dlg.show()
-        self.generate_dlg.finished.connect(self.generate_dialog_finished)
-        self.__generate_action.setEnabled(False)
+        if self.generate_dlg:
+            self.generate_dlg.reject()
+        else:
+            print('generate dialog')
+            self.generate_dlg = GenerateProjectDialog(self.iface, self.ili2db_configuration)
+            self.generate_dlg.setAttribute(Qt.WA_DeleteOnClose)
+            self.generate_dlg.setWindowFlags(self.generate_dlg.windowFlags() | Qt.Tool)
+            print('show dialog')
+            self.generate_dlg.show()
+            self.generate_dlg.finished.connect(self.generate_dialog_finished)
+            self.__generate_action.setChecked(True)
 
     def generate_dialog_finished(self):
-        self.__generate_action.setEnabled(True)
+        self.__generate_action.setChecked(False)
+        self.generate_dlg = None
 
     def show_export_dialog(self):
-        self.export_dlg = ExportDialog(self.ili2db_configuration)
-        self.export_dlg.setAttribute(Qt.WA_DeleteOnClose)
-        self.export_dlg.setWindowFlags(self.export_dlg.windowFlags() | Qt.Tool)
-        self.export_dlg.show()
-        self.export_dlg.finished.connect(self.export_dialog_finished)
-        self.__export_action.setEnabled(False)
+        if self.export_dlg:
+            self.export_dlg.reject()
+        else:
+            self.export_dlg = ExportDialog(self.ili2db_configuration)
+            self.export_dlg.setAttribute(Qt.WA_DeleteOnClose)
+            self.export_dlg.setWindowFlags(self.export_dlg.windowFlags() | Qt.Tool)
+            self.export_dlg.show()
+            self.export_dlg.finished.connect(self.export_dialog_finished)
+            self.__export_action.setChecked(True)
 
     def export_dialog_finished(self):
-        self.__export_action.setEnabled(True)
+        self.__export_action.setChecked(False)
+        self.export_dlg = None
 
     def show_importdata_dialog(self):
-        self.importdata_dlg = ImportDataDialog(self.iface, self.ili2db_configuration)
-        self.importdata_dlg.setAttribute(Qt.WA_DeleteOnClose)
-        self.importdata_dlg.setWindowFlags(self.importdata_dlg.windowFlags() | Qt.Tool)
-        self.importdata_dlg.show()
-        self.importdata_dlg.finished.connect(self.importdata_dialog_finished)
-        self.__importdata_action.setEnabled(False)
+        if self.importdata_dlg:
+            self.importdata_dlg.reject()
+        else:
+            self.importdata_dlg = ImportDataDialog(self.iface, self.ili2db_configuration)
+            self.importdata_dlg.setAttribute(Qt.WA_DeleteOnClose)
+            self.importdata_dlg.setWindowFlags(self.importdata_dlg.windowFlags() | Qt.Tool)
+            self.importdata_dlg.show()
+            self.importdata_dlg.finished.connect(self.importdata_dialog_finished)
+            self.__importdata_action.setChecked(True)
 
     def importdata_dialog_finished(self):
-        self.__importdata_action.setEnabled(True)
+        self.__importdata_action.setChecked(False)
+        self.importdata_dlg = None
 
     def show_options_dialog(self):
         dlg = OptionsDialog(self.ili2db_configuration)

--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -172,10 +172,10 @@ class QgisModelBakerPlugin(QObject):
         self.importdata_dlg.setWindowFlags(self.importdata_dlg.windowFlags() | Qt.Tool)
         self.importdata_dlg.show()
         self.importdata_dlg.finished.connect(self.importdata_dialog_finished)
-        self.__importdata_action.setChecked(False)
+        self.__importdata_action.setEnabled(False)
 
     def importdata_dialog_finished(self):
-        self.__importdata_action.setChecked(True)
+        self.__importdata_action.setEnabled(True)
 
     def show_options_dialog(self):
         dlg = OptionsDialog(self.ili2db_configuration)


### PR DESCRIPTION
By using `show()` instead of `exec()`.

While the dialog is open the action toolbutton is checked.
![modelbaker2](https://user-images.githubusercontent.com/28384354/86223081-62c0c100-bb87-11ea-839f-fdf117b24610.gif)
(in the solution the newly opened dialogs are always on top - this screencast is obsolete)

Another possibility would be to have it like `tool_button.setDown()`, but then it's still enabled in the database menu.

This pretty sure fixes as well #314 because on Windows on focusing on QGIS the dialogs are raised.
