### PR TITLE
Allow NULLs in Relation Reference widgets when appropriate

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
@@ -22,7 +22,10 @@ from typing import List
 from QgisModelBaker.libqgsprojectgen.dataobjects.relations import Relation
 from .layers import Layer
 from .legend import LegendGroup
-from qgis.core import QgsCoordinateReferenceSystem, QgsProject, QgsEditorWidgetSetup
+from qgis.core import (QgsCoordinateReferenceSystem,
+                       QgsProject,
+                       QgsEditorWidgetSetup,
+                       QgsFieldConstraints)
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 
 
@@ -108,12 +111,17 @@ class Project(QObject):
             assert rel.isValid()
             qgis_relations.append(rel)
 
+            referencing_layer = rel.referencingLayer()
+            referencing_field_constraints = referencing_layer.fieldConstraints(rel.referencingFields()[0])
+            allow_null = not bool(referencing_field_constraints & QgsFieldConstraints.ConstraintNotNull)
+
             if rel.referencedLayerId() in dict_domains and dict_domains[rel.referencedLayerId()]:
                 editor_widget_setup = QgsEditorWidgetSetup('RelationReference', {
                     'Relation': rel.id(),
                     'ShowForm': False,
                     'OrderByValue': True,
-                    'ShowOpenFormButton': False
+                    'ShowOpenFormButton': False,
+                    'AllowNULL': allow_null
                 }
                 )
             else:
@@ -122,9 +130,10 @@ class Project(QObject):
                     'ShowForm': False,
                     'OrderByValue': True,
                     'ShowOpenFormButton': False,
-                    'AllowAddFeatures': True
+                    'AllowAddFeatures': True,
+                    'AllowNULL': allow_null
                 }
-                                                           )
+                )
 
             referencing_layer = rel.referencingLayer()
             referencing_layer.setEditorWidgetSetup(


### PR DESCRIPTION
So far, related values (e.g., from a domain) are always required, and if users want to set a `NULL` value for the corresponding field, they have to write (manually) the word `NULL`, since, the X button in the field edit doesn't set the field's value to `NULL` (after all, `NULL` is not an allowed value according to the configuration).