### PR TITLE
Fix mandatory fields

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/dataobjects/fields.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/fields.py
@@ -22,6 +22,7 @@ from qgis.core import (
     QgsEditorWidgetSetup,
     QgsDefaultValue
 )
+from qgis.core import QgsFieldConstraints
 
 
 class Field:
@@ -32,6 +33,7 @@ class Field:
         self.widget = None
         self.widget_config = dict()
         self.default_value_expression = None
+        self.not_null = None
 
     def dump(self):
         definition = dict()
@@ -57,3 +59,7 @@ class Field:
         if self.default_value_expression:
             default_value = QgsDefaultValue(self.default_value_expression)
             layer.layer.setDefaultValueDefinition(field_idx, default_value)
+
+        # Additionally, some DB engines like MSSQL require NotNull constraints being set explicitly
+        if self.not_null:
+            layer.layer.setFieldConstraint(field_idx, QgsFieldConstraints.ConstraintNotNull)

--- a/QgisModelBaker/libqgsprojectgen/db_factory/db_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/db_factory.py
@@ -123,7 +123,7 @@ class DbFactory(ABC):
 
         return messages
 
-    def customize_widget_editor(self, field: Field, data_type: str):
+    def customize_widget_editor(self, field: Field, data_type: str, fielddef: dict):
         """Allows customizing the way a field is shown in the widget editor.
 
         For instance, a boolean field can be shown as a checkbox.
@@ -131,6 +131,7 @@ class DbFactory(ABC):
         :param field: The field that will be customized
         :type field: :class:`Field`
         :param data_type: The type of field
+        :param fielddef: The field information that **get_tables_info** method returns. See more in :class:`DBConnector`
         :return None
         """
         pass

--- a/QgisModelBaker/libqgsprojectgen/db_factory/mssql_factory.py
+++ b/QgisModelBaker/libqgsprojectgen/db_factory/mssql_factory.py
@@ -60,8 +60,12 @@ class MssqlFactory(DbFactory):
         """
         return 'https://downloads.interlis.ch/ili2mssql/ili2mssql-{version}.zip'.format(version=self.get_tool_version(db_ili_version))
 
-    def customize_widget_editor(self, field: Field, data_type: str):
+    def customize_widget_editor(self, field: Field, data_type: str, fielddef: dict):
         if 'bit' in data_type:
             field.widget = 'CheckBox'
             field.widget_config['CheckedState'] = '1'
             field.widget_config['UncheckedState'] = '0'
+
+        if 'mandatory' in fielddef and fielddef['not_null']:
+            field.not_null = True
+            field.widget_config['allow_null'] = False

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
@@ -71,6 +71,7 @@ class DBConnector(QObject):
                 extent [a string: "xmin;ymin;xmax;ymax"]
                 table_alias
                 model
+                not_null (optional)
         '''
         return []
 

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
@@ -282,6 +282,7 @@ class MssqlConnector(DBConnector):
                 stmt += ln + "    , alias.setting AS column_alias"
                 stmt += ln + "    , full_name.iliname AS fully_qualified_name"
             stmt += ln + "    , null AS comment"
+            stmt += ln + "    , case c.IS_NULLABLE when 'NO' then 1 else 0 end as not_null"
             stmt += ln + "FROM INFORMATION_SCHEMA.COLUMNS AS c"
             if metadata_exists:
                 stmt += ln + "LEFT JOIN {schema}.t_ili2db_column_prop unit"

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -209,7 +209,7 @@ class Generator(QObject):
                     elif data_type == self._db_connector.QGIS_DATE_TYPE:
                         field.widget_config['display_format'] = dateFormat
 
-                db_factory.customize_widget_editor(field, data_type)
+                db_factory.customize_widget_editor(field, data_type, fielddef)
 
                 if 'default_value_expression' in fielddef:
                     field.default_value_expression = fielddef['default_value_expression']


### PR DESCRIPTION
This PR allows specifying to widgets which fields are mandatories. Qgis requires that mandatory fields be set explicitly with some DB engines like SQL Server.

For example:
**SQL Server Table**
```sql
CREATE TABLE test.table_a(
	id int IDENTITY NOT NULL primary key,
	number_a  int NOT NULL,
	description_a varchar(256) NOT NULL,
	date_a datetime NOT NULL);
```
**Form with the changes**
<img src='https://user-images.githubusercontent.com/29440924/87470590-97e6fd80-c5e2-11ea-8e19-76c76469d004.png' width='38%'>

**Currently**
<img src='https://user-images.githubusercontent.com/29440924/87470592-987f9400-c5e2-11ea-974c-f412b59e0308.png' width='38%'>