### PR TITLE
Import schema without constraints

### DIFF
--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -95,14 +95,14 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.set_button_to_create_action = QAction(self.create_text, None)
         self.set_button_to_create_action.triggered.connect(self.set_button_to_create)
 
-        self.create_without_validation_text = self.tr('Create without validation')
-        self.set_button_to_create_without_validation_action = QAction(self.create_without_validation_text, None)
-        self.set_button_to_create_without_validation_action.triggered.connect(self.set_button_to_create_without_validation)
+        self.create_without_constraints_text = self.tr('Create without constraints')
+        self.set_button_to_create_without_constraints_action = QAction(self.create_without_constraints_text, None)
+        self.set_button_to_create_without_constraints_action.triggered.connect(self.set_button_to_create_without_constraints)
 
         self.edit_command_action = QAction(self.tr('Edit ili2db command'), None)
         self.edit_command_action.triggered.connect(self.edit_command)
 
-        self.create_tool_button.addAction(self.set_button_to_create_without_validation_action)
+        self.create_tool_button.addAction(self.set_button_to_create_without_constraints_action)
         self.create_tool_button.addAction(self.edit_command_action)
         self.create_tool_button.setText(self.create_text)
         self.create_tool_button.clicked.connect(self.accepted)
@@ -111,7 +111,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.buttonBox.clear()
         self.buttonBox.addButton(QDialogButtonBox.Cancel)
 
-        self.validate_data = True
+        self.create_constraints = True
 
         self.create_button.setText(self.tr('Create'))
         self.create_button.clicked.connect(self.accepted)
@@ -187,25 +187,25 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         So on clicking the button the creation will start with validation.
         The buttons actions are changed to be able to switch the with-validation mode.
         """
-        self.validate_data = True
+        self.create_constraints = True
         self.create_tool_button.removeAction(self.set_button_to_create_action)
         self.create_tool_button.removeAction(self.edit_command_action)
-        self.create_tool_button.addAction(self.set_button_to_create_without_validation_action)
+        self.create_tool_button.addAction(self.set_button_to_create_without_constraints_action)
         self.create_tool_button.addAction(self.edit_command_action)
         self.create_tool_button.setText(self.create_text)
 
-    def set_button_to_create_without_validation(self):
+    def set_button_to_create_without_constraints(self):
         """
         Changes the text of the button to create without validation and sets the validate_data to false.
         So on clicking the button the creation will start without validation.
         The buttons actions are changed to be able to switch the with-validation mode.
         """
-        self.validate_data = False
-        self.create_tool_button.removeAction(self.set_button_to_create_without_validation_action)
+        self.create_constraints = False
+        self.create_tool_button.removeAction(self.set_button_to_create_without_constraints_action)
         self.create_tool_button.removeAction(self.edit_command_action)
         self.create_tool_button.addAction(self.set_button_to_create_action)
         self.create_tool_button.addAction(self.edit_command_action)
-        self.create_tool_button.setText(self.create_without_validation_text)
+        self.create_tool_button.setText(self.create_without_constraints_text)
 
     def edit_command(self):
         """
@@ -450,7 +450,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         if self.ili_models_line_edit.text().strip():
             configuration.ilimodels = self.ili_models_line_edit.text().strip()
 
-        if not self.validate_data:
+        if not self.create_constraints:
             configuration.disable_constraint_parameters = True
 
         return configuration

--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -450,6 +450,9 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         if self.ili_models_line_edit.text().strip():
             configuration.ilimodels = self.ili_models_line_edit.text().strip()
 
+        if not self.validate_data:
+            configuration.disable_constraint_parameters = True
+
         return configuration
 
     def save_configuration(self, configuration):

--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -91,19 +91,30 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.db_simple_factory = DbSimpleFactory()
         QgsGui.instance().enableAutoGeometryRestore(self)
 
-        self.edit_command_action = QAction( self.tr('Edit ili2db command'), None)
+        self.create_text = self.tr('Create')
+        self.set_button_to_create_action = QAction(self.create_text, None)
+        self.set_button_to_create_action.triggered.connect(self.set_button_to_create)
+
+        self.create_without_validation_text = self.tr('Create without validation')
+        self.set_button_to_create_without_validation_action = QAction(self.create_without_validation_text, None)
+        self.set_button_to_create_without_validation_action.triggered.connect(self.set_button_to_create_without_validation)
+
+        self.edit_command_action = QAction(self.tr('Edit ili2db command'), None)
         self.edit_command_action.triggered.connect(self.edit_command)
 
+        self.create_tool_button.addAction(self.set_button_to_create_without_validation_action)
         self.create_tool_button.addAction(self.edit_command_action)
-        self.create_tool_button.setText(self.tr('Create'))
+        self.create_tool_button.setText(self.create_text)
         self.create_tool_button.clicked.connect(self.accepted)
-
-        self.create_button.setText(self.tr('Create'))
-        self.create_button.clicked.connect(self.accepted)
 
         self.buttonBox.accepted.disconnect()
         self.buttonBox.clear()
         self.buttonBox.addButton(QDialogButtonBox.Cancel)
+
+        self.validate_data = True
+
+        self.create_button.setText(self.tr('Create'))
+        self.create_button.clicked.connect(self.accepted)
 
         self.ili_file_browse_button.clicked.connect(
             make_file_selector(self.ili_file_line_edit, title=self.tr('Open Interlis Model'),
@@ -170,7 +181,36 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
         self.ili_file_line_edit.textChanged.emit(
             self.ili_file_line_edit.text())
 
+    def set_button_to_create(self):
+        """
+        Changes the text of the button to create (with validation) and sets the validate_data to true.
+        So on clicking the button the creation will start with validation.
+        The buttons actions are changed to be able to switch the with-validation mode.
+        """
+        self.validate_data = True
+        self.create_tool_button.removeAction(self.set_button_to_create_action)
+        self.create_tool_button.removeAction(self.edit_command_action)
+        self.create_tool_button.addAction(self.set_button_to_create_without_validation_action)
+        self.create_tool_button.addAction(self.edit_command_action)
+        self.create_tool_button.setText(self.create_text)
+
+    def set_button_to_create_without_validation(self):
+        """
+        Changes the text of the button to create without validation and sets the validate_data to false.
+        So on clicking the button the creation will start without validation.
+        The buttons actions are changed to be able to switch the with-validation mode.
+        """
+        self.validate_data = False
+        self.create_tool_button.removeAction(self.set_button_to_create_without_validation_action)
+        self.create_tool_button.removeAction(self.edit_command_action)
+        self.create_tool_button.addAction(self.set_button_to_create_action)
+        self.create_tool_button.addAction(self.edit_command_action)
+        self.create_tool_button.setText(self.create_without_validation_text)
+
     def edit_command(self):
+        """
+        A dialog opens giving the user the possibility to edit the ili2db command used for the creation
+        """
         importer = iliimporter.Importer()
         importer.tool = self.type_combo_box.currentData()
         importer.configuration = self.updated_configuration()

--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -451,7 +451,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             configuration.ilimodels = self.ili_models_line_edit.text().strip()
 
         if not self.create_constraints:
-            configuration.disable_constraint_parameters = True
+            configuration.disable_validation = True
 
         return configuration
 

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -202,15 +202,15 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         args += ["--coalesceCatalogueRef"]
         args += ["--createEnumTabs"]
 
-        if not self.disable_constraint_parameters:
-            args += ["--createNumChecks"]
-            args += ["--createFk"]
-            args += ["--createFkIdx"]
-            args += ["--createUnique"]
-
         if self.disable_constraint_parameters:
             args += ["--sqlEnableNull"]
 
+        if not self.disable_constraint_parameters:
+            args += ["--createNumChecks"]
+            args += ["--createUnique"]
+            args += ["--createFk"]
+
+        args += ["--createFkIdx"]
         args += ["--coalesceMultiSurface"]
         args += ["--coalesceMultiLine"]
         args += ["--coalesceMultiPoint"]

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -185,6 +185,7 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         self.db_ili_version = None
         self.pre_script = ''
         self.post_script = ''
+        self.disable_constraint_parameters = False
 
     def to_ili2db_args(self, extra_args=[], with_action=True):
         """
@@ -200,16 +201,22 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
 
         args += ["--coalesceCatalogueRef"]
         args += ["--createEnumTabs"]
-        args += ["--createNumChecks"]
+
+        if not self.disable_constraint_parameters:
+            args += ["--createNumChecks"]
+            args += ["--createFk"]
+            args += ["--createFkIdx"]
+            args += ["--createUnique"]
+
+        if self.disable_constraint_parameters:
+            args += ["--sqlEnableNull"]
+
         args += ["--coalesceMultiSurface"]
         args += ["--coalesceMultiLine"]
         args += ["--coalesceMultiPoint"]
         args += ["--coalesceArray"]
         args += ["--beautifyEnumDispName"]
-        args += ["--createUnique"]
         args += ["--createGeomIdx"]
-        args += ["--createFk"]
-        args += ["--createFkIdx"]
         args += ["--createMetaInfo"]
         args += ["--expandMultilingual"]
         if self.db_ili_version is None or self.db_ili_version > 3:

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -113,6 +113,7 @@ class Ili2DbCommandConfiguration(object):
         self.tomlfile = ''
         self.dbinstance = ''
         self.db_odbc_driver = ''
+        self.disable_validation = False
 
     def to_ili2db_args(self):
 
@@ -140,7 +141,6 @@ class ExportConfiguration(Ili2DbCommandConfiguration):
     def __init__(self):
         super().__init__()
         self.xtffile = ''
-        self.disable_validation = False
         self.with_exporttid = False
         self.iliexportmodels = ''
         self.db_ili_version = None
@@ -185,7 +185,6 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         self.db_ili_version = None
         self.pre_script = ''
         self.post_script = ''
-        self.disable_constraint_parameters = False
 
     def to_ili2db_args(self, extra_args=[], with_action=True):
         """
@@ -202,10 +201,10 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         args += ["--coalesceCatalogueRef"]
         args += ["--createEnumTabs"]
 
-        if self.disable_constraint_parameters:
+        if self.disable_validation:
             args += ["--sqlEnableNull"]
 
-        if not self.disable_constraint_parameters:
+        if not self.disable_validation:
             args += ["--createNumChecks"]
             args += ["--createUnique"]
             args += ["--createFk"]
@@ -265,7 +264,6 @@ class ImportDataConfiguration(SchemaImportConfiguration):
         super().__init__()
         self.xtffile = ''
         self.delete_data = False
-        self.disable_validation = False
         self.with_importtid = False
 
     def to_ili2db_args(self, extra_args=[], with_action=True):

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -204,7 +204,7 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         if self.disable_validation:
             args += ["--sqlEnableNull"]
 
-        if not self.disable_validation:
+        else:
             args += ["--createNumChecks"]
             args += ["--createUnique"]
             args += ["--createFk"]


### PR DESCRIPTION
Like the possibility to import and export without validation, we have now the possibility to import a **schema** without constraints.

![image](https://user-images.githubusercontent.com/28384354/92084846-424ff580-edc8-11ea-8742-8326cab2b319.png)

If this is started, the ili2db command is run with this parameter:
- `--sqlEnableNull`
and without this parameters
- `--createNumChecks`
- `--createUnique`
- `--createFk`

`--createFkIdx` is still used, since it has nothing to do directly with constraints (it just indexes the column for the fks AFAIK)

resolves #427

Since on importing an xtf File the schema is created (if not existing) the import schema parameters are taken there as well. On "Import without validation" these constraint-parameters are not set.