### PR TITLE
Add Iliupdater

### DIFF
--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -342,16 +342,16 @@ class ExportDialog(QDialog, DIALOG_UI):
             self.progress_bar.setValue(25)
 
             try:
-                if exporter.run(4, edited_command) != iliexporter.Exporter.SUCCESS:
+                if exporter.run(edited_command) != iliexporter.Exporter.SUCCESS:
                     if configuration.db_ili_version == 3:
                         # failed with a db created by ili2db version 3
                         if not edited_command:
                             # fallback because of issues with --export3 argument
                             self.show_message(Qgis.Warning, self.tr('Tried export with ili2db version 3.x.x (fallback)'))
-                            # set db version to 4 (means no special arguments like --export3) in the configuration
-                            configuration.db_ili_version = 4
+
+                            exporter.version = 3
                             # ... and enforce the Exporter to use ili2db version 3.x.x
-                            if exporter.run(3) != iliexporter.Exporter.SUCCESS:
+                            if exporter.run() != iliexporter.Exporter.SUCCESS:
                                 self.enable()
                                 self.progress_bar.hide()
                                 return

--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -31,8 +31,7 @@ from QgisModelBaker.gui.edit_command import EditCommandDialog
 from QgisModelBaker.libili2db.globals import CRS_PATTERNS, displayDbIliMode, DbActionType
 from QgisModelBaker.libili2db.ili2dbconfig import SchemaImportConfiguration
 from QgisModelBaker.libili2db.ilicache import IliCache, ModelCompleterDelegate
-from QgisModelBaker.libili2db.iliimporter import JavaNotFoundError
-from QgisModelBaker.libili2db.ili2dbutils import color_log_text
+from QgisModelBaker.libili2db.ili2dbutils import color_log_text, JavaNotFoundError
 from QgisModelBaker.utils.qt_utils import (
     make_file_selector,
     Validators,

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -289,3 +289,36 @@ class ImportDataConfiguration(SchemaImportConfiguration):
         args += [self.xtffile]
 
         return args
+
+
+class UpdateDataConfiguration(Ili2DbCommandConfiguration):
+
+    def __init__(self):
+        super().__init__()
+        self.xtffile = ''
+        self.dataset = ''
+        self.with_importtid = False
+        self.with_importbid = False
+
+    def to_ili2db_args(self, extra_args=[], with_action=True):
+        args = list()
+
+        if with_action:
+            args += ["--update"]
+
+        if self.disable_validation:
+            args += ["--disableValidation"]
+
+        if self.with_importtid:
+            args += ["--importTid"]
+
+        if self.with_importbid:
+            args += ["--importBid"]
+
+        args += ["--dataset", self.dataset]
+
+        args += Ili2DbCommandConfiguration.to_ili2db_args(self)
+
+        args += [self.xtffile]
+
+        return args

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -299,12 +299,15 @@ class UpdateDataConfiguration(Ili2DbCommandConfiguration):
         self.dataset = ''
         self.with_importtid = False
         self.with_importbid = False
+        self.db_ili_version = None
 
     def to_ili2db_args(self, extra_args=[], with_action=True):
         args = list()
 
         if with_action:
             args += ["--update"]
+
+        args += extra_args
 
         if self.disable_validation:
             args += ["--disableValidation"]

--- a/QgisModelBaker/libili2db/iliexecutable.py
+++ b/QgisModelBaker/libili2db/iliexecutable.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+    begin                :    09/09/23
+    git sha              :    :%H$
+    copyright            :    (C) 2020 by Yesid Polania
+    email                :    yesidpol.3@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+import functools
+import locale
+import re
+from qgis.PyQt.QtCore import QObject, pyqtSignal, QProcess, QEventLoop
+from abc import ABCMeta, abstractmethod
+
+from QgisModelBaker.libili2db.ili2dbutils import get_java_path, get_ili2db_bin, JavaNotFoundError
+from QgisModelBaker.libqgsprojectgen.db_factory.db_simple_factory import DbSimpleFactory
+
+
+class AbstractQObjectMeta(ABCMeta, type(QObject)):
+    pass
+
+
+class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
+    SUCCESS = 0
+    # TODO: Insert more codes?
+    ERROR = 1000
+    ILI2DB_NOT_FOUND = 1001
+
+    stdout = pyqtSignal(str)
+    stderr = pyqtSignal(str)
+    process_started = pyqtSignal(str)
+    process_finished = pyqtSignal(int, int)
+
+    __result = None
+
+    def __init__(self, parent=None):
+        QObject.__init__(self, parent)
+        self.filename = None
+        self.tool = None
+        self.configuration = self._create_config()
+        self.encoding = locale.getlocale()[1]
+
+        # Lets python try to determine the default locale
+        if not self.encoding:
+            self.encoding = locale.getdefaultlocale()[1]
+
+        # This might be unset
+        # (https://stackoverflow.com/questions/1629699/locale-getlocale-problems-on-osx)
+        if not self.encoding:
+            self.encoding = 'UTF8'
+
+    @abstractmethod
+    def _create_config(self):
+        pass
+
+    @abstractmethod
+    def _get_done_pattern(self):
+        pass
+
+    def _get_ili2db_version(self):
+        return self.configuration.db_ili_version
+
+    def _args(self, hide_password):
+        self.configuration.tool = self.tool
+        db_simple_factory = DbSimpleFactory()
+        db_factory = db_simple_factory.create_factory(self.tool)
+
+        config_manager = db_factory.get_db_command_config_manager(self.configuration)
+
+        return config_manager.get_ili2db_args(hide_password)
+
+    def command(self, hide_password):
+        ili2db_bin = get_ili2db_bin(self.tool, self._get_ili2db_version(), self.stdout, self.stderr)
+        if not ili2db_bin:
+            return self.ILI2DB_NOT_FOUND
+
+        ili2db_jar_arg = ["-jar", ili2db_bin]
+
+        args = self._args(hide_password)
+
+        java_path = get_java_path(self.configuration.base_configuration)
+
+        command_args = ili2db_jar_arg + args
+        command = java_path + ' ' + ' '.join(command_args)
+
+        return command
+
+    def command_with_password(self, command):
+        if '--dbpwd ******' in command:
+            args = self._args(False)
+            i = args.index('--dbpwd')
+            command = command.replace('--dbpwd ******', '--dbpwd '+args[i+1])
+        return command
+
+    def command_without_password(self, command):
+        regex = re.compile('--dbpwd [^ ]*')
+        match = regex.match(command)
+        if match:
+            command = command.replace(match.group(1), '--dbpwd ******')
+        return command
+
+    def run(self, command=None):
+        if not command:
+            # we usually use version 4 except in case of a fallback
+            command = self.command(False)
+
+        proc = QProcess()
+        proc.readyReadStandardError.connect(
+            functools.partial(self.stderr_ready, proc=proc))
+        proc.readyReadStandardOutput.connect(
+            functools.partial(self.stdout_ready, proc=proc))
+
+        proc.start(self.command_with_password(command))
+
+        if not proc.waitForStarted():
+            proc = None
+
+        if not proc:
+            raise JavaNotFoundError()
+
+        self.process_started.emit(self.command_without_password(command))
+
+        self.__result = self.ERROR
+
+        loop = QEventLoop()
+        proc.finished.connect(loop.exit)
+        loop.exec()
+
+        self.process_finished.emit(proc.exitCode(), self.__result)
+        return self.__result
+
+    def stderr_ready(self, proc):
+        text = bytes(proc.readAllStandardError()).decode(self.encoding)
+
+        done_pattern = self._get_done_pattern()
+
+        if done_pattern.search(text):
+            self.__result = self.SUCCESS
+
+        self.stderr.emit(text)
+
+    def stdout_ready(self, proc):
+        text = bytes(proc.readAllStandardOutput()).decode(self.encoding)
+        self.stdout.emit(text)

--- a/QgisModelBaker/libili2db/iliexecutable.py
+++ b/QgisModelBaker/libili2db/iliexecutable.py
@@ -41,6 +41,7 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
     process_started = pyqtSignal(str)
     process_finished = pyqtSignal(int, int)
 
+    __done_pattern = None
     __result = None
 
     def __init__(self, parent=None):
@@ -61,10 +62,6 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
 
     @abstractmethod
     def _create_config(self):
-        pass
-
-    @abstractmethod
-    def _get_done_pattern(self):
         pass
 
     def _get_ili2db_version(self):
@@ -142,9 +139,10 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
     def stderr_ready(self, proc):
         text = bytes(proc.readAllStandardError()).decode(self.encoding)
 
-        done_pattern = self._get_done_pattern()
+        if not self.__done_pattern:
+            self.__done_pattern = re.compile(r"Info: \.\.\.([a-z]+ )?done")
 
-        if done_pattern.search(text):
+        if self.__done_pattern.search(text):
             self.__result = self.SUCCESS
 
         self.stderr.emit(text)

--- a/QgisModelBaker/libili2db/iliexporter.py
+++ b/QgisModelBaker/libili2db/iliexporter.py
@@ -17,26 +17,15 @@
  *                                                                         *
  ***************************************************************************/
 """
-
 import re
-import functools
-import locale
 
-from QgisModelBaker.libili2db.ili2dbutils import (
-    get_ili2db_bin,
-    get_java_path,
-    JavaNotFoundError
-)
-from qgis.PyQt.QtCore import QObject, pyqtSignal, QProcess, QEventLoop
+from qgis.PyQt.QtCore import pyqtSignal
 
 from QgisModelBaker.libili2db.ili2dbconfig import ExportConfiguration
-from QgisModelBaker.libqgsprojectgen.db_factory.db_simple_factory import DbSimpleFactory
+from QgisModelBaker.libili2db.iliexecutable import IliExecutable
 
 
-class Exporter(QObject):
-    SUCCESS = 0
-    # TODO: Insert more codes?
-    ERROR = 1000
+class Exporter(IliExecutable):
 
     stdout = pyqtSignal(str)
     stderr = pyqtSignal(str)
@@ -44,102 +33,27 @@ class Exporter(QObject):
     process_finished = pyqtSignal(int, int)
 
     __done_pattern = None
-    __result = None
 
     def __init__(self, parent=None):
-        QObject.__init__(self, parent)
-        self.filename = None
-        self.tool = None
-        self.configuration = ExportConfiguration()
-        self.encoding = locale.getlocale()[1]
+        super(Exporter, self).__init__(parent)
+        self.version = 4
 
-        # Lets python try to determine the default locale
-        if not self.encoding:
-            self.encoding = locale.getdefaultlocale()[1]
+    def _create_config(self):
+        return ExportConfiguration()
 
-        # This might be unset
-        # (https://stackoverflow.com/questions/1629699/locale-getlocale-problems-on-osx)
-        if not self.encoding:
-            self.encoding = 'UTF8'
-
-    def args(self, hide_password ):
-        self.configuration.tool = self.tool
-        db_simple_factory = DbSimpleFactory()
-        db_factory = db_simple_factory.create_factory(self.tool)
-
-        config_manager = db_factory.get_db_command_config_manager(self.configuration)
-
-        return config_manager.get_ili2db_args(hide_password)
-
-    def command(self, hide_password, version=4):
-        ili2db_bin = get_ili2db_bin(self.tool, version, self.stdout, self.stderr)
-        if not ili2db_bin:
-            return
-
-        ili2db_jar_arg = ["-jar", ili2db_bin]
-
-        args = self.args(hide_password)
-
-        java_path = get_java_path(self.configuration.base_configuration)
-
-        command_args = ili2db_jar_arg + args
-        command = java_path + ' ' + ' '.join(command_args)
-
-        return command
-
-    def command_with_password(self, command):
-        if '--dbpwd ******' in command:
-            args = self.args(False)
-            i = args.index('--dbpwd')
-            command = command.replace('--dbpwd ******', '--dbpwd '+args[i+1])
-        return command
-
-    def command_without_password(self, command):
-        regex = re.compile('--dbpwd [^ ]*')
-        match = regex.match(command)
-        if match:
-            command = command.replace(match.group(1), '--dbpwd ******')
-        return command
-
-    def run(self, version=4, command=None):
-        if not command:
-            # we usually use version 4 except in case of a fallback
-            command = self.command(False,version)
-
-        proc = QProcess()
-        proc.readyReadStandardError.connect(
-            functools.partial(self.stderr_ready, proc=proc))
-        proc.readyReadStandardOutput.connect(
-            functools.partial(self.stdout_ready, proc=proc))
-
-        proc.start(self.command_with_password(command))
-
-        if not proc.waitForStarted():
-            proc = None
-
-        if not proc:
-            raise JavaNotFoundError()
-
-        self.process_started.emit(self.command_without_password(command))
-
-        self.__result = Exporter.ERROR
-
-        loop = QEventLoop()
-        proc.finished.connect(loop.exit)
-        loop.exec()
-
-        self.process_finished.emit(proc.exitCode(), self.__result)
-        return self.__result
-
-    def stderr_ready(self, proc):
-        text = bytes(proc.readAllStandardError()).decode(self.encoding)
+    def _get_done_pattern(self):
         if not self.__done_pattern:
             self.__done_pattern = re.compile(r"Info: ...export done")
-        if self.__done_pattern.search(text):
-            self.__result = Exporter.SUCCESS
 
-        self.stderr.emit(text)
+        return self.__done_pattern
 
-    def stdout_ready(self, proc):
-        text = bytes(proc.readAllStandardOutput()).decode(self.encoding)
-        self.stdout.emit(text)
+    def _get_ili2db_version(self):
+        return self.version
+
+    def _args(self, hide_password):
+        args = super(Exporter, self)._args(hide_password)
+
+        if self.version == 3 and '--export3' in args:
+            args.remove('--export3')
+
+        return args

--- a/QgisModelBaker/libili2db/iliexporter.py
+++ b/QgisModelBaker/libili2db/iliexporter.py
@@ -27,25 +27,12 @@ from QgisModelBaker.libili2db.iliexecutable import IliExecutable
 
 class Exporter(IliExecutable):
 
-    stdout = pyqtSignal(str)
-    stderr = pyqtSignal(str)
-    process_started = pyqtSignal(str)
-    process_finished = pyqtSignal(int, int)
-
-    __done_pattern = None
-
     def __init__(self, parent=None):
         super(Exporter, self).__init__(parent)
         self.version = 4
 
     def _create_config(self):
         return ExportConfiguration()
-
-    def _get_done_pattern(self):
-        if not self.__done_pattern:
-            self.__done_pattern = re.compile(r"Info: ...export done")
-
-        return self.__done_pattern
 
     def _get_ili2db_version(self):
         return self.version

--- a/QgisModelBaker/libili2db/iliexporter.py
+++ b/QgisModelBaker/libili2db/iliexporter.py
@@ -17,11 +17,7 @@
  *                                                                         *
  ***************************************************************************/
 """
-import re
-
-from qgis.PyQt.QtCore import pyqtSignal
-
-from QgisModelBaker.libili2db.ili2dbconfig import ExportConfiguration
+from QgisModelBaker.libili2db.ili2dbconfig import ExportConfiguration, Ili2DbCommandConfiguration
 from QgisModelBaker.libili2db.iliexecutable import IliExecutable
 
 
@@ -31,7 +27,7 @@ class Exporter(IliExecutable):
         super(Exporter, self).__init__(parent)
         self.version = 4
 
-    def _create_config(self):
+    def _create_config(self) -> Ili2DbCommandConfiguration:
         return ExportConfiguration()
 
     def _get_ili2db_version(self):

--- a/QgisModelBaker/libili2db/iliimporter.py
+++ b/QgisModelBaker/libili2db/iliimporter.py
@@ -17,31 +17,15 @@
  *                                                                         *
  ***************************************************************************/
 """
-import os
-
 import re
-import locale
-import functools
 
-from QgisModelBaker.libili2db.ili2dbutils import (
-    get_ili2db_bin,
-    get_java_path,
-    JavaNotFoundError
-)
-from qgis.PyQt.QtCore import QObject, pyqtSignal, QProcess, QEventLoop
+from qgis.PyQt.QtCore import pyqtSignal
 
-from QgisModelBaker.libili2db.ili2dbconfig import (
-        SchemaImportConfiguration,
-        ImportDataConfiguration
-)
-from QgisModelBaker.libqgsprojectgen.db_factory.db_simple_factory import DbSimpleFactory
+from QgisModelBaker.libili2db.ili2dbconfig import SchemaImportConfiguration, ImportDataConfiguration
+from QgisModelBaker.libili2db.iliexecutable import IliExecutable
 
 
-class Importer(QObject):
-    SUCCESS = 0
-    # TODO: Insert more codes?
-    ERROR = 1000
-    ILI2DB_NOT_FOUND = 1001
+class Importer(IliExecutable):
 
     stdout = pyqtSignal(str)
     stderr = pyqtSignal(str)
@@ -49,108 +33,24 @@ class Importer(QObject):
     process_finished = pyqtSignal(int, int)
 
     __done_pattern = None
-    __result = None
 
     def __init__(self, dataImport=False, parent=None):
-        QObject.__init__(self, parent)
-        self.filename = None
-        self.tool = None
-        self.dataImport = dataImport
-        if dataImport:
-            self.configuration = ImportDataConfiguration()
+        self.__data_import = dataImport
+        super(Importer, self).__init__(parent)
+
+    def _create_config(self):
+        if self.__data_import:
+            configuration = ImportDataConfiguration()
         else:
-            self.configuration = SchemaImportConfiguration()
-        self.encoding = locale.getlocale()[1]
+            configuration = SchemaImportConfiguration()
 
-        # Lets python try to determine the default locale
-        if not self.encoding:
-            self.encoding = locale.getdefaultlocale()[1]
+        return configuration
 
-        # This might be unset
-        # (https://stackoverflow.com/questions/1629699/locale-getlocale-problems-on-osx)
-        if not self.encoding:
-            self.encoding = 'UTF8'
-
-    def args(self, hide_password ):
-        self.configuration.tool = self.tool
-        db_simple_factory = DbSimpleFactory()
-        db_factory = db_simple_factory.create_factory(self.tool)
-
-        config_manager = db_factory.get_db_command_config_manager(self.configuration)
-
-        return config_manager.get_ili2db_args(hide_password)
-
-    def command(self, hide_password):
-        ili2db_bin = get_ili2db_bin(self.tool, self.configuration.db_ili_version, self.stdout, self.stderr)
-        if not ili2db_bin:
-            return Importer.ILI2DB_NOT_FOUND
-
-        ili2db_jar_arg = ["-jar", ili2db_bin]
-
-        args = self.args(hide_password)
-
-        java_path = get_java_path(self.configuration.base_configuration)
-
-        command_args = ili2db_jar_arg + args
-        command = java_path + ' ' + ' '.join(command_args)
-
-        return command
-
-    def command_with_password(self, command):
-        if '--dbpwd ******' in command:
-            args = self.args(False)
-            i = args.index('--dbpwd')
-            command = command.replace('--dbpwd ******', '--dbpwd '+args[i+1])
-        return command
-
-    def command_without_password(self, command):
-        regex = re.compile('--dbpwd [^ ]*')
-        match = regex.match(command)
-        if match:
-            command = command.replace(match.group(1), '--dbpwd ******')
-        return command
-
-    def run(self, command=None):
-        if not command:
-            command = self.command(False)
-
-        proc = QProcess()
-        proc.readyReadStandardError.connect(
-            functools.partial(self.stderr_ready, proc=proc))
-        proc.readyReadStandardOutput.connect(
-            functools.partial(self.stdout_ready, proc=proc))
-
-        proc.start(self.command_with_password(command))
-
-        if not proc.waitForStarted():
-            proc = None
-
-        if not proc:
-            raise JavaNotFoundError()
-
-        self.process_started.emit(self.command_without_password(command))
-
-        self.__result = Importer.ERROR
-
-        loop = QEventLoop()
-        proc.finished.connect(loop.exit)
-        loop.exec()
-
-        self.process_finished.emit(proc.exitCode(), self.__result)
-        return self.__result
-
-    def stderr_ready(self, proc):
-        text = bytes(proc.readAllStandardError()).decode(self.encoding)
+    def _get_done_pattern(self):
         if not self.__done_pattern:
-            if self.dataImport:
+            if self.__data_import:
                 self.__done_pattern = re.compile(r"Info: \.\.\.import done")
             else:
                 self.__done_pattern = re.compile(r"Info: \.\.\.done")
-        if self.__done_pattern.search(text):
-            self.__result = Importer.SUCCESS
 
-        self.stderr.emit(text)
-
-    def stdout_ready(self, proc):
-        text = bytes(proc.readAllStandardOutput()).decode(self.encoding)
-        self.stdout.emit(text)
+        return self.__done_pattern

--- a/QgisModelBaker/libili2db/iliimporter.py
+++ b/QgisModelBaker/libili2db/iliimporter.py
@@ -27,13 +27,6 @@ from QgisModelBaker.libili2db.iliexecutable import IliExecutable
 
 class Importer(IliExecutable):
 
-    stdout = pyqtSignal(str)
-    stderr = pyqtSignal(str)
-    process_started = pyqtSignal(str)
-    process_finished = pyqtSignal(int, int)
-
-    __done_pattern = None
-
     def __init__(self, dataImport=False, parent=None):
         self.__data_import = dataImport
         super(Importer, self).__init__(parent)
@@ -45,12 +38,3 @@ class Importer(IliExecutable):
             configuration = SchemaImportConfiguration()
 
         return configuration
-
-    def _get_done_pattern(self):
-        if not self.__done_pattern:
-            if self.__data_import:
-                self.__done_pattern = re.compile(r"Info: \.\.\.import done")
-            else:
-                self.__done_pattern = re.compile(r"Info: \.\.\.done")
-
-        return self.__done_pattern

--- a/QgisModelBaker/libili2db/iliimporter.py
+++ b/QgisModelBaker/libili2db/iliimporter.py
@@ -17,11 +17,8 @@
  *                                                                         *
  ***************************************************************************/
 """
-import re
-
-from qgis.PyQt.QtCore import pyqtSignal
-
-from QgisModelBaker.libili2db.ili2dbconfig import SchemaImportConfiguration, ImportDataConfiguration
+from QgisModelBaker.libili2db.ili2dbconfig import SchemaImportConfiguration, ImportDataConfiguration, \
+    Ili2DbCommandConfiguration
 from QgisModelBaker.libili2db.iliexecutable import IliExecutable
 
 
@@ -31,7 +28,7 @@ class Importer(IliExecutable):
         self.__data_import = dataImport
         super(Importer, self).__init__(parent)
 
-    def _create_config(self):
+    def _create_config(self) -> Ili2DbCommandConfiguration:
         if self.__data_import:
             configuration = ImportDataConfiguration()
         else:

--- a/QgisModelBaker/libili2db/iliupdater.py
+++ b/QgisModelBaker/libili2db/iliupdater.py
@@ -26,7 +26,8 @@ from QgisModelBaker.libili2db.iliexecutable import IliExecutable
 
 
 class Updater(IliExecutable):
-
+    """Executes an update operation on ili2db.
+    """
     def __init__(self, parent=None):
         super(Updater, self).__init__(parent)
 

--- a/QgisModelBaker/libili2db/iliupdater.py
+++ b/QgisModelBaker/libili2db/iliupdater.py
@@ -27,21 +27,8 @@ from QgisModelBaker.libili2db.iliexecutable import IliExecutable
 
 class Updater(IliExecutable):
 
-    stdout = pyqtSignal(str)
-    stderr = pyqtSignal(str)
-    process_started = pyqtSignal(str)
-    process_finished = pyqtSignal(int, int)
-
-    __done_pattern = None
-
     def __init__(self, parent=None):
         super(Updater, self).__init__(parent)
 
     def _create_config(self):
         return UpdateDataConfiguration()
-
-    def _get_done_pattern(self):
-        if not self.__done_pattern:
-            self.__done_pattern = re.compile(r"Info: \.\.\.update done")
-
-        return self.__done_pattern

--- a/QgisModelBaker/libili2db/iliupdater.py
+++ b/QgisModelBaker/libili2db/iliupdater.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+                              -------------------
+        begin                : 23/03/17
+        git sha              : :%H$
+        copyright            : (C) 2017 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+import re
+
+from qgis.PyQt.QtCore import pyqtSignal
+
+from QgisModelBaker.libili2db.ili2dbconfig import UpdateDataConfiguration
+from QgisModelBaker.libili2db.iliexecutable import IliExecutable
+
+
+class Updater(IliExecutable):
+
+    stdout = pyqtSignal(str)
+    stderr = pyqtSignal(str)
+    process_started = pyqtSignal(str)
+    process_finished = pyqtSignal(int, int)
+
+    __done_pattern = None
+
+    def __init__(self, parent=None):
+        super(Updater, self).__init__(parent)
+
+    def _create_config(self):
+        return UpdateDataConfiguration()
+
+    def _get_done_pattern(self):
+        if not self.__done_pattern:
+            self.__done_pattern = re.compile(r"Info: \.\.\.update done")
+
+        return self.__done_pattern

--- a/QgisModelBaker/tests/test_export.py
+++ b/QgisModelBaker/tests/test_export.py
@@ -58,10 +58,9 @@ class TestExport(unittest.TestCase):
         if result != iliexporter.Exporter.SUCCESS:
             # failed with a db created by ili2db version 3
             # fallback since of issues with --export3 argument
-            # set db version to 4 (means no special arguments like --export3) in the configuration
-            exporter.configuration.db_ili_version = 4
             # ... and enforce the Exporter to use ili2db version 3.x.x
-            result = exporter.run(3)
+            exporter.version = 3
+            result = exporter.run()
         self.assertEqual(result, iliexporter.Exporter.SUCCESS)
         self.compare_xtfs(testdata_path(
             'xtf/test_ciaf_ladm.xtf'), obtained_xtf_path)
@@ -157,10 +156,9 @@ class TestExport(unittest.TestCase):
         if result != iliexporter.Exporter.SUCCESS:
             # failed with a db created by ili2db version 3
             # fallback since of issues with --export3 argument
-            # set db version to 4 (means no special arguments like --export3) in the configuration
-            exporter.configuration.db_ili_version = 4
             # ... and enforce the Exporter to use ili2db version 3.x.x
-            result = exporter.run(3)
+            exporter.version = 3
+            result = exporter.run()
         self.assertEqual(result, iliexporter.Exporter.SUCCESS)
         self.compare_xtfs(testdata_path(
             'xtf/test_ciaf_ladm.xtf'), obtained_xtf_path)
@@ -419,7 +417,8 @@ class TestExport(unittest.TestCase):
         exporter.configuration.xtffile = obtained_xtf_path
         exporter.stdout.connect(self.print_info)
         exporter.stderr.connect(self.print_error)
-        self.assertEqual(exporter.run(3), iliexporter.Exporter.SUCCESS)
+        exporter.version = 3
+        self.assertEqual(exporter.run(), iliexporter.Exporter.SUCCESS)
         self.compare_xtfs(testdata_path(
             'xtf/test_ciaf_ladm.xtf'), obtained_xtf_path)
 

--- a/QgisModelBaker/tests/test_update.py
+++ b/QgisModelBaker/tests/test_update.py
@@ -1,0 +1,175 @@
+import datetime
+import logging
+import os
+
+import pyodbc
+import psycopg2
+import psycopg2.extras
+import shutil
+import tempfile
+
+from QgisModelBaker.libili2db import iliupdater, iliimporter
+from QgisModelBaker.libili2db.globals import DbIliMode
+from qgis.testing import unittest, start_app
+from qgis import utils
+
+from QgisModelBaker.libqgsprojectgen.db_factory.mssql_command_config_manager import MssqlCommandConfigManager
+from QgisModelBaker.libqgsprojectgen.db_factory.pg_command_config_manager import PgCommandConfigManager
+from QgisModelBaker.tests.utils import iliimporter_config, iliupdater_config, testdata_path
+
+
+start_app()
+
+
+class TestUpdate(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests."""
+        cls.base_test_path = tempfile.mkdtemp()
+
+    def test_update_postgis(self):
+        tool = DbIliMode.ili2pg
+        dataset_name = 'updater_test'
+        schema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
+
+        importer = self.__get_importer(tool)
+        importer.configuration.dbschema = schema
+
+        self.assertEqual(importer.run(), iliimporter.Importer.SUCCESS)
+
+        updater = self.__get_updater(tool, dataset_name)
+        updater.configuration.dbschema = schema
+
+        self.assertEqual(updater.run(), iliupdater.Updater.SUCCESS)
+
+        config_manager = PgCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+        conn = psycopg2.connect(uri)
+        cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+        # Check expected data is there in the database schema
+        self.__check_updater(dataset_name, cursor, schema)
+
+        cursor.close()
+        conn.close()
+
+    def test_update_mssql(self):
+        tool = DbIliMode.ili2mssql
+        dataset_name = 'updater_test'
+        schema = 'ciaf_ladm_{:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
+
+        importer = self.__get_importer(tool)
+        importer.configuration.dbschema = schema
+
+        self.assertEqual(importer.run(), iliimporter.Importer.SUCCESS)
+
+        updater = self.__get_updater(tool, dataset_name)
+        updater.configuration.dbschema = schema
+
+        self.assertEqual(updater.run(), iliupdater.Updater.SUCCESS)
+
+        config_manager = MssqlCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+        conn = pyodbc.connect(uri)
+        cursor = conn.cursor()
+
+        # Check expected data is there in the database schema
+        self.__check_updater(dataset_name, cursor, schema)
+
+        cursor.close()
+        conn.close()
+
+    def test_update_gpkg(self):
+        tool = DbIliMode.ili2gpkg
+        dataset_name = 'updater_test'
+        db_file = os.path.join(self.base_test_path, 'tmp_update_gpkg.gpkg')
+
+        importer = self.__get_importer(tool)
+        importer.configuration.dbfile = db_file
+        self.assertEqual(importer.run(), iliimporter.Importer.SUCCESS)
+
+        updater = self.__get_updater(tool, dataset_name)
+        updater.configuration.dbfile = db_file
+        self.assertEqual(updater.run(), iliupdater.Updater.SUCCESS)
+
+        conn = utils.spatialite_connect(importer.configuration.dbfile)
+        cursor = conn.cursor()
+
+        self.__check_updater(dataset_name, cursor)
+
+        cursor.close()
+        conn.close()
+
+    def __get_importer(self, tool):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = tool
+        importer.configuration = iliimporter_config(tool, 'ilimodels/CIAF_LADM')
+        importer.configuration.ilimodels = 'CIAF_LADM'
+        importer.configuration.srs_code = 3116
+        importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+
+        return importer
+
+    def __get_updater(self, tool, dataset_name):
+        updater = iliupdater.Updater()
+        updater.tool = tool
+        updater.configuration = iliupdater_config(tool, 'ilimodels/CIAF_LADM')
+        updater.configuration.dataset = dataset_name
+        updater.configuration.with_importbid = True
+        updater.configuration.with_importtid = True
+        updater.configuration.xtffile = testdata_path('xtf/test_ciaf_ladm.xtf')
+
+        updater.stdout.connect(self.print_info)
+        updater.stderr.connect(self.print_error)
+
+        return updater
+
+    def __check_updater(self, dataset_name, cursor, schema=None):
+        schema = schema + '.' if schema else ''
+
+        # check_expected dataset
+        cursor.execute("""
+              SELECT T_Id, datasetName
+              FROM {}T_ILI2DB_DATASET
+            """.format(schema))
+        record = next(cursor)
+        self.assertIsNotNone(record)
+        t_id_dataset = record[0]
+        self.assertEqual(record[1], dataset_name)
+
+        # check --importBID
+        expected_basket_name = 'CIAF_LADM.Catastro'
+
+        cursor.execute("""SELECT T_Id, T_Ili_Tid 
+            FROM {}T_ILI2DB_BASKET WHERE dataset={}""".format(schema, t_id_dataset))
+
+        record = next(cursor)
+        self.assertIsNotNone(record)
+        t_id_basket = record[0]
+        self.assertEqual(record[1], expected_basket_name)
+
+        # check --importTID
+        expected_t_ili_tid = '1'
+
+        cursor.execute("""SELECT T_Ili_Tid 
+            FROM {}avaluo WHERE T_basket = {}""".format(schema, t_id_basket))
+
+        record = next(cursor)
+        self.assertIsNotNone(record)
+        self.assertEqual(record[0], expected_t_ili_tid)
+
+    def print_info(self, text):
+        logging.info(text)
+
+    def print_error(self, text):
+        logging.error(text)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Run after all tests."""
+        shutil.rmtree(cls.base_test_path, True)

--- a/QgisModelBaker/tests/utils.py
+++ b/QgisModelBaker/tests/utils.py
@@ -23,7 +23,8 @@ from subprocess import call
 
 from QgisModelBaker.libili2db import ili2dbconfig
 from QgisModelBaker.libili2db.globals import DbIliMode
-from QgisModelBaker.libili2db.ili2dbconfig import SchemaImportConfiguration, ExportConfiguration, ImportDataConfiguration, BaseConfiguration
+from QgisModelBaker.libili2db.ili2dbconfig import SchemaImportConfiguration, ExportConfiguration, \
+    ImportDataConfiguration, BaseConfiguration, UpdateDataConfiguration
 from QgisModelBaker.libqgsprojectgen.db_factory.db_simple_factory import DbSimpleFactory
 
 def iliimporter_config(tool=DbIliMode.ili2pg, modeldir=None):
@@ -102,6 +103,30 @@ def ilidataimporter_config(tool=DbIliMode.ili2pg, modeldir=None):
 
     return configuration
 
+
+def iliupdater_config(tool=DbIliMode.ili2pg, modeldir=None):
+    base_config = BaseConfiguration()
+    if modeldir is None:
+        base_config.custom_model_directories_enabled = False
+    else:
+        base_config.custom_model_directories = testdata_path(modeldir)
+        base_config.custom_model_directories_enabled = True
+
+    configuration = UpdateDataConfiguration()
+    if tool == DbIliMode.ili2pg:
+        configuration.dbhost = os.environ['PGHOST']
+        configuration.dbusr = 'docker'
+        configuration.dbpwd = 'docker'
+        configuration.database = 'gis'
+    elif tool == DbIliMode.ili2mssql:
+        configuration.dbhost = 'mssql'
+        configuration.dbusr = 'sa'
+        configuration.dbpwd = '<YourStrong!Passw0rd>'
+        configuration.database = 'gis'
+
+    configuration.base_configuration = base_config
+
+    return configuration
 
 @pytest.mark.skip('This is a utility function, not a test function')
 def testdata_path(path):

--- a/QgisModelBaker/utils/qt_utils.py
+++ b/QgisModelBaker/utils/qt_utils.py
@@ -20,6 +20,8 @@
 
 import os.path
 import functools
+from abc import ABCMeta
+
 from qgis.PyQt.QtWidgets import (
     QFileDialog,
     QApplication
@@ -238,3 +240,14 @@ class OverrideCursor():
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         QApplication.restoreOverrideCursor()
+
+
+class AbstractQObjectMeta(ABCMeta, type(QObject)):
+    """Metaclass that is used by any class that must be abstract and inherit from QObject.
+
+    If a class must be abstract (ABC or ABCMeta) and inherit from QObject, multiple inheritance fails because
+    the classes have different metaclasses. See more:
+
+    https://stackoverflow.com/questions/46837947/how-to-create-an-abstract-base-class-in-python-which-derived-from-qobject
+    """
+    pass


### PR DESCRIPTION
QgisModelBaker allows users to run these ili2db operations: Schema Import, Import, and Export.

This PR adds update operation support at the API level (class **Updater**). Because **Importer** and **Exporter** classes have a lot of common code and **Updater** would have the same code, this PR refactors that common code moving it to the new class **IliExecutable**. Also, it was created a specific configuration class: UpdateDataConfiguration.

### Class diagram

![image](https://user-images.githubusercontent.com/29440924/94071756-1073f280-fdba-11ea-85fc-dac5ed306021.png)

