### PR TITLE
Add support for filtering domain values for extended domains

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/dataobjects/fields.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/fields.py
@@ -32,6 +32,7 @@ class Field:
         self.widget = None
         self.widget_config = dict()
         self.default_value_expression = None
+        self.enum_domain = None
 
     def dump(self):
         definition = dict()

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
@@ -19,14 +19,17 @@
 """
 from typing import List
 
-from QgisModelBaker.libqgsprojectgen.dataobjects.relations import Relation
-from .layers import Layer
-from .legend import LegendGroup
 from qgis.core import (QgsCoordinateReferenceSystem,
                        QgsProject,
                        QgsEditorWidgetSetup,
                        QgsFieldConstraints)
 from qgis.PyQt.QtCore import QObject, pyqtSignal
+
+from QgisModelBaker.libqgsprojectgen.dataobjects.layers import Layer
+from QgisModelBaker.libqgsprojectgen.dataobjects.legend import LegendGroup
+from QgisModelBaker.libqgsprojectgen.dataobjects.relations import Relation
+
+ENUM_THIS_CLASS_COLUMN = "thisclass"
 
 
 class Project(QObject):
@@ -115,13 +118,19 @@ class Project(QObject):
             referencing_field_constraints = referencing_layer.fieldConstraints(rel.referencingFields()[0])
             allow_null = not bool(referencing_field_constraints & QgsFieldConstraints.ConstraintNotNull)
 
+            # If we have an extended ili2db domain, we need to filter its values
+            filter_expression = "\"{}\" = '{}'".format(ENUM_THIS_CLASS_COLUMN,
+                                                       relation.child_domain_name) if relation.child_domain_name else ''
+
             if rel.referencedLayerId() in dict_domains and dict_domains[rel.referencedLayerId()]:
                 editor_widget_setup = QgsEditorWidgetSetup('RelationReference', {
                     'Relation': rel.id(),
                     'ShowForm': False,
                     'OrderByValue': True,
                     'ShowOpenFormButton': False,
-                    'AllowNULL': allow_null
+                    'AllowNULL': allow_null,
+                    'FilterExpression': filter_expression,
+                    'FilterFields': list()
                 }
                 )
             else:

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/relations.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/relations.py
@@ -11,6 +11,7 @@ class Relation(object):
         self.referenced_field = None
         self.name = None
         self.strength = QgsRelation.Association
+        self.child_domain_name = None
         self.qgis_relation = None
         self._id = None
 
@@ -21,6 +22,7 @@ class Relation(object):
         definition['referencedLayer'] = self.referenced_layer
         definition['referencedField'] = self.referenced_field
         definition['strength'] = self.strength
+        definition['child_domain_name'] = self.child_domain_name
 
         return definition
 
@@ -30,6 +32,7 @@ class Relation(object):
         self.referenced_layer = definition['referencedLayer']
         self.referenced_field = definition['referencedField']
         self.strength = definition['strength']
+        self.child_domain_name = definition['child_domain_name']
 
     def create(self, qgis_project, relations):
         relation = QgsRelation()

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
@@ -211,8 +211,8 @@ class DBConnector(QObject):
 
         return tables + referencing_tables
 
-    def get_iliname_dbname_mapping(self, sqlnames):
-        """Used for ili2db version 3 relation creation"""
+    def get_iliname_dbname_mapping(self, sqlnames=list()):
+        """Note: the parameter sqlnames is only used for ili2db version 3 relation creation"""
         return {}
 
     def get_classili_classdb_mapping(self, models_info, extended_classes):

--- a/QgisModelBaker/tests/testdata/ilimodels/ColorsParentChildDomain.ili
+++ b/QgisModelBaker/tests/testdata/ilimodels/ColorsParentChildDomain.ili
@@ -1,0 +1,37 @@
+INTERLIS 2.3;
+
+MODEL Colors (es)
+AT "mailto:PC-1@localhost"
+VERSION "2020-08-26"  =
+
+  DOMAIN
+
+    DomBaseColorType = (
+      Green,
+      Red,
+      Blue
+    );
+
+    DomChildColorType
+    EXTENDS DomBaseColorType = (
+      Blue(
+        Dark_Blue,
+        Light_Blue,
+        Medium_Blue
+      )
+    );
+
+  TOPIC Colors =
+
+    CLASS BaseColor (ABSTRACT) =
+      ColorType : Colors.DomBaseColorType;
+    END BaseColor;
+
+    CLASS ChildColor
+    EXTENDS BaseColor =
+      ColorType (EXTENDED) : Colors.DomChildColorType;
+    END ChildColor;
+
+  END Colors;
+
+END Colors.


### PR DESCRIPTION
With ili2db 4.4.4 we have an update in domain inheritance.

If DomainB extends DomainA in the conceptual model, we end up with a single table in the database containing all values from DomainA plus all values from DomainB (there may be even repeated values if the value is let untouched from the parent domain). 

Example (single table where we have both parent and child domain values):
![image](https://user-images.githubusercontent.com/652785/96141701-e5675500-0ec6-11eb-9013-5309d91f5bef.png)

Therefore, for letting users pick a value from DomainB, we need to filter the values from the database.

The way of doing this is the following:

1. Read the `tag` "ch.ehi.ili2db.enumDomain" (new in ili2db 4.4.4) from table `t_ili2db_column_prop` and store it in a Field object.
2. When creating Relation objects, inspect the referenced table to know if we deal with domain-class relation. If so, go to referencing field and get its enumDomain `setting`.
3. If the corresponding `setting` value is NOT found in `t_ili2b_classname` (field `iliname`), then we have the inheritance case (a domain that extends another domain).
  3.a. For that particular case, store a `child_domain_name` in the Relation object.
  3.b. When configuring widgets, take `child_domain_name` into account for domain RelationReferences (`FilterExpression`: `"thisclass" = 'setting_value').
4. Otherwise, the domain will be a single table and will not need any filter.


See more details at https://github.com/claeis/ili2db/issues/362