### PR TITLE
Schema creation on XTF import

### DIFF
--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -32,6 +32,7 @@ from QgisModelBaker.libili2db.ili2dbutils import (
 )
 from ..libqgsprojectgen.db_factory.db_simple_factory import DbSimpleFactory
 from QgisModelBaker.libili2db.globals import DbIliMode, displayDbIliMode, DbActionType
+from ..libqgsprojectgen.dbconnector.db_connector import DBConnectorError
 
 from QgisModelBaker.utils.qt_utils import (
     make_file_selector,

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -345,20 +345,12 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         Returns the ili2db version the database has been created with or None if the database
         could not be detected as a ili2db database
         """
-        schema = configuration.dbschema
+        db_connector = self.__db_connector(configuration)
 
-        db_factory = self.db_simple_factory.create_factory(configuration.tool)
-        config_manager = db_factory.get_db_command_config_manager(configuration)
-        uri_string = config_manager.get_uri(configuration.db_use_super_login)
-
-        db_connector = None
-
-        try:
-            db_connector = db_factory.get_db_connector(uri_string, schema)
-            db_connector.new_message.connect(self.show_message)
+        if db_connector:
             return db_connector.ili_version()
-        except (DBConnectorError, FileNotFoundError):
-            return None
+
+        return None
 
     def updated_configuration(self):
         """
@@ -383,16 +375,10 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         configuration.base_configuration = self.base_configuration
         configuration.db_ili_version = self.db_ili_version(configuration)
 
-        try:
-            db_factory = self.db_simple_factory.create_factory(configuration.tool)
-            config_manager = db_factory.get_db_command_config_manager(configuration)
-            db_connector = db_factory.get_db_connector(
-                config_manager.get_uri(configuration.db_use_super_login) or config_manager.get_uri(),
-                configuration.dbschema)
-            if not db_connector.db_or_schema_exists():
-                configuration.with_schemaimport = True
-        except (DBConnectorError, FileNotFoundError):
-            configuration.with_schemaimport = True
+        configuration.with_schemaimport = True
+        db_connector = self.__db_connector(configuration)
+        if db_connector and db_connector.db_or_schema_exists():
+            configuration.with_schemaimport = False
 
         if not self.validate_data:
             configuration.disable_validation = True
@@ -518,3 +504,15 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         elif text.strip() == 'Info: create table structure...':
             self.progress_bar.setValue(75)
             QCoreApplication.processEvents()
+
+    def __db_connector(self, configuration):
+        db_factory = self.db_simple_factory.create_factory(configuration.tool)
+        config_manager = db_factory.get_db_command_config_manager(configuration)
+        try:
+            db_connector = db_factory.get_db_connector(
+                config_manager.get_uri(configuration.db_use_super_login) or config_manager.get_uri(),
+                configuration.dbschema)
+            db_connector.new_message.connect(self.show_message)
+            return db_connector
+        except (DBConnectorError, FileNotFoundError):
+            return None

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -383,6 +383,17 @@ class ImportDataDialog(QDialog, DIALOG_UI):
         configuration.base_configuration = self.base_configuration
         configuration.db_ili_version = self.db_ili_version(configuration)
 
+        try:
+            db_factory = self.db_simple_factory.create_factory(configuration.tool)
+            config_manager = db_factory.get_db_command_config_manager(configuration)
+            db_connector = db_factory.get_db_connector(
+                config_manager.get_uri(configuration.db_use_super_login) or config_manager.get_uri(),
+                configuration.dbschema)
+            if not db_connector.db_or_schema_exists():
+                configuration.with_schemaimport = True
+        except (DBConnectorError, FileNotFoundError):
+            configuration.with_schemaimport = True
+
         if not self.validate_data:
             configuration.disable_validation = True
         return configuration

--- a/QgisModelBaker/gui/panel/gpkg_config_panel.py
+++ b/QgisModelBaker/gui/panel/gpkg_config_panel.py
@@ -27,6 +27,8 @@ from QgisModelBaker.utils.qt_utils import (
 
 from .db_config_panel import DbConfigPanel
 from ...utils import get_ui_class
+from QgisModelBaker.libili2db.globals import DbActionType
+
 WIDGET_UI = get_ui_class('gpkg_settings_panel.ui')
 
 
@@ -50,7 +52,8 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
 
         self.gpkgSaveFileValidator = FileValidator(
             pattern=['*.' + ext for ext in self.ValidExtensions], allow_non_existing=True)
-        self.gpkgOpenFileValidator = FileValidator(pattern=['*.' + ext for ext in self.ValidExtensions])
+        self.gpkgOpenFileValidator = FileValidator(pattern=['*.' + ext for ext in self.ValidExtensions],
+                                                   allow_non_existing=(True if self._db_action_type == DbActionType.IMPORT_DATA else False))
         self.gpkg_file_line_edit.textChanged.connect(
             self.validators.validate_line_edits)
 

--- a/QgisModelBaker/gui/panel/gpkg_config_panel.py
+++ b/QgisModelBaker/gui/panel/gpkg_config_panel.py
@@ -53,7 +53,7 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
         self.gpkgSaveFileValidator = FileValidator(
             pattern=['*.' + ext for ext in self.ValidExtensions], allow_non_existing=True)
         self.gpkgOpenFileValidator = FileValidator(pattern=['*.' + ext for ext in self.ValidExtensions],
-                                                   allow_non_existing=(True if self._db_action_type == DbActionType.IMPORT_DATA else False))
+                                                   allow_non_existing=(self._db_action_type == DbActionType.IMPORT_DATA))
         self.gpkg_file_line_edit.textChanged.connect(
             self.validators.validate_line_edits)
 

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -275,6 +275,7 @@ class ImportDataConfiguration(SchemaImportConfiguration):
         self.with_importtid = False
         self.dataset = ''
         self.baskets = list()
+        self.with_schemaimport = False
 
     def to_ili2db_args(self, extra_args=[], with_action=True):
         args = list()
@@ -282,8 +283,8 @@ class ImportDataConfiguration(SchemaImportConfiguration):
         if with_action:
             args += ["--import"]
 
-        # No schema import, see https://github.com/opengisch/QgisModelBaker/issues/322
-        # args += ["--doSchemaImport"]
+        if self.with_schemaimport:
+            args += ["--doSchemaImport"]
 
         if self.disable_validation:
             args += ["--disableValidation"]


### PR DESCRIPTION
Re-introduce parameter `--doSchemaImport` when the file (Geopackage) or the db schema (PG, MSSQL) does not exist.

Fixes #349