### PR TITLE
Support arguments with spaces and quotes

### DIFF
--- a/QgisModelBaker/libili2db/iliexecutable.py
+++ b/QgisModelBaker/libili2db/iliexecutable.py
@@ -89,17 +89,28 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
             return self.ILI2DB_NOT_FOUND
         return ["-jar", ili2db_bin]
 
+    def _escaped_arg(self, argument):
+        if '"' in argument:
+            argument = argument.replace('"', '"""')
+        if ' ' in argument:
+            argument = ('"'+argument+'"')
+        return argument
+
     def command(self, hide_password):
         ili2db_jar_arg = self._ili2db_jar_arg()
         args = self._args(hide_password)
-        java_path = get_java_path(self.configuration.base_configuration)
-
+        java_path = self._escaped_arg(get_java_path(self.configuration.base_configuration))
         command_args = ili2db_jar_arg + args
-        command = java_path + ' ' + ' '.join(command_args)
+
+        valid_args = []
+        for command_arg in command_args:
+            valid_args.append(self._escaped_arg(command_arg))
+
+        command = java_path + ' ' + ' '.join(valid_args)
 
         return command
 
-    def command_with_password(self, edited_command=None):
+    def command_with_password(self, edited_command):
         if '--dbpwd ******' in edited_command:
             args = self._args(False)
             i = args.index('--dbpwd')

--- a/QgisModelBaker/libili2db/iliexecutable.py
+++ b/QgisModelBaker/libili2db/iliexecutable.py
@@ -93,7 +93,7 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
         if '"' in argument:
             argument = argument.replace('"', '"""')
         if ' ' in argument:
-            argument = ('"'+argument+'"')
+            argument = '"' + argument + '"'
         return argument
 
     def command(self, hide_password):

--- a/QgisModelBaker/libili2db/iliexecutable.py
+++ b/QgisModelBaker/libili2db/iliexecutable.py
@@ -135,6 +135,8 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
 
         if not edited_command:
             ili2db_jar_arg = self._ili2db_jar_arg()
+            if ili2db_jar_arg == self.ILI2DB_NOT_FOUND:
+                return self.ILI2DB_NOT_FOUND
             args = self._args(False)
             java_path = get_java_path(self.configuration.base_configuration)
             proc.start(java_path, ili2db_jar_arg + args)


### PR DESCRIPTION
In the normal call of `QProcess` we use an array of arguments again instead of passing always a command.

If the command is edited, we pass the command. There a slight escaping is done by replacing `"` by `"""` and putting arguments with spaces into doublequotes.

This fixes #444