### PR TITLE
Drop XTF followup - ask the user if using Model Baker or QGIS default behavior

### DIFF
--- a/QgisModelBaker/gui/drop_message.py
+++ b/QgisModelBaker/gui/drop_message.py
@@ -40,8 +40,8 @@ class DropMessageDialog(QDialog, DIALOG_UI):
     def handle_dropped_file_configuration(self, handle_dropped):
         settings = QSettings()
         if not self.chk_dontask.isChecked():
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.ASK.value)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.ASK.name)
         elif handle_dropped:
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.YES.value)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.YES.name)
         else:
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.NO.value)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.NO.name)

--- a/QgisModelBaker/gui/drop_message.py
+++ b/QgisModelBaker/gui/drop_message.py
@@ -18,6 +18,7 @@
  ***************************************************************************/
 """
 from QgisModelBaker.utils import get_ui_class
+from QgisModelBaker.libili2db.globals import DropMode
 
 from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox
 from qgis.PyQt.QtCore import QSettings
@@ -36,5 +37,9 @@ class DropMessageDialog(QDialog, DIALOG_UI):
 
     def handle_dropped_file_configuration(self, handle_dropped):
         settings = QSettings()
-        settings.setValue('QgisModelBaker/handle_dropped_file/ask', not self.chk_dontask.isChecked())
-        settings.setValue('QgisModelBaker/handle_dropped_file/handle', handle_dropped)
+        if not self.chk_dontask.isChecked():
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.ask)
+        elif handle_dropped:
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.yes)
+        else:
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.no)

--- a/QgisModelBaker/gui/drop_message.py
+++ b/QgisModelBaker/gui/drop_message.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+                              -------------------
+        begin                : 27.08.2020
+        git sha              : :%H$
+        copyright            : (C) 2020 by Dave Signer
+        email                : david at opengis ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+from QgisModelBaker.utils import get_ui_class
+
+from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox
+from qgis.PyQt.QtCore import QSettings
+from qgis.gui import QgsGui
+
+DIALOG_UI = get_ui_class('drop_message.ui')
+
+class DropMessageDialog(QDialog, DIALOG_UI):
+
+    def __init__(self, parent=None):
+        QDialog.__init__(self, parent)
+        self.setupUi(self)
+        QgsGui.instance().enableAutoGeometryRestore(self)
+        self.accepted.connect(lambda: self.handle_dropped_file_configuration(True))
+        self.rejected.connect(lambda: self.handle_dropped_file_configuration(False))
+
+    def handle_dropped_file_configuration(self, handle_dropped):
+        settings = QSettings()
+        settings.setValue('QgisModelBaker/handle_dropped_file/ask', not self.chk_dontask.isChecked())
+        settings.setValue('QgisModelBaker/handle_dropped_file/handle', handle_dropped)

--- a/QgisModelBaker/gui/drop_message.py
+++ b/QgisModelBaker/gui/drop_message.py
@@ -17,6 +17,7 @@
  *                                                                         *
  ***************************************************************************/
 """
+
 from QgisModelBaker.utils import get_ui_class
 from QgisModelBaker.libili2db.globals import DropMode
 
@@ -28,18 +29,19 @@ DIALOG_UI = get_ui_class('drop_message.ui')
 
 class DropMessageDialog(QDialog, DIALOG_UI):
 
-    def __init__(self, parent=None):
+    def __init__(self, file_name, parent=None):
         QDialog.__init__(self, parent)
         self.setupUi(self)
         QgsGui.instance().enableAutoGeometryRestore(self)
+        self.info_label.setText(self.tr('Do you want to use the Model Baker plugin to handle file {}?').format(file_name))
         self.accepted.connect(lambda: self.handle_dropped_file_configuration(True))
         self.rejected.connect(lambda: self.handle_dropped_file_configuration(False))
 
     def handle_dropped_file_configuration(self, handle_dropped):
         settings = QSettings()
         if not self.chk_dontask.isChecked():
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.ask)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.ask.value)
         elif handle_dropped:
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.yes)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.yes.value)
         else:
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.no)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.no.value)

--- a/QgisModelBaker/gui/drop_message.py
+++ b/QgisModelBaker/gui/drop_message.py
@@ -40,8 +40,8 @@ class DropMessageDialog(QDialog, DIALOG_UI):
     def handle_dropped_file_configuration(self, handle_dropped):
         settings = QSettings()
         if not self.chk_dontask.isChecked():
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.ask.value)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.ASK.value)
         elif handle_dropped:
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.yes.value)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.YES.value)
         else:
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.no.value)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.NO.value)

--- a/QgisModelBaker/gui/options.py
+++ b/QgisModelBaker/gui/options.py
@@ -19,7 +19,7 @@
 """
 import webbrowser
 
-from QgisModelBaker.libili2db.globals import DbIliMode, displayDbIliMode
+from QgisModelBaker.libili2db.globals import DbIliMode, displayDbIliMode, DropMode
 from QgisModelBaker.libqgsprojectgen.db_factory.db_simple_factory import DbSimpleFactory
 from QgisModelBaker.libili2db.ili2dbconfig import SchemaImportConfiguration, ImportDataConfiguration, \
     ExportConfiguration
@@ -43,6 +43,9 @@ class OptionsDialog(QDialog, DIALOG_UI):
 
         self.pg_user_line_edit.setText(configuration.super_pg_user)
         self.pg_password_line_edit.setText(configuration.super_pg_password)
+        settings = QSettings()
+        print(settings.fileName())
+        self.chk_dontask_to_handle_dropped_files.setChecked(DropMode(settings.value('QgisModelBaker/drop_mode', defaultValue=3)) != DropMode.ask)
 
         self.custom_model_directories_line_edit.setText(
             configuration.custom_model_directories)
@@ -92,7 +95,9 @@ class OptionsDialog(QDialog, DIALOG_UI):
         self.configuration.super_pg_user = self.pg_user_line_edit.text()
         self.configuration.super_pg_password = self.pg_password_line_edit.text()
 
-        self.configuration.ask_to_handle_dropped_files = self.chk_dontask.isChecked()
+        settings = QSettings()
+        if not self.chk_dontask_to_handle_dropped_files.isChecked():
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.ask.value)
 
     def show_custom_model_dir(self):
         dlg = CustomModelDirDialog(

--- a/QgisModelBaker/gui/options.py
+++ b/QgisModelBaker/gui/options.py
@@ -92,6 +92,8 @@ class OptionsDialog(QDialog, DIALOG_UI):
         self.configuration.super_pg_user = self.pg_user_line_edit.text()
         self.configuration.super_pg_password = self.pg_password_line_edit.text()
 
+        self.configuration.ask_to_handle_dropped_files = self.chk_dontask.isChecked()
+
     def show_custom_model_dir(self):
         dlg = CustomModelDirDialog(
             self.custom_model_directories_line_edit.text(), self)

--- a/QgisModelBaker/gui/options.py
+++ b/QgisModelBaker/gui/options.py
@@ -84,8 +84,8 @@ class OptionsDialog(QDialog, DIALOG_UI):
 
         settings = QSettings()
         drop_mode = DropMode(settings.value('QgisModelBaker/drop_mode', 3, int))
-        self.chk_dontask_to_handle_dropped_files.setEnabled(drop_mode != DropMode.ask)
-        self.chk_dontask_to_handle_dropped_files.setChecked(drop_mode != DropMode.ask)
+        self.chk_dontask_to_handle_dropped_files.setEnabled(drop_mode != DropMode.ASK)
+        self.chk_dontask_to_handle_dropped_files.setChecked(drop_mode != DropMode.ASK)
 
     def accepted(self):
         self.configuration.custom_model_directories = self.custom_model_directories_line_edit.text()
@@ -99,7 +99,7 @@ class OptionsDialog(QDialog, DIALOG_UI):
 
         settings = QSettings()
         if not self.chk_dontask_to_handle_dropped_files.isChecked():
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.ask.value)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.ASK.value)
 
     def show_custom_model_dir(self):
         dlg = CustomModelDirDialog(

--- a/QgisModelBaker/gui/options.py
+++ b/QgisModelBaker/gui/options.py
@@ -83,7 +83,7 @@ class OptionsDialog(QDialog, DIALOG_UI):
         self.ili2db_command_reload()
 
         settings = QSettings()
-        drop_mode = DropMode(settings.value('QgisModelBaker/drop_mode', 3, int))
+        drop_mode = DropMode[settings.value('QgisModelBaker/drop_mode', DropMode.ASK.name, str)]
         self.chk_dontask_to_handle_dropped_files.setEnabled(drop_mode != DropMode.ASK)
         self.chk_dontask_to_handle_dropped_files.setChecked(drop_mode != DropMode.ASK)
 
@@ -99,7 +99,7 @@ class OptionsDialog(QDialog, DIALOG_UI):
 
         settings = QSettings()
         if not self.chk_dontask_to_handle_dropped_files.isChecked():
-            settings.setValue('QgisModelBaker/drop_mode', DropMode.ASK.value)
+            settings.setValue('QgisModelBaker/drop_mode', DropMode.ASK.name)
 
     def show_custom_model_dir(self):
         dlg = CustomModelDirDialog(

--- a/QgisModelBaker/gui/options.py
+++ b/QgisModelBaker/gui/options.py
@@ -43,9 +43,6 @@ class OptionsDialog(QDialog, DIALOG_UI):
 
         self.pg_user_line_edit.setText(configuration.super_pg_user)
         self.pg_password_line_edit.setText(configuration.super_pg_password)
-        settings = QSettings()
-        print(settings.fileName())
-        self.chk_dontask_to_handle_dropped_files.setChecked(DropMode(settings.value('QgisModelBaker/drop_mode', defaultValue=3)) != DropMode.ask)
 
         self.custom_model_directories_line_edit.setText(
             configuration.custom_model_directories)
@@ -84,6 +81,11 @@ class OptionsDialog(QDialog, DIALOG_UI):
             self.ili2db_command_reload)
 
         self.ili2db_command_reload()
+
+        settings = QSettings()
+        drop_mode = DropMode(settings.value('QgisModelBaker/drop_mode', defaultValue=3))
+        self.chk_dontask_to_handle_dropped_files.setEnabled(drop_mode != DropMode.ask)
+        self.chk_dontask_to_handle_dropped_files.setChecked(drop_mode != DropMode.ask)
 
     def accepted(self):
         self.configuration.custom_model_directories = self.custom_model_directories_line_edit.text()

--- a/QgisModelBaker/gui/options.py
+++ b/QgisModelBaker/gui/options.py
@@ -83,7 +83,7 @@ class OptionsDialog(QDialog, DIALOG_UI):
         self.ili2db_command_reload()
 
         settings = QSettings()
-        drop_mode = DropMode(settings.value('QgisModelBaker/drop_mode', defaultValue=3))
+        drop_mode = DropMode(settings.value('QgisModelBaker/drop_mode', 3, int))
         self.chk_dontask_to_handle_dropped_files.setEnabled(drop_mode != DropMode.ask)
         self.chk_dontask_to_handle_dropped_files.setChecked(drop_mode != DropMode.ask)
 

--- a/QgisModelBaker/libili2db/globals.py
+++ b/QgisModelBaker/libili2db/globals.py
@@ -49,6 +49,10 @@ displayDbIliMode = {
     DbIliMode.ili2mssql: QCoreApplication.translate('QgisModelBaker', 'Interlis (use SQL Server)')
 }
 
+class DropMode(IntFlag):
+    yes = 1
+    no = 2
+    ask = 3
 
 class DbActionType(Enum):
     """Defines constants for generate, import data, or export actions of QgisModelBaker.

--- a/QgisModelBaker/libili2db/globals.py
+++ b/QgisModelBaker/libili2db/globals.py
@@ -49,7 +49,7 @@ displayDbIliMode = {
     DbIliMode.ili2mssql: QCoreApplication.translate('QgisModelBaker', 'Interlis (use SQL Server)')
 }
 
-class DropMode(IntFlag):
+class DropMode(Enum):
     yes = 1
     no = 2
     ask = 3

--- a/QgisModelBaker/libili2db/globals.py
+++ b/QgisModelBaker/libili2db/globals.py
@@ -50,9 +50,9 @@ displayDbIliMode = {
 }
 
 class DropMode(Enum):
-    yes = 1
-    no = 2
-    ask = 3
+    YES = 1
+    NO = 2
+    ASK = 3
 
 class DbActionType(Enum):
     """Defines constants for generate, import data, or export actions of QgisModelBaker.

--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -39,6 +39,7 @@ from qgis.PyQt.QtGui import QIcon
 
 from QgisModelBaker.gui.options import OptionsDialog
 from QgisModelBaker.libili2db.ili2dbconfig import BaseConfiguration
+from QgisModelBaker.libili2db.globals import DropMode
 
 import pyplugin_installer
 
@@ -303,11 +304,13 @@ class DropFileFilter(QObject):
 
     def handle_dropped_file(self):
         settings = QSettings()
-        if settings.value('QgisModelBaker/handle_dropped_file/ask', defaultValue=True, type=bool):
+        drop_mode = settings.value('QgisModelBaker/drop_mode', defaultValue=DropMode.ask, type=DropMode)
+
+        if drop_mode == DropMode.ask:
             drop_message_dialog = DropMessageDialog()
             return drop_message_dialog.exec_()
         else:
-            return settings.value('QgisModelBaker/handle_dropped_file/handle', defaultValue=True, type=bool)
+            return drop_mode == DropMode.yes
 
     def eventFilter(self, obj, event):
         """

--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -304,7 +304,7 @@ class DropFileFilter(QObject):
 
     def is_handling_requested(self, file_path):
         settings = QSettings()
-        drop_mode = DropMode(settings.value('QgisModelBaker/drop_mode', defaultValue=3))
+        drop_mode = DropMode(settings.value('QgisModelBaker/drop_mode', 3, int))
         if drop_mode == DropMode.ask:
             drop_message_dialog = DropMessageDialog(os.path.basename(file_path))
             return drop_message_dialog.exec_()

--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -305,10 +305,10 @@ class DropFileFilter(QObject):
     def is_handling_requested(self, file_path):
         settings = QSettings()
         drop_mode = DropMode(settings.value('QgisModelBaker/drop_mode', 3, int))
-        if drop_mode == DropMode.ask:
+        if drop_mode == DropMode.ASK:
             drop_message_dialog = DropMessageDialog(os.path.basename(file_path))
             return drop_message_dialog.exec_()
-        return drop_mode == DropMode.yes
+        return drop_mode == DropMode.YES
 
     def eventFilter(self, obj, event):
         """

--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -303,12 +303,14 @@ class DropFileFilter(QObject):
         self.parent = parent
 
     def is_handling_requested(self, file_path):
-        settings = QSettings()
-        drop_mode = DropMode(settings.value('QgisModelBaker/drop_mode', 3, int))
-        if drop_mode == DropMode.ASK:
-            drop_message_dialog = DropMessageDialog(os.path.basename(file_path))
-            return drop_message_dialog.exec_()
-        return drop_mode == DropMode.YES
+        if pathlib.Path(file_path).suffix[1:] in ['xtf', 'XTF', 'itf', 'ITF']:
+            settings = QSettings()
+            drop_mode = DropMode[settings.value('QgisModelBaker/drop_mode', DropMode.ASK.name, str)]
+            if drop_mode == DropMode.ASK:
+                drop_message_dialog = DropMessageDialog(os.path.basename(file_path))
+                return drop_message_dialog.exec_()
+            return drop_mode == DropMode.YES
+        return False
 
     def eventFilter(self, obj, event):
         """

--- a/QgisModelBaker/ui/drop_message.ui
+++ b/QgisModelBaker/ui/drop_message.ui
@@ -37,7 +37,7 @@
    <item row="1" column="0">
     <widget class="QCheckBox" name="chk_dontask">
      <property name="text">
-      <string>Apply behavior for all XTF / ITF files (you can undo this in the Model Baker settings)</string>
+      <string>Remember my decision and don't ask me again (you can undo this in the Model Baker settings)</string>
      </property>
     </widget>
    </item>

--- a/QgisModelBaker/ui/drop_message.ui
+++ b/QgisModelBaker/ui/drop_message.ui
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DropMessage</class>
+ <widget class="QDialog" name="DropMessage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>516</width>
+    <height>95</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Handle Import Files</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::No|QDialogButtonBox::Yes</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_info">
+     <property name="text">
+      <string>Do you want to use the Qgis Model Baker plugin to handle XTF/ ITF files?</string>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="chk_dontask">
+     <property name="text">
+      <string>Don't ask again (you can undo this in the Qgis Model Baker settigns)</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>button_box</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>DropMessage</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>DropMessage</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/QgisModelBaker/ui/drop_message.ui
+++ b/QgisModelBaker/ui/drop_message.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>516</width>
-    <height>95</height>
+    <width>481</width>
+    <height>112</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,9 +25,9 @@
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="QLabel" name="label_info">
+    <widget class="QLabel" name="info_label">
      <property name="text">
-      <string>Do you want to use the Qgis Model Baker plugin to handle XTF/ ITF files?</string>
+      <string>Do you want to use the Model Baker plugin to handle XTF/ ITF files?</string>
      </property>
      <property name="openExternalLinks">
       <bool>true</bool>
@@ -37,7 +37,7 @@
    <item row="1" column="0">
     <widget class="QCheckBox" name="chk_dontask">
      <property name="text">
-      <string>Don't ask again (you can undo this in the Qgis Model Baker settigns)</string>
+      <string>Apply behavior for all XTF / ITF files (you can undo this in the Model Baker settings)</string>
      </property>
     </widget>
    </item>

--- a/QgisModelBaker/ui/options.ui
+++ b/QgisModelBaker/ui/options.ui
@@ -30,16 +30,6 @@
        <string>General</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_3">
-       <item row="1" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The less options, the better the software&lt;/p&gt;&lt;p&gt;&lt;i&gt;Aristotle, 343 BC&lt;/i&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::RichText</enum>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="0">
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
@@ -78,6 +68,23 @@
            </widget>
           </item>
          </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The less options, the better the software&lt;/p&gt;&lt;p&gt;&lt;i&gt;Aristotle, 343 BC&lt;/i&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="chk_dontask_to_handle_dropped_files">
+         <property name="text">
+          <string> Don't ask the user to handle dropped XTF / ITF with this plugin or not</string>
+         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
**The behavior is:**
If not XTF / ITF -> QGIS default behavior
If XTF / ITF multiple files -> QGIS default behavior
If XTF / ITF single file -> Dialog asking what to do? -> selected behavior
IF XTF / ITF single file, and selected don't ask again in dialog -> last chosen behavior

> The difference to the last version with multiple files is, that the default behavior is taken instead printing a message: "Model Baker cannot handle multiple dropped files" - this because before the QGIS behavior is "removed" completely and now it's part of the solution, so it should be used still.

When dropping an XTF or an ITF file a dialog is opened:
![baker1](https://user-images.githubusercontent.com/28384354/104313820-e36a5d80-54d8-11eb-9a8f-f2454431c04e.png)

On checking the checkbox, the behavior is used without popping up a dialog in future. To get the dialog again, the user can reset the "check" in the settings. 
![baker2](https://user-images.githubusercontent.com/28384354/104313917-0432b300-54d9-11eb-8944-86158b06fa19.png)
Since there is no need for this setting, when it's not checked in the drop-dialog (because it's not decided if it should use the model baker setting or not) it's a disabled widget.
![image](https://user-images.githubusercontent.com/28384354/104314085-33e1bb00-54d9-11eb-9876-d162d043016f.png)


