### PR TITLE
Fix modeldir support of % values

### DIFF
--- a/QgisModelBaker/libili2db/ili2dbutils.py
+++ b/QgisModelBaker/libili2db/ili2dbutils.py
@@ -105,13 +105,17 @@ def get_ili2db_bin(tool, db_ili_version, stdout, stderr):
 
 def get_all_modeldir_in_path(path, lambdafunction=None):
     all_subdirs = [path[0] for path in os.walk(path)] # include path
-    modeldir = ''
+    # Make sure path is included, it can be a special string like `%XTF_DIR`
+    modeldirs = [path]
     for subdir in all_subdirs:
         if os.path.isdir(subdir) and len(glob.glob(subdir + '/*.ili')) > 0:
             if lambdafunction is not None:
                 lambdafunction(subdir)
-            modeldir += subdir + ';'
-    return modeldir[:-1]  # remove last ';'
+            modeldirs += [subdir]
+
+    # Remove duplicates
+    modeldirs = list(dict.fromkeys(modeldirs))
+    return ';'.join(modeldirs)
 
 
 def color_log_text(text, txt_edit):

--- a/QgisModelBaker/tests/test_ili2dbutils.py
+++ b/QgisModelBaker/tests/test_ili2dbutils.py
@@ -18,7 +18,7 @@ class TestILI2DBUtils(unittest.TestCase):
 
     def test_parse_subdirs_in_parent_dir(self):
         modeldirs = get_all_modeldir_in_path(self.parent_dir)  # Parent folder: testdata
-        expected_dirs = [self.ilimodels, self.ciaf_ladm, self.hidden, self.not_hidden]
+        expected_dirs = [self.parent_dir, self.ilimodels, self.ciaf_ladm, self.hidden, self.not_hidden]
         self.assertEqual(sorted(expected_dirs), sorted(modeldirs.split(";")))
 
     def test_parse_subdirs_in_hidden_dir(self):
@@ -29,10 +29,20 @@ class TestILI2DBUtils(unittest.TestCase):
         modeldirs = get_all_modeldir_in_path(self.not_hidden)
         self.assertEqual(self.not_hidden, modeldirs)
 
+    def test_parse_mixed_dir(self):
+        subparent_dir = testdata_path('ilimodels/subparent_dir')
+        modeldirs = get_all_modeldir_in_path(subparent_dir)
+        expected_dirs = [subparent_dir, self.hidden, self.not_hidden]
+        self.assertEqual(sorted(expected_dirs), sorted(modeldirs.split(";")))
+
     def test_parse_subdirs_in_empty_dir(self):
         modeldirs = get_all_modeldir_in_path(self.empty)
-        self.assertEqual('', modeldirs)
+        self.assertEqual(self.empty, modeldirs)
 
     def test_parse_subdirs_in_not_model_dir(self):
         modeldirs = get_all_modeldir_in_path(self.not_modeldir)
-        self.assertEqual('', modeldirs)
+        self.assertEqual(self.not_modeldir, modeldirs)
+
+    def test_parse_special_strings(self):
+        modeldirs = get_all_modeldir_in_path('%XTF_DIR')
+        self.assertEqual('%XTF_DIR', modeldirs)


### PR DESCRIPTION
The old approach was locally searching for .ili files in the model directories
and recursively adding all of them. The setting actually supports a couple of
magic strings like `%XTF_DIR` and similar which got lost this way because
we couldn't glob them.

This approach always adds all directories from the setting and adds
additional subdirs only if they contain .ili files

Fixes #464