### PR TITLE
Fix Layernames for tables with multiple geometry columns

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -113,7 +113,13 @@ class Generator(QObject):
                 if is_domain and is_attribute:
                     short_name = record['ili_name'].split('.')[-2] + '_' + record['ili_name'].split('.')[-1] if 'ili_name' in record else ''
                 else:
-                    short_name = record['ili_name'].split('.')[-1] if 'ili_name' in record else ''
+                    if 'ili_name' in record:
+                        match = re.search('([^\(]*).*', record['ili_name'])
+                        if match.group(0) == match.group(1):
+                            short_name = match.group(1).split('.')[-1]
+                        else:
+                            #additional brackets in the the name - extended layer in geopackage
+                            short_name = match.group(1).split('.')[-2] + ' (' + match.group(1).split('.')[-1]+')'
                 alias = short_name
 
             display_expression = ''

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -80,8 +80,7 @@ class Generator(QObject):
             self.collected_print_messages.append(message)
 
     def layers(self, filter_layer_list=[]):
-        ignored_layers = self.get_ignored_layers()
-        tables_info = self.get_tables_info()
+        tables_info = self.get_tables_info_without_ignored_tables()
         layers = list()
 
         db_factory = self.db_simple_factory.create_factory(self.tool)
@@ -91,13 +90,10 @@ class Generator(QObject):
 
         # When in PostGIS mode, there can be multiple geometries per table - this leads to multiple layers
         table_appearances = {}
-        check_tables_info=self.get_tables_info()
-        for record in check_tables_info:
+        for record in tables_info:
             if self.schema:
                 if record['schemaname'] != self.schema:
                     continue
-            if ignored_layers and record['tablename'] in ignored_layers:
-                continue
             if filter_layer_list and record['tablename'] not in filter_layer_list:
                 continue
             table_appearances[record['tablename']] = 1 if record['tablename'] not in table_appearances else table_appearances[record['tablename']]+1
@@ -108,8 +104,6 @@ class Generator(QObject):
             if self.schema:
                 if record['schemaname'] != self.schema:
                     continue
-            if ignored_layers and record['tablename'] in ignored_layers:
-                continue
 
             if filter_layer_list and record['tablename'] not in filter_layer_list:
                 continue

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -89,13 +89,25 @@ class Generator(QObject):
         layer_uri = db_factory.get_layer_uri(self.uri)
         layer_uri.pg_estimated_metadata = self.pg_estimated_metadata
 
+        # When in PostGIS mode, there can be multiple geometries per table - this leads to multiple layers
+        table_appearances = {}
+        check_tables_info=self.get_tables_info()
+        for record in check_tables_info:
+            if self.schema:
+                if record['schemaname'] != self.schema:
+                    continue
+            if ignored_layers and record['tablename'] in ignored_layers:
+                continue
+            if filter_layer_list and record['tablename'] not in filter_layer_list:
+                continue
+            table_appearances[record['tablename']] = 1 if record['tablename'] not in table_appearances else table_appearances[record['tablename']]+1
+
         for record in tables_info:
             # When in PostGIS mode, leaving schema blank should load tables from
             # all schemas, except the ignored ones
             if self.schema:
                 if record['schemaname'] != self.schema:
                     continue
-
             if ignored_layers and record['tablename'] in ignored_layers:
                 continue
 
@@ -113,7 +125,15 @@ class Generator(QObject):
                 if is_domain and is_attribute:
                     short_name = record['ili_name'].split('.')[-2] + '_' + record['ili_name'].split('.')[-1] if 'ili_name' in record else ''
                 else:
-                    if 'ili_name' in record:
+                    if table_appearances[record['tablename']] > 1 and 'geometry_column' in record:
+                        # multiple layers for this table - append geometry column to name
+                        fields_info = self.get_fields_info(record['tablename'])
+                        for field_info in fields_info:
+                            if field_info['column_name'] == record['geometry_column']:
+                                short_name = field_info['fully_qualified_name'].split('.')[-2] + ' (' + \
+                                             field_info['fully_qualified_name'].split('.')[
+                                                 -1]+')' if 'fully_qualified_name' in field_info else record['tablename']
+                    elif 'ili_name' in record:
                         match = re.search('([^\(]*).*', record['ili_name'])
                         if match.group(0) == match.group(1):
                             short_name = match.group(1).split('.')[-1]

--- a/QgisModelBaker/tests/testdata/toml/multisurface.toml
+++ b/QgisModelBaker/tests/testdata/toml/multisurface.toml
@@ -1,0 +1,2 @@
+[KbS_LV95_V1_4.Belastete_Standorte.MultiPolygon]
+ili2db.mapping = "MultiSurface"


### PR DESCRIPTION
These commits are cherrypicks from the branch of usabilityhub_toppings - I think it's better to consider it seperately.

**GeoPackage:**
fix layernames on tables that are created twice in geopackage  and contain the iliname with brackets (e.g. KbS_LV95_V1_4.Belastete_Standorte.Belasteter_Standort.Geo_Lage_Punkt(KbS_LV95_V1_4.Belastete_Standorte.Belasteter_Standort)) They are now named **Belasteter_Standort (Geo_Lage_Punkt)** This fixes #469

**Postgres:**
On creating layers from a Postgres dataset where a table has multiplegeometry columns, this table is loaded for each geometry column. To have a unique name, we check for duplicate tablenames and if we found one we check out the t_ili2db_attrname for the geometry column and add it's proper name to the table.

