### PR TITLE
Use of models.opengis.ch instead of usabilityhub.opengis.ch

### DIFF
--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -100,7 +100,7 @@ class BaseConfiguration(object):
             dirs = self.custom_model_directories.split(';')
         else:
             dirs = [
-                'https://usabilityhub.opengis.ch/'
+                'https://models.opengis.ch/'
             ]
         return dirs
 

--- a/QgisModelBaker/libili2db/ilicache.py
+++ b/QgisModelBaker/libili2db/ilicache.py
@@ -678,7 +678,7 @@ class IliToppingFileCache(IliMetaConfigCache):
                                     toppingfile['repository'] = netloc
                                     # relative_file_path like qml/something.qml
                                     toppingfile['relative_file_path'] = path
-                                    # url like http://usabilityhub.opengis.ch or /home/nyuki/folder
+                                    # url like http://models.opengis.ch or /home/nyuki/folder
                                     toppingfile['url'] = url
                                     toppingfile['local_file_path'] = self.download_file(netloc, url, path, dataset_id)
                                     repo_files.append(toppingfile)

--- a/QgisModelBaker/tests/testdata/ilirepo/24/ilidata.xml
+++ b/QgisModelBaker/tests/testdata/ilirepo/24/ilidata.xml
@@ -10,7 +10,7 @@
       <DatasetIdx16.DataIndex.Metadata TID="72c20986-b358-48da-b5eb-4fe7f3a0fc12">
         <id>usabilityhub</id>
         <version>2021-01-06</version>
-        <owner>http://usabilityhub.opengis.ch</owner>
+        <owner>http://models.opengis.ch</owner>
         <technicalContact>mailto:david@opengis.ch</technicalContact>
       </DatasetIdx16.DataIndex.Metadata>
 


### PR DESCRIPTION
Because usabilityhub.opengis.ch is for the Website