### PR TITLE
gh workflow - use published as type

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - '**'
   release:
-    types: ['prereleased', 'released']
+    types: [published]
 
 jobs:
   # Run unit tests


### PR DESCRIPTION
because otherwise no workflows are triggered on pre-release