### PR TITLE
No need to explicitly upload artifacts

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -51,12 +51,6 @@ jobs:
       - name: Release
         run: |
           qgis-plugin-ci release ${GITHUB_REF##*/} --transifex-token ${TX_TOKEN} --github-token ${GITHUB_TOKEN} --osgeo-username ${OSGEO_USERNAME} --osgeo-password ${OSGEO_PASSWORD}
-      - name: Upload release assets
-        uses: AButler/upload-release-assets@v2.0
-        with:
-          files: ./QgisModelBaker.${GITHUB_REF##*/}.zip
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          release-tag: ${GITHUB_REF##*/}
 
   translations:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
`qgis-plugin-ci` already automatically uploads the artifacts for you.