### PR TITLE
Fix weird completer behavior

### DIFF
--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -802,7 +802,11 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             self.ili_models_line_edit.completer().setCompletionMode(QCompleter.UnfilteredPopupCompletion)
             self.ili_models_line_edit.completer().complete()
         else:
-            self.ili_models_line_edit.completer().setCompletionMode(QCompleter.PopupCompletion)
+            match_contains = self.ili_models_line_edit.completer().completionModel().match(self.ili_models_line_edit.completer().completionModel().index(0, 0),
+                                            Qt.DisplayRole, self.ili_models_line_edit.text(), -1, Qt.MatchContains)
+            if len(match_contains) > 1:
+                self.ili_models_line_edit.completer().setCompletionMode(QCompleter.PopupCompletion)
+                self.ili_models_line_edit.completer().complete()
 
     def update_models_completer(self):
         completer = QCompleter(self.ilicache.model, self.ili_models_line_edit)
@@ -824,7 +828,12 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
             self.ili_metaconfig_line_edit.completer().setCompletionMode(QCompleter.UnfilteredPopupCompletion)
             self.ili_metaconfig_line_edit.completer().complete()
         else:
-            self.ili_metaconfig_line_edit.completer().setCompletionMode(QCompleter.PopupCompletion)
+            if ';' not in self.ili_metaconfig_line_edit.text():
+                match_contains = self.ili_metaconfig_line_edit.completer().completionModel().match(self.ili_metaconfig_line_edit.completer().completionModel().index(0, 0),
+                                                Qt.DisplayRole, self.ili_metaconfig_line_edit.text(), -1, Qt.MatchContains)
+                if len(match_contains) > 1:
+                    self.ili_metaconfig_line_edit.completer().setCompletionMode(QCompleter.PopupCompletion)
+                    self.ili_metaconfig_line_edit.completer().complete()
 
     def update_metaconfig_completer(self):
         self.ili_metaconfig_line_edit.completer().setModel(self.ilimetaconfigcache.model)

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -465,7 +465,11 @@ class ImportDataDialog(QDialog, DIALOG_UI):
             self.ili_models_line_edit.completer().setCompletionMode(QCompleter.UnfilteredPopupCompletion)
             self.ili_models_line_edit.completer().complete()
         else:
-            self.ili_models_line_edit.completer().setCompletionMode(QCompleter.PopupCompletion)
+            match_contains = self.ili_models_line_edit.completer().completionModel().match(self.ili_models_line_edit.completer().completionModel().index(0, 0),
+                                            Qt.DisplayRole, self.ili_models_line_edit.text(), -1, Qt.MatchContains)
+            if len(match_contains) > 1:
+                self.ili_models_line_edit.completer().setCompletionMode(QCompleter.PopupCompletion)
+                self.ili_models_line_edit.completer().complete()
 
     def update_models_completer(self):
         completer = QCompleter(self.ilicache.model, self.ili_models_line_edit)


### PR DESCRIPTION
Fixes #495
there is the punched signal requesting completion when getting focus or receiving mouse press. then there is the text change signal that requests completion because it's not done per default (i don't know why) and in the end there were two problems:
- does not make a completion on punching when the text is not empty
- does make a weird completion (with random values it seems) when finding one single entry
so it makes a complete() even on having a text and it makes no complete() when finding one single entry.
this might have been solved better, but at the moment I don't see a better sollution.