### PR TITLE
Allow null in relation references always on domains - when the value …

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
@@ -115,10 +115,6 @@ class Project(QObject):
             assert rel.isValid()
             qgis_relations.append(rel)
 
-            referencing_layer = rel.referencingLayer()
-            referencing_field_constraints = referencing_layer.fieldConstraints(rel.referencingFields()[0])
-            allow_null = not bool(referencing_field_constraints & QgsFieldConstraints.ConstraintNotNull)
-
             # If we have an extended ili2db domain, we need to filter its values
             filter_expression = "\"{}\" = '{}'".format(ENUM_THIS_CLASS_COLUMN,
                                                        relation.child_domain_name) if relation.child_domain_name else ''
@@ -141,7 +137,7 @@ class Project(QObject):
                     'OrderByValue': True,
                     'ShowOpenFormButton': False,
                     'AllowAddFeatures': True,
-                    'AllowNULL': allow_null
+                    'AllowNULL': True
                 }
                 )
 

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
@@ -129,7 +129,7 @@ class Project(QObject):
                     'ShowForm': False,
                     'OrderByValue': True,
                     'ShowOpenFormButton': False,
-                    'AllowNULL': allow_null,
+                    'AllowNULL': True,
                     'FilterExpression': filter_expression,
                     'FilterFields': list()
                 }


### PR DESCRIPTION
When the value is mandatory the constraints will concern that the user has to choose something. 
![image](https://user-images.githubusercontent.com/28384354/123435339-c2e91800-d5cd-11eb-873c-14e5cb872b00.png)

Otherwise, the first value of the domain table is chosen automatically, what is not what we want.

This fixes #467