### PR TITLE
Create tabs when the layer is the referenced layer (parent) 

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
@@ -133,7 +133,7 @@ class Layer(object):
         '''
         has_tabs = False
         for relation in project.relations:
-            if relation.referencing_layer == self:
+            if relation.referenced_layer == self:
                 has_tabs = True
                 break
 


### PR DESCRIPTION
and contiins relation editors and **not when it's a referencing layer (child)**

So this one is a referencing layer:
![image](https://user-images.githubusercontent.com/28384354/123437976-8834af00-d5d0-11eb-9bf2-9859aca13d84.png)

And this one is a referenced layer:
![image](https://user-images.githubusercontent.com/28384354/123438047-997dbb80-d5d0-11eb-8ec3-b341d6341994.png)
