### PR TITLE
Fix crash on accessing layer of QgsNodeTreeNode

### DIFF
--- a/QgisModelBaker/utils/qgis_utils.py
+++ b/QgisModelBaker/utils/qgis_utils.py
@@ -17,7 +17,7 @@
  ***************************************************************************/
 """
 
-from qgis.core import QgsLayerTreeNode, QgsWkbTypes, QgsMapLayer
+from qgis.core import QgsLayerTreeNode, QgsWkbTypes, QgsMapLayer, QgsLayerTreeLayer
 
 layer_order = ['point',  #QgsWkbTypes.PointGeometry
                'line',  #QgsWkbTypes.LineGeometry
@@ -48,9 +48,10 @@ def get_first_index_for_layer_type(layer_type, group, ignore_node_names=None):
             # We've reached the lowest index in the layer tree before a group
             return current
 
-        layer = tree_node.layer()
-        if get_layer_type(layer) == layer_type:
-            return current
+        if isinstance(tree_node, QgsLayerTreeLayer):
+            layer = tree_node.layer()
+            if get_layer_type(layer) == layer_type:
+                return current
 
     return None
 


### PR DESCRIPTION
This error occurred on getting through the layer tree to find the index for the new tables
```
AttributeError: 'QgsLayerTreeNode' object has no attribute 'layer' 
Traceback (most recent call last):
  File "/home/dave/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QgisModelBaker/gui/generate_project.py", line 452, in accepted
    project.create(None, qgis_project)
  File "/home/dave/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QgisModelBaker/libqgsprojectgen/dataobjects/project.py", line 186, in create
    self.legend.create(qgis_project)
  File "/home/dave/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QgisModelBaker/libqgsprojectgen/dataobjects/legend.py", line 88, in create
    index = get_suggested_index_for_layer(layer, group, self.ignore_node_names)
  File "/home/dave/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QgisModelBaker/utils/qgis_utils.py", line 71, in get_suggested_index_for_layer
    index = get_first_index_for_layer_type(layer_type, group, ignore_node_names)
  File "/home/dave/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QgisModelBaker/utils/qgis_utils.py", line 51, in get_first_index_for_layer_type
    layer = tree_node.layer()
AttributeError: 'QgsLayerTreeNode' object has no attribute 'layer'
```

This because `tree_node` is not an instance of `QgsLayerTreeLayer` but on `QgsLayerTreeNode` instead.
But why?

I made a test in the console with a weird result:
```
>>> root2 = QgsProject().instance().layerTreeRoot()
>>> root2.children()
[<qgis._core.QgsLayerTreeNode object at 0x7f29f9a41e50>, <qgis._core.QgsLayerTreeNode object at 0x7f29f9a41ee0>, <qgis._core.QgsLayerTreeNode object at 0x7f29f9a41f70>, <qgis._core.QgsLayerTreeNode object at 0x7f29f9a39f70> [...]
>>> root2.findLayers()
[<qgis._core.QgsLayerTreeLayer object at 0x7f29f9a42dc0>, <qgis._core.QgsLayerTreeLayer object at 0x7f29f9a42e50>, <qgis._core.QgsLayerTreeLayer object at 0x7f29f9a42ee0>, <qgis._core.QgsLayerTreeLayer object at 0x7f29f9a42f70>[...]
>>> root2.children()
[<qgis._core.QgsLayerTreeLayer object at 0x7f29f9a42dc0>, <qgis._core.QgsLayerTreeLayer object at 0x7f29f9a42e50>, <qgis._core.QgsLayerTreeLayer object at 0x7f29f9a42ee0>, <qgis._core.QgsLayerTreeLayer object at 0x7f29f9a42f70>[...]
```
In this test `children()` only return `QgsLayerTreeNode` on the first call and `QgsLayerTreeLayer` only after the call of `findLayers()` what shouldn't have an influence. I'm confused. It's hard to reproduce in other projects...