### PR TITLE
Use save file browser for import data

### DIFF
--- a/QgisModelBaker/gui/panel/gpkg_config_panel.py
+++ b/QgisModelBaker/gui/panel/gpkg_config_panel.py
@@ -63,7 +63,7 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
             validator = self.gpkgSaveFileValidator
             file_selector = make_save_file_selector(self.gpkg_file_line_edit, title=self.tr("Open GeoPackage database file"),
                                         file_filter=self.tr("GeoPackage Database (*.gpkg *.GPKG)"),
-                                                    extensions=['.' + ext for ext in self.ValidExtensions])
+                                                    extensions=['.' + ext for ext in self.ValidExtensions], dont_confirm_overwrite = (self._db_action_type == DbActionType.IMPORT_DATA) )
         else:
             validator = self.gpkgOpenFileValidator
             file_selector = make_file_selector(self.gpkg_file_line_edit, title=self.tr("Open GeoPackage database file"),

--- a/QgisModelBaker/gui/panel/gpkg_config_panel.py
+++ b/QgisModelBaker/gui/panel/gpkg_config_panel.py
@@ -52,15 +52,14 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
 
         self.gpkgSaveFileValidator = FileValidator(
             pattern=['*.' + ext for ext in self.ValidExtensions], allow_non_existing=True)
-        self.gpkgOpenFileValidator = FileValidator(pattern=['*.' + ext for ext in self.ValidExtensions],
-                                                   allow_non_existing=(self._db_action_type == DbActionType.IMPORT_DATA))
+        self.gpkgOpenFileValidator = FileValidator(pattern=['*.' + ext for ext in self.ValidExtensions])
         self.gpkg_file_line_edit.textChanged.connect(
             self.validators.validate_line_edits)
 
         self.gpkg_file_line_edit.textChanged.connect(self.notify_fields_modified)
 
     def _show_panel(self):
-        if self.interlis_mode:
+        if self.interlis_mode or self._db_action_type == DbActionType.IMPORT_DATA:
             validator = self.gpkgSaveFileValidator
             file_selector = make_save_file_selector(self.gpkg_file_line_edit, title=self.tr("Open GeoPackage database file"),
                                         file_filter=self.tr("GeoPackage Database (*.gpkg *.GPKG)"),

--- a/QgisModelBaker/gui/panel/gpkg_config_panel.py
+++ b/QgisModelBaker/gui/panel/gpkg_config_panel.py
@@ -63,7 +63,7 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
             validator = self.gpkgSaveFileValidator
             file_selector = make_save_file_selector(self.gpkg_file_line_edit, title=self.tr("Open GeoPackage database file"),
                                         file_filter=self.tr("GeoPackage Database (*.gpkg *.GPKG)"),
-                                                    extensions=['.' + ext for ext in self.ValidExtensions], dont_confirm_overwrite = (self._db_action_type == DbActionType.IMPORT_DATA) )
+                                                    extensions=['.' + ext for ext in self.ValidExtensions], dont_confirm_overwrite = True )
         else:
             validator = self.gpkgOpenFileValidator
             file_selector = make_file_selector(self.gpkg_file_line_edit, title=self.tr("Open GeoPackage database file"),

--- a/QgisModelBaker/utils/qt_utils.py
+++ b/QgisModelBaker/utils/qt_utils.py
@@ -52,8 +52,8 @@ def make_file_selector(widget, title=QCoreApplication.translate('QgisModelBaker'
     return partial(selectFileName, line_edit_widget=widget, title=title, file_filter=file_filter, parent=parent)
 
 
-def selectFileNameToSave(line_edit_widget, title, file_filter, parent, extension, extensions):
-    filename, matched_filter = QFileDialog.getSaveFileName(parent, title, line_edit_widget.text(), file_filter)
+def selectFileNameToSave(line_edit_widget, title, file_filter, parent, extension, extensions, dont_confirm_overwrite):
+    filename, matched_filter = QFileDialog.getSaveFileName(parent, title, line_edit_widget.text(), file_filter,  options=QFileDialog.DontConfirmOverwrite if dont_confirm_overwrite else QFileDialog.Options())
     extension_valid = False
 
     if not extensions:
@@ -70,9 +70,9 @@ def selectFileNameToSave(line_edit_widget, title, file_filter, parent, extension
 
 def make_save_file_selector(widget, title=QCoreApplication.translate('QgisModelBaker', 'Open File'),
                             file_filter=QCoreApplication.translate('QgisModelBaker', 'Any file(*)'), parent=None,
-                            extension='', extensions=None):
+                            extension='', extensions=None, dont_confirm_overwrite=False):
     return partial(selectFileNameToSave, line_edit_widget=widget, title=title, file_filter=file_filter, parent=parent,
-                   extension=extension, extensions=extensions)
+                   extension=extension, extensions=extensions, dont_confirm_overwrite=dont_confirm_overwrite)
 
 
 def selectFolder(line_edit_widget, title, parent):


### PR DESCRIPTION
It still allows you to select an existing file.

The fix is needed to have the ability to choose a non-existing file, because you can create the GPKG with ili2db Parameter `--doschemaimport`.

Negative point is that because it's a default Qt Component (`QFileDialog`) on providing the ability to choose a non-exisiting file (by using `getSaveFileName`, it displays a warning like this when choosing an existing file:
![image](https://user-images.githubusercontent.com/28384354/126174158-10f70d81-48fc-4511-aeeb-17492236a22e.png)

So this could irritate the use, because we do not "replace" the file when importing into an existing GPKG-File.

So I'm not sure about this fix.