### PR TITLE
Basic Basket Dataset Support

### DIFF
--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -465,19 +465,20 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
                 qml_section = dict(self.metaconfig['qgis.modelbaker.qml'])
                 qml_file_model = self.get_topping_file_model(list(qml_section.values()))
                 for layer in project.layers:
-                    if any(layer.alias.lower() == s for s in qml_section):
-                        layer_qml = layer.alias.lower()
-                    elif any(f'"{layer.alias.lower()}"' == s for s in qml_section):
-                        layer_qml = f'"{layer.alias.lower()}"'
-                    else:
-                        continue
-                    matches = qml_file_model.match(qml_file_model.index(0, 0), Qt.DisplayRole,
-                                                   qml_section[layer_qml], 1)
-                    if matches:
-                        style_file_path = matches[0].data(int(IliToppingFileItemModel.Roles.LOCALFILEPATH))
-                        self.print_info(self.tr('Apply QML topping on layer {}:{}…').format(layer.alias, style_file_path),
-                                        COLOR_TOPPING)
-                        layer.layer.loadNamedStyle(style_file_path)
+                    if layer.alias:
+                        if any(layer.alias.lower() == s for s in qml_section):
+                            layer_qml = layer.alias.lower()
+                        elif any(f'"{layer.alias.lower()}"' == s for s in qml_section):
+                            layer_qml = f'"{layer.alias.lower()}"'
+                        else:
+                            continue
+                        matches = qml_file_model.match(qml_file_model.index(0, 0), Qt.DisplayRole,
+                                                    qml_section[layer_qml], 1)
+                        if matches:
+                            style_file_path = matches[0].data(int(IliToppingFileItemModel.Roles.LOCALFILEPATH))
+                            self.print_info(self.tr('Apply QML topping on layer {}:{}…').format(layer.alias, style_file_path),
+                                            COLOR_TOPPING)
+                            layer.layer.loadNamedStyle(style_file_path)
 
             self.progress_bar.setValue(80)
 

--- a/QgisModelBaker/gui/ili2db_options.py
+++ b/QgisModelBaker/gui/ili2db_options.py
@@ -151,7 +151,7 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
             self.smart1_radio_button.setChecked(True)
         else:
             self.smart2_radio_button.setChecked(True)
-        create_basket_col = settings.value('QgisModelBaker/ili2db/create_basket_col', defaultValue=False, type=bool)
+        create_basket_col = settings.value('QgisModelBaker/ili2db/create_basket_col', defaultValue=True, type=bool)
         create_import_tid = settings.value('QgisModelBaker/ili2db/create_import_tid', defaultValue=True, type=bool)
         stroke_arcs = settings.value('QgisModelBaker/ili2db/stroke_arcs', defaultValue=True, type=bool)
 

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -205,7 +205,7 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
     def __init__(self):
         super().__init__()
         self.inheritance = 'smart1'
-        self.create_basket_col = False
+        self.create_basket_col = True
         self.create_import_tid = True
         self.srs_auth = 'EPSG'  # Default SRS auth in ili2db
         self.srs_code = 21781  # Default SRS code in ili2db

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/form.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/form.py
@@ -47,7 +47,7 @@ class Form(object):
             if relation.referenced_layer == layer:
                 # get other relations, that have the same referencing_layer and set the first as nm-rel
                 for other_relation in project.relations:
-                    if other_relation.referencing_field != relation.referencing_field and other_relation.referencing_layer == relation.referencing_layer and relation.referencing_layer.is_nmrel:
+                    if other_relation.referencing_field != relation.referencing_field and other_relation.referencing_layer == relation.referencing_layer and relation.referencing_layer.is_nmrel and not other_relation.referenced_layer.is_basket_table:
                         edit_form_config.setWidgetConfig(relation.id, {'nm-rel': other_relation.id})
                         break
         return edit_form_config

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
@@ -35,7 +35,7 @@ from qgis.PyQt.QtCore import QCoreApplication, QSettings
 
 class Layer(object):
 
-    def __init__(self, provider, uri, name, srid, extent, geometry_column=None, wkb_type=QgsWkbTypes.Unknown, alias=None, is_domain=False, is_structure=False, is_nmrel=False, display_expression=None, coordinate_precision=None, is_basket_table=False, model_topic_name=None):
+    def __init__(self, provider, uri, name, srid, extent, geometry_column=None, wkb_type=QgsWkbTypes.Unknown, alias=None, is_domain=False, is_structure=False, is_nmrel=False, display_expression=None, coordinate_precision=None, is_basket_table=False, is_dataset_table = False, model_topic_name=None):
         self.provider = provider
         self.uri = uri
         self.name = name
@@ -65,6 +65,7 @@ class Layer(object):
         self.coordinate_precision = coordinate_precision
 
         self.is_basket_table = is_basket_table
+        self.is_dataset_table = is_dataset_table
         self.model_topic_name = model_topic_name
 
         self.__form = Form()
@@ -82,6 +83,7 @@ class Layer(object):
         definition['isstructure'] = self.is_structure
         definition['isnmrel'] = self.is_nmrel
         definition['isbaskettable'] = self.is_basket_table
+        definition['isdatasettable'] = self.is_dataset_table
         definition['displayexpression'] = self.display_expression
         definition['coordinateprecision'] = self.coordinate_precision
         definition['modeltopicname'] = self.model_topic_name
@@ -95,6 +97,7 @@ class Layer(object):
         self.is_structure = definition['isstructure']
         self.is_nmrel = definition['isnmrel']
         self.is_basket_table = definition['isbaskettable']
+        self.is_dataset_table = definition['isdatasettable']
         self.display_expression = definition['displayexpression']
         self.coordinate_precision = definition['coordinateprecision']
         self.model_topic_name = definition['modeltopicname']
@@ -116,7 +119,7 @@ class Layer(object):
                 if not crs.isValid():
                     crs = QgsCoordinateReferenceSystem(self.srid)  # Fallback
                 self.__layer.setCrs(crs)
-            if self.is_domain:
+            if self.is_domain or self.is_basket_table or self.is_dataset_table:
                 self.__layer.setReadOnly()
             if self.display_expression:
                 self.__layer.setDisplayExpression(self.display_expression)

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
@@ -35,7 +35,7 @@ from qgis.PyQt.QtCore import QCoreApplication, QSettings
 
 class Layer(object):
 
-    def __init__(self, provider, uri, name, srid, extent, geometry_column=None, wkb_type=QgsWkbTypes.Unknown, alias=None, is_domain=False, is_structure=False, is_nmrel=False, display_expression=None, coordinate_precision=None):
+    def __init__(self, provider, uri, name, srid, extent, geometry_column=None, wkb_type=QgsWkbTypes.Unknown, alias=None, is_domain=False, is_structure=False, is_nmrel=False, display_expression=None, coordinate_precision=None, is_basket_table=False, model_topic_name=None):
         self.provider = provider
         self.uri = uri
         self.name = name
@@ -64,6 +64,9 @@ class Layer(object):
 
         self.coordinate_precision = coordinate_precision
 
+        self.is_basket_table = is_basket_table
+        self.model_topic_name = model_topic_name
+
         self.__form = Form()
 
         #legend settings
@@ -78,8 +81,10 @@ class Layer(object):
         definition['isdomain'] = self.is_domain
         definition['isstructure'] = self.is_structure
         definition['isnmrel'] = self.is_nmrel
+        definition['isbaskettable'] = self.is_basket_table
         definition['displayexpression'] = self.display_expression
         definition['coordinateprecision'] = self.coordinate_precision
+        definition['modeltopicname'] = self.model_topic_name
         definition['form'] = self.__form.dump()
         return definition
 
@@ -89,8 +94,10 @@ class Layer(object):
         self.is_domain = definition['isdomain']
         self.is_structure = definition['isstructure']
         self.is_nmrel = definition['isnmrel']
+        self.is_basket_table = definition['isbaskettable']
         self.display_expression = definition['displayexpression']
         self.coordinate_precision = definition['coordinateprecision']
+        self.model_topic_name = definition['modeltopicname']
         self.__form.load(definition['form'])
 
     def create(self):

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/config.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/config.py
@@ -6,16 +6,13 @@ IGNORED_SCHEMAS = [
 IGNORED_TABLES = [
     'spatial_ref_sys',
     't_ili2db_import_object',
-    't_ili2db_dataset',
     't_ili2db_attrname',
-    't_ili2db_basket',
     't_ili2db_settings',
     't_ili2db_import',
     't_ili2db_inheritance',
     't_ili2db_model',
     't_ili2db_classname',
     't_ili2db_import_basket',
-    'T_ILI2DB_DATASET',
     'T_ILI2DB_TABLE_PROP',
     'T_ILI2DB_INHERITANCE',
     'T_ILI2DB_ATTRNAME',
@@ -27,7 +24,6 @@ IGNORED_TABLES = [
     'T_ILI2DB_COLUMN',
     'T_ILI2DB_COLUMN_PROP',
     'T_ILI2DB_CLASSNAME',
-    'T_ILI2DB_BASKET',
     'T_ILI2DB_IMPORT_OBJECT',
     'T_ILI2DB_IMPORT_BASKET',
     'T_ILI2DB_META_ATTRS',
@@ -52,6 +48,13 @@ IGNORED_TABLES = [
     'gpkg_metadata',
     'gpkg_metadata_reference',
     'sqlite_sequence'
+]
+
+BASKET_TABLES = [
+    't_ili2db_dataset',
+    't_ili2db_basket',
+    'T_ILI2DB_DATASET',
+    'T_ILI2DB_BASKET'
 ]
 
 IGNORED_ILI_ELEMENTS = [

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/config.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/config.py
@@ -51,10 +51,10 @@ IGNORED_TABLES = [
 ]
 
 BASKET_TABLES = [
-    't_ili2db_dataset',
     't_ili2db_basket',
-    'T_ILI2DB_DATASET',
-    'T_ILI2DB_BASKET'
+    'T_ILI2DB_BASKET',
+    't_ili2db_dataset',
+    'T_ILI2DB_DATASET'
 ]
 
 IGNORED_ILI_ELEMENTS = [

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
@@ -33,8 +33,11 @@ class DBConnector(QObject):
         self.QGIS_TIME_TYPE = 'time'
         self.QGIS_DATE_TIME_TYPE = 'datetime'
         self.iliCodeName = ''  # For Domain-Class relations, specific for each DB
-        self.tid = ''  # For BAG OF config, specific for each DB
+        self.tid = ''  # For BAG OF config and basket handling, specific for each DB
+        self.tilitid = ''  # For basket handling, specific for each DB
         self.dispName = ''  # For BAG OF config, specific for each DB
+        self.basket_table_name = ''  # For basket handling, specific for each DB
+        self.dataset_table_name = ''  # For basket handling, specific for each DB
 
     def map_data_types(self, data_type):
         '''Map provider date/time types to QGIS date/time types'''

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
@@ -185,7 +185,7 @@ class DBConnector(QObject):
         tables_info = self.get_tables_info()
         relations_info = self.get_relations_info()
         meta_attrs_info = self.get_meta_attrs_info()
-        basket_handling_info = self.get_basket_handling_info()
+        basket_handling = self.get_basket_handling()
         mapping_ili_elements = []
         static_tables = []
         detected_tables = []
@@ -207,7 +207,7 @@ class DBConnector(QObject):
                 if record['tablename'] in IGNORED_TABLES:
                     static_tables.append(record['tablename'])
                     continue
-                if not basket_handling_info and record['tablename'] in BASKET_TABLES:
+                if not basket_handling and record['tablename'] in BASKET_TABLES:
                     static_tables.append(record['tablename'])
                     continue
 
@@ -242,7 +242,7 @@ class DBConnector(QObject):
         """
         return None
 
-    def get_basket_handling_info(self):
+    def get_basket_handling(self):
         """
         Returns if there is a basket handling enabled according to the settings table
         """

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
@@ -19,7 +19,7 @@
 
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 
-from .config import IGNORED_SCHEMAS, IGNORED_TABLES, IGNORED_ILI_ELEMENTS
+from .config import IGNORED_SCHEMAS, IGNORED_TABLES, IGNORED_ILI_ELEMENTS, BASKET_TABLES
 
 class DBConnector(QObject):
     '''SuperClass for all DB connectors.'''
@@ -185,6 +185,7 @@ class DBConnector(QObject):
         tables_info = self.get_tables_info()
         relations_info = self.get_relations_info()
         meta_attrs_info = self.get_meta_attrs_info()
+        basket_handling_info = self.get_basket_handling_info()
         mapping_ili_elements = []
         static_tables = []
         detected_tables = []
@@ -204,6 +205,10 @@ class DBConnector(QObject):
                     continue
             if 'tablename' in record:
                 if record['tablename'] in IGNORED_TABLES:
+                    static_tables.append(record['tablename'])
+                    continue
+                if not basket_handling_info and record['tablename'] in BASKET_TABLES:
+                    print(f"append table to ignored tables {record['tablename']}")
                     static_tables.append(record['tablename'])
                     continue
 
@@ -237,6 +242,12 @@ class DBConnector(QObject):
         Returns the version of the ili2db application that was used to create the schema
         """
         return None
+
+    def get_basket_handling_info(self):
+        """
+        Returns if there is a basket handling enabled according to the settings table
+        """
+        return False
 
 
 class DBConnectorError(Exception):

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
@@ -208,7 +208,6 @@ class DBConnector(QObject):
                     static_tables.append(record['tablename'])
                     continue
                 if not basket_handling_info and record['tablename'] in BASKET_TABLES:
-                    print(f"append table to ignored tables {record['tablename']}")
                     static_tables.append(record['tablename'])
                     continue
 

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -480,11 +480,14 @@ class GPKGConnector(DBConnector):
         else:
             return 4
 
-    def get_basket_handling_info(self):
+    def get_basket_handling(self):
         """Entry exists when it's active. Currently we don't use the content of the entry besides that."""
         cursor = self.conn.cursor()
         cursor.execute("""SELECT setting
                            FROM t_ili2db_settings
                            WHERE tag = 'ch.ehi.ili2db.BasketHandling'
                         """)
-        return cursor.fetchone() is not None
+        content = cursor.fetchone()
+        if content: 
+            return content[0] == 'readWrite'
+        return False

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -48,7 +48,10 @@ class GPKGConnector(DBConnector):
         self._tables_info = self._get_tables_info()
         self.iliCodeName = 'iliCode'
         self.tid = 'T_Id'
+        self.tilitid = 'T_Ili_Tid'
         self.dispName = 'dispName'
+        self.basket_table_name = 'T_ILI2DB_BASKET'
+        self.dataset_table_name = 'T_ILI2DB_DATASET'
 
     def map_data_types(self, data_type):
         '''GPKG date/time types correspond to QGIS date/time types'''

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -479,3 +479,12 @@ class GPKGConnector(DBConnector):
             return 3
         else:
             return 4
+
+    def get_basket_handling_info(self):
+        """Entry exists when it's active. Currently we don't use the content of the entry besides that."""
+        cursor = self.conn.cursor()
+        cursor.execute("""SELECT setting
+                           FROM t_ili2db_settings
+                           WHERE tag = 'ch.ehi.ili2db.BasketHandling'
+                        """)
+        return cursor.fetchone() is not None

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -27,6 +27,7 @@ from ..generator.config import GPKG_FILTER_TABLES_MATCHING_PREFIX_SUFFIX
 
 GPKG_METADATA_TABLE = 'T_ILI2DB_TABLE_PROP'
 GPKG_METAATTRS_TABLE = 'T_ILI2DB_META_ATTRS'
+GPKG_SETTINGS_TABLE = 'T_ILI2DB_SETTINGS'
 
 
 class GPKGConnector(DBConnector):
@@ -484,13 +485,13 @@ class GPKGConnector(DBConnector):
             return 4
 
     def get_basket_handling(self):
-        """Entry exists when it's active. Currently we don't use the content of the entry besides that."""
-        cursor = self.conn.cursor()
-        cursor.execute("""SELECT setting
-                           FROM t_ili2db_settings
-                           WHERE tag = 'ch.ehi.ili2db.BasketHandling'
-                        """)
-        content = cursor.fetchone()
-        if content: 
-            return content[0] == 'readWrite'
+        if self._table_exists(GPKG_SETTINGS_TABLE):
+            cursor = self.conn.cursor()
+            cursor.execute("""SELECT setting
+                            FROM {}
+                            WHERE tag = 'ch.ehi.ili2db.BasketHandling'
+                            """.format(GPKG_SETTINGS_TABLE))
+            content = cursor.fetchone()
+            if content: 
+                return content[0] == 'readWrite'
         return False

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
@@ -544,3 +544,14 @@ WHERE TABLE_SCHEMA='{schema}'
             return 3
         else:
             return 4
+
+    def get_basket_handling_info(self):
+        """Entry exists when it's active. Currently we don't use the content of the entry besides that."""
+        if self.schema:
+            cur = self.conn.cursor()
+            cur.execute("""SELECT setting
+                           FROM {schema}.t_ili2db_settings
+                           WHERE tag = 'ch.ehi.ili2db.BasketHandling'
+                        """.format(schema=self.schema))
+            return bool(cur.rowcount)
+        return False

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
@@ -43,7 +43,10 @@ class MssqlConnector(DBConnector):
         self._bMetadataTable = self._metadata_exists()
         self.iliCodeName = 'iliCode'
         self.tid = 'T_Id'
+        self.tilitid = 'T_Ili_Tid'
         self.dispName = 'dispName'
+        self.basket_table_name = 't_ili2db_basket'
+        self.dataset_table_name = 't_ili2db_dataset'
 
     def map_data_types(self, data_type):
         result = data_type.lower()

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
@@ -545,7 +545,7 @@ WHERE TABLE_SCHEMA='{schema}'
         else:
             return 4
 
-    def get_basket_handling_info(self):
+    def get_basket_handling(self):
         """Entry exists when it's active. Currently we don't use the content of the entry besides that."""
         if self.schema:
             cur = self.conn.cursor()
@@ -553,5 +553,7 @@ WHERE TABLE_SCHEMA='{schema}'
                            FROM {schema}.t_ili2db_settings
                            WHERE tag = 'ch.ehi.ili2db.BasketHandling'
                         """.format(schema=self.schema))
-            return bool(cur.rowcount)
+            content = cur.fetchone()
+            if content:
+                return content[0] == 'readWrite'
         return False

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
@@ -27,6 +27,7 @@ from .db_connector import (DBConnector, DBConnectorError)
 
 METADATA_TABLE = 't_ili2db_table_prop'
 METAATTRS_TABLE = 't_ili2db_meta_attrs'
+SETTINGS_TABLE = 't_ili2db_settings'
 
 
 class MssqlConnector(DBConnector):
@@ -549,14 +550,13 @@ WHERE TABLE_SCHEMA='{schema}'
             return 4
 
     def get_basket_handling(self):
-        """Entry exists when it's active. Currently we don't use the content of the entry besides that."""
-        if self.schema:
-            cur = self.conn.cursor()
-            cur.execute("""SELECT setting
-                           FROM {schema}.t_ili2db_settings
-                           WHERE tag = 'ch.ehi.ili2db.BasketHandling'
-                        """.format(schema=self.schema))
-            content = cur.fetchone()
-            if content:
-                return content[0] == 'readWrite'
+        if self.schema and self._table_exists(SETTINGS_TABLE):
+                cur = self.conn.cursor()
+                cur.execute("""SELECT setting
+                            FROM {schema}.{settings_table}
+                            WHERE tag = 'ch.ehi.ili2db.BasketHandling'
+                            """.format(schema=self.schema, settings_table=SETTINGS_TABLE))
+                content = cur.fetchone()
+                if content:
+                    return content[0] == 'readWrite'
         return False

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -590,7 +590,7 @@ class PGConnector(DBConnector):
         else:
             return 4
 
-    def get_basket_handling_info(self):
+    def get_basket_handling(self):
         """Entry exists when it's active. Currently we don't use the content of the entry besides that."""
         if self.schema:
             cur = self.conn.cursor()
@@ -598,5 +598,7 @@ class PGConnector(DBConnector):
                            FROM {schema}.t_ili2db_settings
                            WHERE tag = 'ch.ehi.ili2db.BasketHandling'
                         """.format(schema=self.schema))
-            return bool(cur.rowcount)
+            content = cur.fetchone()
+            if content:
+                return content[0] == 'readWrite'
         return False

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -589,3 +589,14 @@ class PGConnector(DBConnector):
             return 3
         else:
             return 4
+
+    def get_basket_handling_info(self):
+        """Entry exists when it's active. Currently we don't use the content of the entry besides that."""
+        if self.schema:
+            cur = self.conn.cursor()
+            cur.execute("""SELECT setting
+                           FROM {schema}.t_ili2db_settings
+                           WHERE tag = 'ch.ehi.ili2db.BasketHandling'
+                        """.format(schema=self.schema))
+            return bool(cur.rowcount)
+        return False

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -26,6 +26,7 @@ from qgis.core import Qgis
 
 PG_METADATA_TABLE = 't_ili2db_table_prop'
 PG_METAATTRS_TABLE = 't_ili2db_meta_attrs'
+PG_SETTINGS_TABLE = 't_ili2db_settings'
 
 class PGConnector(DBConnector):
     _geom_parse_regexp = None
@@ -594,13 +595,12 @@ class PGConnector(DBConnector):
             return 4
 
     def get_basket_handling(self):
-        """Entry exists when it's active. Currently we don't use the content of the entry besides that."""
-        if self.schema:
+        if self.schema and self._table_exists(PG_SETTINGS_TABLE):
             cur = self.conn.cursor()
             cur.execute("""SELECT setting
-                           FROM {schema}.t_ili2db_settings
+                           FROM {schema}.{settings_table}
                            WHERE tag = 'ch.ehi.ili2db.BasketHandling'
-                        """.format(schema=self.schema))
+                        """.format(schema=self.schema, settings_table=PG_SETTINGS_TABLE))
             content = cur.fetchone()
             if content:
                 return content[0] == 'readWrite'

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -42,7 +42,10 @@ class PGConnector(DBConnector):
         self._bMetadataTable = self._metadata_exists()
         self.iliCodeName = 'ilicode'
         self.tid = 't_id'
+        self.tilitid = 't_ili_tid'
         self.dispName = 'dispname'
+        self.basket_table_name = 't_ili2db_basket'
+        self.dataset_table_name = 't_ili2db_dataset'
 
     def map_data_types(self, data_type):
         if not data_type:

--- a/QgisModelBaker/libqgsprojectgen/generator/config.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/config.py
@@ -1,12 +1,15 @@
 IGNORED_FIELDNAMES = [
     't_id',
     't_seq',
-    't_basket',
     't_ili_tid',
     'T_Id',
-    'T_basket',
     'T_Seq',
     'T_Ili_Tid'
+]
+
+BASKET_FIELDNAMES = [
+    't_basket',
+    'T_basket'
 ]
 
 READONLY_FIELDNAMES = [

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -30,7 +30,7 @@ from QgisModelBaker.libqgsprojectgen.dataobjects.layers import Layer
 from QgisModelBaker.libqgsprojectgen.dataobjects.relations import Relation
 from ..dbconnector import pg_connector, gpkg_connector
 from .domain_relations_generator import DomainRelationGenerator
-from .config import IGNORED_FIELDNAMES, READONLY_FIELDNAMES
+from .config import IGNORED_FIELDNAMES, READONLY_FIELDNAMES, BASKET_FIELDNAMES
 from ..db_factory.db_simple_factory import DbSimpleFactory
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 
@@ -81,6 +81,7 @@ class Generator(QObject):
 
     def layers(self, filter_layer_list=[]):
         tables_info = self.get_tables_info_without_ignored_tables()
+        basket_handling_info = self.get_basket_handling_info()
         layers = list()
 
         db_factory = self.db_simple_factory.create_factory(self.tool)
@@ -200,6 +201,9 @@ class Generator(QObject):
                                     break
 
                 if column_name in IGNORED_FIELDNAMES:
+                    hide_attribute = True
+
+                if not basket_handling_info and column_name in BASKET_FIELDNAMES:
                     hide_attribute = True
 
                 field.hidden = hide_attribute

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -129,7 +129,7 @@ class Generator(QObject):
                                 short_name = field_info['fully_qualified_name'].split('.')[-2] + ' (' + \
                                              field_info['fully_qualified_name'].split('.')[
                                                  -1]+')' if 'fully_qualified_name' in field_info else record['tablename']
-                    elif 'ili_name' in record:
+                    elif 'ili_name' in record and record['ili_name']:
                         match = re.search('([^\(]*).*', record['ili_name'])
                         if match.group(0) == match.group(1):
                             short_name = match.group(1).split('.')[-1]
@@ -139,7 +139,7 @@ class Generator(QObject):
                 alias = short_name
 
             display_expression = ''
-            if 'ili_name' in record:
+            if 'ili_name' in record and record['ili_name']:
                 meta_attrs = self.get_meta_attrs(record['ili_name'])
                 for attr_record in meta_attrs:
                     if attr_record['attr_name'] == 'dispExpression':
@@ -461,3 +461,6 @@ class Generator(QObject):
 
     def get_iliname_dbname_mapping(self):
         return self._db_connector.get_iliname_dbname_mapping()
+
+    def get_basket_handling_info(self):
+        return self._db_connector.get_basket_handling_info()

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -110,13 +110,12 @@ class Generator(QObject):
             if filter_layer_list and record['tablename'] not in filter_layer_list:
                 continue
 
-            is_domain = record['kind_settings'] == 'ENUM' or record[
-                'kind_settings'] == 'CATALOGUE' if 'kind_settings' in record else False
-            is_attribute = bool(record['attribute_name']) if 'attribute_name' in record else False
-            is_structure = record['kind_settings'] == 'STRUCTURE' if 'kind_settings' in record else False
-            is_nmrel = record['kind_settings'] == 'ASSOCIATION' if 'kind_settings' in record else False
-            is_basket_table = record['tablename'] == self._db_connector.basket_table_name if 'tablename' in record else False
-            is_dataset_table = record['tablename'] == self._db_connector.dataset_table_name if 'tablename' in record else False
+            is_domain = record.get('kind_settings') == 'ENUM' or record.get('kind_settings') == 'CATALOGUE'
+            is_attribute = bool(record.get('attribute_name'))
+            is_structure = record.get('kind_settings') == 'STRUCTURE'
+            is_nmrel = record.get('kind_settings') == 'ASSOCIATION'
+            is_basket_table = record.get('tablename') == self._db_connector.basket_table_name
+            is_dataset_table = record.get('tablename') == self._db_connector.dataset_table_name
 
             alias = record['table_alias'] if 'table_alias' in record else None
             if not alias:

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -81,7 +81,7 @@ class Generator(QObject):
 
     def layers(self, filter_layer_list=[]):
         tables_info = self.get_tables_info_without_ignored_tables()
-        basket_handling_info = self.get_basket_handling_info()
+        basket_handling = self.get_basket_handling()
         layers = list()
 
         db_factory = self.db_simple_factory.create_factory(self.tool)
@@ -203,7 +203,7 @@ class Generator(QObject):
                 if column_name in IGNORED_FIELDNAMES:
                     hide_attribute = True
 
-                if not basket_handling_info and column_name in BASKET_FIELDNAMES:
+                if not basket_handling and column_name in BASKET_FIELDNAMES:
                     hide_attribute = True
 
                 field.hidden = hide_attribute
@@ -466,5 +466,5 @@ class Generator(QObject):
     def get_iliname_dbname_mapping(self):
         return self._db_connector.get_iliname_dbname_mapping()
 
-    def get_basket_handling_info(self):
-        return self._db_connector.get_basket_handling_info()
+    def get_basket_handling(self):
+        return self._db_connector.get_basket_handling()

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -121,16 +121,19 @@ class Generator(QObject):
             if not alias:
                 short_name = None
                 if is_domain and is_attribute:
-                    short_name = record['ili_name'].split('.')[-2] + '_' + record['ili_name'].split('.')[-1] if 'ili_name' in record and record['ili_name'] else ''
+                    short_name = ''
+                    if 'ili_name' in record and record['ili_name']:
+                        short_name = record['ili_name'].split('.')[-2] + '_' + record['ili_name'].split('.')[-1]
                 else:
                     if table_appearance_count[record['tablename']] > 1 and 'geometry_column' in record:
                         # multiple layers for this table - append geometry column to name
                         fields_info = self.get_fields_info(record['tablename'])
                         for field_info in fields_info:
                             if field_info['column_name'] == record['geometry_column']:
-                                short_name = field_info['fully_qualified_name'].split('.')[-2] + ' (' + \
-                                             field_info['fully_qualified_name'].split('.')[
-                                                 -1]+')' if 'fully_qualified_name' in field_info else record['tablename']
+                                if 'fully_qualified_name' in field_info and field_info['fully_qualified_name']:
+                                    short_name =  field_info['fully_qualified_name'].split('.')[-2] + ' (' + field_info['fully_qualified_name'].split('.')[-1]+')'
+                                else:
+                                    short_name = record['tablename']
                     elif 'ili_name' in record and record['ili_name']:
                         match = re.search('([^\(]*).*', record['ili_name'])
                         if match.group(0) == match.group(1):
@@ -140,7 +143,9 @@ class Generator(QObject):
                             short_name = match.group(1).split('.')[-2] + ' (' + match.group(1).split('.')[-1]+')'
                 alias = short_name
 
-            model_topic_name = f"{record['ili_name'].split('.')[0]}.{record['ili_name'].split('.')[1]}" if 'ili_name' in record and record['ili_name'] else ''
+            model_topic_name = ""
+            if 'ili_name' in record and record['ili_name']:
+                model_topic_name = f"{record['ili_name'].split('.')[0]}.{record['ili_name'].split('.')[1]}"
             
             display_expression = ''
             if is_basket_table:

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -145,6 +145,12 @@ class Generator(QObject):
                 for attr_record in meta_attrs:
                     if attr_record['attr_name'] == 'dispExpression':
                         display_expression = attr_record['attr_value']
+            elif record["tablename"] == self._db_connector.basket_table_name:
+                display_expression = "coalesce(attribute(get_feature('{dataset_layer_name}', '{tid}', dataset), 'datasetname') || ' (' || {tilitid} || ') ', coalesce( attribute(get_feature('{dataset_layer_name}', '{tid}', dataset), 'datasetname'), {tilitid}))".format(
+                    tid=self._db_connector.tid,
+                    tilitid=self._db_connector.tilitid,
+                    dataset_layer_name=self._db_connector.dataset_table_name,
+                )
 
             coord_decimals = record['coord_decimals'] if 'coord_decimals' in record else None
             coordinate_precision = None

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -116,6 +116,7 @@ class Generator(QObject):
             is_structure = record['kind_settings'] == 'STRUCTURE' if 'kind_settings' in record else False
             is_nmrel = record['kind_settings'] == 'ASSOCIATION' if 'kind_settings' in record else False
             is_basket_table = record['tablename'] == self._db_connector.basket_table_name if 'tablename' in record else False
+            is_dataset_table = record['tablename'] == self._db_connector.dataset_table_name if 'tablename' in record else False
 
             alias = record['table_alias'] if 'table_alias' in record else None
             if not alias:
@@ -175,6 +176,7 @@ class Generator(QObject):
                 display_expression,
                 coordinate_precision,
                 is_basket_table,
+                is_dataset_table,
                 model_topic_name )
 
             # Configure fields for current table
@@ -388,6 +390,8 @@ class Generator(QObject):
                 QCoreApplication.translate('LegendGroup', 'tables'))
             domains = LegendGroup(QCoreApplication.translate(
                 'LegendGroup', 'domains'), False)
+            system = LegendGroup(QCoreApplication.translate(
+                'LegendGroup', 'system'), False)
 
             point_layers = []
             line_layers = []
@@ -405,6 +409,8 @@ class Generator(QObject):
                 else:
                     if layer.is_domain:
                         domains.append(layer)
+                    elif layer.name in [self._db_connector.basket_table_name, self._db_connector.dataset_table_name]:
+                        system.append(layer)
                     else:
                         tables.append(layer)
 
@@ -419,6 +425,8 @@ class Generator(QObject):
                 legend.append(tables)
             if not domains.is_empty():
                 legend.append(domains)
+            if not system.is_empty():
+                legend.append(system)
 
         return legend
 

--- a/QgisModelBaker/tests/test_domain_class_relations.py
+++ b/QgisModelBaker/tests/test_domain_class_relations.py
@@ -137,6 +137,7 @@ class TestDomainClassRelation(unittest.TestCase):
             datetime.datetime.now())
         importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -209,6 +210,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.dbschema = 'colors_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -365,6 +367,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 datetime.datetime.now()))
         importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -441,6 +444,7 @@ class TestDomainClassRelation(unittest.TestCase):
             self.basetestpath, 'tmp_colors_gpkg_{:%Y%m%d%H%M%S%f}.gpkg'.format(
                 datetime.datetime.now()))
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -512,6 +516,7 @@ class TestDomainClassRelation(unittest.TestCase):
             datetime.datetime.now())
         importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -679,6 +684,7 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.configuration.dbschema = 'colors_{:%Y%m%d%H%M%S%f}'.format(
             datetime.datetime.now())
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS

--- a/QgisModelBaker/tests/test_export.py
+++ b/QgisModelBaker/tests/test_export.py
@@ -91,6 +91,7 @@ class TestExport(unittest.TestCase):
             datetime.datetime.now())
         importer_e.configuration.srs_code = 3116
         importer_e.configuration.inheritance = 'smart2'
+        importer_e.configuration.create_basket_col = False
         importer_e.stdout.connect(self.print_info)
         importer_e.stderr.connect(self.print_error)
         assert importer_e.run() == iliimporter.Importer.SUCCESS
@@ -173,6 +174,7 @@ class TestExport(unittest.TestCase):
             datetime.datetime.now())
         importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -184,6 +186,7 @@ class TestExport(unittest.TestCase):
             dataImporter.tool, 'ilimodels/CIAF_LADM')
         dataImporter.configuration.ilimodels = 'Catastro_COL_ES_V2_1_6;CIAF_LADM;ISO19107_V1_MAGNABOG'
         dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.create_basket_col = False
         dataImporter.configuration.xtffile = testdata_path(
             'xtf/test_ili2db4_ciaf_ladm.xtf')
         dataImporter.stdout.connect(self.print_info)
@@ -248,6 +251,7 @@ class TestExport(unittest.TestCase):
             datetime.datetime.now())
         importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -259,6 +263,7 @@ class TestExport(unittest.TestCase):
         dataImporter.configuration = ilidataimporter_config(dataImporter.tool)
         dataImporter.configuration.ilimodels = 'RoadsSimple'
         dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.create_basket_col = False
         dataImporter.configuration.xtffile = testdata_path(
             'xtf/test_roads_simple.xtf')
         dataImporter.configuration.db_ili_version = 3
@@ -295,6 +300,7 @@ class TestExport(unittest.TestCase):
             datetime.datetime.now())
         importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -305,6 +311,7 @@ class TestExport(unittest.TestCase):
         dataImporter.configuration = ilidataimporter_config(dataImporter.tool)
         dataImporter.configuration.ilimodels = 'RoadsSimple'
         dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.create_basket_col = False
         dataImporter.configuration.xtffile = testdata_path(
             'xtf/test_roads_simple.xtf')
         dataImporter.stdout.connect(self.print_info)
@@ -338,6 +345,7 @@ class TestExport(unittest.TestCase):
             datetime.datetime.now())
         importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -349,6 +357,7 @@ class TestExport(unittest.TestCase):
             dataImporter.tool, 'ilimodels/CIAF_LADM')
         dataImporter.configuration.ilimodels = 'Catastro_COL_ES_V2_1_6;CIAF_LADM;ISO19107_V1_MAGNABOG'
         dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.create_basket_col = False
         dataImporter.configuration.xtffile = testdata_path(
             'xtf/test_ili2db4_ciaf_ladm.xtf')
         dataImporter.stdout.connect(self.print_info)
@@ -381,6 +390,7 @@ class TestExport(unittest.TestCase):
             datetime.datetime.now())
         importer.configuration.srs_code = 3116
         importer.configuration.inheritance = 'smart2'
+        importer.configuration.create_basket_col = False
         importer.configuration.db_ili_version = 3
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -393,6 +403,7 @@ class TestExport(unittest.TestCase):
             dataImporter.tool, 'ilimodels/CIAF_LADM')
         dataImporter.configuration.ilimodels = 'CIAF_LADM'
         dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.create_basket_col = False
         dataImporter.configuration.xtffile = testdata_path(
             'xtf/test_ciaf_ladm.xtf')
         dataImporter.configuration.db_ili_version = 3

--- a/QgisModelBaker/tests/test_projectgen.py
+++ b/QgisModelBaker/tests/test_projectgen.py
@@ -28,6 +28,8 @@ import yaml
 import pathlib
 from decimal import Decimal
 
+from yaml.events import DocumentStartEvent
+
 from QgisModelBaker.libili2db import iliimporter
 from QgisModelBaker.libili2db.globals import DbIliMode
 from QgisModelBaker.libqgsprojectgen.dataobjects import Project
@@ -111,7 +113,8 @@ class TestProjectGen(unittest.TestCase):
                                               'standorttyp',
                                               'bemerkung',
                                               'geo_lage_punkt',
-                                              'bemerkung_de'])
+                                              'bemerkung_de',
+                                              't_basket'])
 
                 # This might need to be adjusted if we get better names
                 assert tabs[1].name() == 'deponietyp_'
@@ -120,11 +123,11 @@ class TestProjectGen(unittest.TestCase):
                 belasteter_standort_polygon_layer = layer
 
         assert count == 1
-        assert len(available_layers) == 16
+        assert len(available_layers) == 18
 
-        assert len(qgis_project.relationManager().referencingRelations(belasteter_standort_polygon_layer.layer)) > 2
+        assert len(qgis_project.relationManager().referencingRelations(belasteter_standort_polygon_layer.layer)) > 3
         assert len(qgis_project.relationManager().referencedRelations(belasteter_standort_polygon_layer.layer)) > 3
-        assert len(qgis_project.relationManager().referencingRelations(belasteter_standort_punkt_layer.layer)) > 2
+        assert len(qgis_project.relationManager().referencingRelations(belasteter_standort_punkt_layer.layer)) > 3
         assert len(qgis_project.relationManager().referencedRelations(belasteter_standort_punkt_layer.layer)) > 3
 
     def test_kbs_postgis(self):
@@ -180,7 +183,8 @@ class TestProjectGen(unittest.TestCase):
                                               'bemerkung_rm',
                                               'bemerkung_it',
                                               'bemerkung_en',
-                                              'geo_lage_punkt'])
+                                              'geo_lage_punkt',
+                                              't_basket'])
 
                 # This might need to be adjusted if we get better names
                 assert tabs[1].name() == 'deponietyp_'
@@ -189,11 +193,11 @@ class TestProjectGen(unittest.TestCase):
                 belasteter_standort_polygon_layer = layer
 
         assert count == 1
-        assert len(available_layers) == 16
+        assert len(available_layers) == 18
 
-        assert len(qgis_project.relationManager().referencingRelations(belasteter_standort_polygon_layer.layer)) > 2
+        assert len(qgis_project.relationManager().referencingRelations(belasteter_standort_polygon_layer.layer)) > 3
         assert len(qgis_project.relationManager().referencedRelations(belasteter_standort_polygon_layer.layer)) > 3
-        assert len(qgis_project.relationManager().referencingRelations(belasteter_standort_punkt_layer.layer)) > 2
+        assert len(qgis_project.relationManager().referencingRelations(belasteter_standort_punkt_layer.layer)) > 3
         assert len(qgis_project.relationManager().referencedRelations(belasteter_standort_punkt_layer.layer)) > 3
 
     def test_ili2db3_kbs_geopackage(self):
@@ -252,7 +256,8 @@ class TestProjectGen(unittest.TestCase):
                                               'bemerkung_fr',
                                               'standorttyp',
                                               'bemerkung',
-                                              'bemerkung_de'])
+                                              'bemerkung_de',
+                                              'T_basket'])
 
                 tab_list = [tab.name() for tab in tabs]
                 expected_tab_list = ['General',
@@ -285,7 +290,9 @@ class TestProjectGen(unittest.TestCase):
                       'egrid_',
                       'untersmassn_',
                       'parzellenidentifikation',
-                      'belasteter_standort_geo_lage_punkt']) == set([layer.name for layer in available_layers])
+                      'belasteter_standort_geo_lage_punkt',
+                      'T_ILI2DB_BASKET',
+                      'T_ILI2DB_DATASET']) == set([layer.name for layer in available_layers])
 
     def test_kbs_geopackage(self):
         importer = iliimporter.Importer()
@@ -342,7 +349,8 @@ class TestProjectGen(unittest.TestCase):
                                               'bemerkung_fr',
                                               'bemerkung_rm',
                                               'bemerkung_it',
-                                              'bemerkung_en'])
+                                              'bemerkung_en',
+                                              'T_basket'])
 
                 tab_list = [tab.name() for tab in tabs]
                 expected_tab_list = ['General',
@@ -375,7 +383,9 @@ class TestProjectGen(unittest.TestCase):
                               'egrid_',
                               'untersmassn_',
                               'parzellenidentifikation',
-                              'belasteter_standort_geo_lage_punkt']) == set([layer.name for layer in available_layers])
+                              'belasteter_standort_geo_lage_punkt',
+                              'T_ILI2DB_BASKET',
+                              'T_ILI2DB_DATASET']) == set([layer.name for layer in available_layers])
 
     def test_naturschutz_postgis(self):
         importer = iliimporter.Importer()
@@ -395,9 +405,9 @@ class TestProjectGen(unittest.TestCase):
         available_layers = generator.layers([])
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 15
-        assert len(available_layers) == 23
-        assert len(relations) == 13
+        assert len(ignored_layers) == 13
+        assert len(available_layers) == 25
+        assert len(relations) == 29
 
     def test_naturschutz_geopackage(self):
         importer = iliimporter.Importer()
@@ -421,9 +431,9 @@ class TestProjectGen(unittest.TestCase):
         available_layers = generator.layers([])
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 24
-        assert len(available_layers) == 23
-        assert len(relations) == 13
+        assert len(ignored_layers) == 22
+        assert len(available_layers) == 25
+        assert len(relations) == 29
 
     def test_naturschutz_mssql(self):
         importer = iliimporter.Importer()
@@ -451,9 +461,9 @@ class TestProjectGen(unittest.TestCase):
         available_layers = generator.layers([])
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 19
-        assert len(available_layers) == 23
-        assert len(relations) == 22
+        assert len(ignored_layers) == 17
+        assert len(available_layers) == 25
+        assert len(relations) == 38
 
     def test_naturschutz_set_ignored_layers_postgis(self):
         importer = iliimporter.Importer()
@@ -474,9 +484,9 @@ class TestProjectGen(unittest.TestCase):
         available_layers = generator.layers([])
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 17
-        assert len(available_layers) == 21
-        assert len(relations) == 12
+        assert len(ignored_layers) == 15
+        assert len(available_layers) == 23
+        assert len(relations) == 26
 
     def test_naturschutz_set_ignored_layers_geopackage(self):
         importer = iliimporter.Importer()
@@ -502,9 +512,9 @@ class TestProjectGen(unittest.TestCase):
         legend = generator.legend(available_layers)
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 26
-        assert len(available_layers) == 21
-        assert len(relations) == 12
+        assert len(ignored_layers) == 24
+        assert len(available_layers) == 23
+        assert len(relations) == 26
 
         project = Project()
         project.layers = available_layers
@@ -547,9 +557,9 @@ class TestProjectGen(unittest.TestCase):
         available_layers = generator.layers([])
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 21
-        assert len(available_layers) == 21
-        assert len(relations) == 21
+        assert len(ignored_layers) == 19
+        assert len(available_layers) == 23
+        assert len(relations) == 35
 
     def test_naturschutz_nometa_postgis(self):
         #model with missing meta attributes for multigeometry - no layers should be ignored
@@ -570,9 +580,9 @@ class TestProjectGen(unittest.TestCase):
         available_layers = generator.layers([])
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 9
-        assert len(available_layers) == 29
-        assert len(relations) == 23
+        assert len(ignored_layers) == 7
+        assert len(available_layers) == 31
+        assert len(relations) == 45
 
     def test_naturschutz_nometa_geopackage(self):
         #model with missing meta attributes for multigeometry - no layers should be ignored
@@ -597,9 +607,9 @@ class TestProjectGen(unittest.TestCase):
         available_layers = generator.layers([])
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 18
-        assert len(available_layers) == 29
-        assert len(relations) == 23
+        assert len(ignored_layers) == 16
+        assert len(available_layers) == 31
+        assert len(relations) == 45
 
     def test_ranges_postgis(self):
         importer = iliimporter.Importer()
@@ -1355,7 +1365,7 @@ class TestProjectGen(unittest.TestCase):
                     if tab.name() == 'General':
                         count = 1
                         attribute_names = [child.name() for child in tab.children()]
-                        assert len(attribute_names) == 18
+                        assert len(attribute_names) == 19
                         assert 'tipo' not in attribute_names
                         assert 'avaluo' not in attribute_names
 
@@ -1405,7 +1415,7 @@ class TestProjectGen(unittest.TestCase):
                     if tab.name() == 'General':
                         count = 1
                         attribute_names = [child.name() for child in tab.children()]
-                        assert len(attribute_names) == 18
+                        assert len(attribute_names) == 19
                         assert 'tipo' not in attribute_names
                         assert 'avaluo' not in attribute_names
 
@@ -2080,17 +2090,18 @@ class TestProjectGen(unittest.TestCase):
                                               'ilidata:ch.opengis.topping.opengisch_KbS_LV95_V1_4_005']
         qml_file_model = self.get_topping_file_model(importer.configuration.base_configuration, list(qml_section.values()))
         for layer in project.layers:
-            if any(layer.alias.lower() == s for s in qml_section):
-                layer_qml = layer.alias.lower()
-            elif any(f'"{layer.alias.lower()}"' == s for s in qml_section):
-                layer_qml = f'"{layer.alias.lower()}"'
-            else:
-                continue
-            matches = qml_file_model.match(qml_file_model.index(0, 0), Qt.DisplayRole,
-                                           qml_section[layer_qml], 1)
-            if matches:
-                style_file_path = matches[0].data(int(IliToppingFileItemModel.Roles.LOCALFILEPATH))
-                layer.layer.loadNamedStyle(style_file_path)
+            if layer.alias: 
+                if any(layer.alias.lower() == s for s in qml_section):
+                    layer_qml = layer.alias.lower()
+                elif any(f'"{layer.alias.lower()}"' == s for s in qml_section):
+                    layer_qml = f'"{layer.alias.lower()}"'
+                else:
+                    continue
+                matches = qml_file_model.match(qml_file_model.index(0, 0), Qt.DisplayRole,
+                                            qml_section[layer_qml], 1)
+                if matches:
+                    style_file_path = matches[0].data(int(IliToppingFileItemModel.Roles.LOCALFILEPATH))
+                    layer.layer.loadNamedStyle(style_file_path)
 
         layer_names = set([layer.name for layer in available_layers])
         assert layer_names == {'untersuchungsmassnahmen_definition', 'statusaltlv_definition', 'untersmassn',
@@ -2098,7 +2109,7 @@ class TestProjectGen(unittest.TestCase):
                                        'languagecode_iso639_1', 'belasteter_standort', 'zustaendigkeitkataster',
                                        'deponietyp_', 'standorttyp', 'localisedtext', 'multilingualmtext',
                                        'untersmassn_', 'statusaltlv', 'localisedmtext', 'standorttyp_definition',
-                                       'egrid_', 'deponietyp'}
+                                       'egrid_', 'deponietyp', 't_ili2db_basket', 't_ili2db_dataset'}
         
         count = 0
         for layer in available_layers:
@@ -2329,17 +2340,18 @@ class TestProjectGen(unittest.TestCase):
                                               'ilidata:ch.opengis.topping.opengisch_KbS_LV95_V1_4_005']
         qml_file_model = self.get_topping_file_model(importer.configuration.base_configuration, list(qml_section.values()))
         for layer in project.layers:
-            if any(layer.alias.lower() == s for s in qml_section):
-                layer_qml = layer.alias.lower()
-            elif any(f'"{layer.alias.lower()}"' == s for s in qml_section):
-                layer_qml = f'"{layer.alias.lower()}"'
-            else:
-                continue
-            matches = qml_file_model.match(qml_file_model.index(0, 0), Qt.DisplayRole,
-                                           qml_section[layer_qml], 1)
-            if matches:
-                style_file_path = matches[0].data(int(IliToppingFileItemModel.Roles.LOCALFILEPATH))
-                layer.layer.loadNamedStyle(style_file_path)
+            if layer.alias: 
+                if any(layer.alias.lower() == s for s in qml_section):
+                    layer_qml = layer.alias.lower()
+                elif any(f'"{layer.alias.lower()}"' == s for s in qml_section):
+                    layer_qml = f'"{layer.alias.lower()}"'
+                else:
+                    continue
+                matches = qml_file_model.match(qml_file_model.index(0, 0), Qt.DisplayRole,
+                                            qml_section[layer_qml], 1)
+                if matches:
+                    style_file_path = matches[0].data(int(IliToppingFileItemModel.Roles.LOCALFILEPATH))
+                    layer.layer.loadNamedStyle(style_file_path)
 
         layer_names = set([layer.name for layer in available_layers])
         assert layer_names == {'untersuchungsmassnahmen_definition', 'statusaltlv_definition', 'untersmassn',
@@ -2347,7 +2359,7 @@ class TestProjectGen(unittest.TestCase):
                                        'languagecode_iso639_1', 'belasteter_standort', 'zustaendigkeitkataster',
                                        'deponietyp_', 'standorttyp', 'localisedtext', 'multilingualmtext',
                                        'untersmassn_', 'statusaltlv', 'localisedmtext', 'standorttyp_definition',
-                                       'egrid_', 'deponietyp', 'belasteter_standort_geo_lage_punkt'}
+                                       'egrid_', 'deponietyp', 'belasteter_standort_geo_lage_punkt', 'T_ILI2DB_BASKET', 'T_ILI2DB_DATASET'}
 
         count = 0
         for layer in available_layers:


### PR DESCRIPTION
`--createBasketCol` is active on default - you are still able to deactivate it.

When it's enabled, the following things are done:
- The layers have a `t_basket` column (ili2db) and the fields are integrated in the form.
- The layers `t_ili2db_basket` and `t_ili2db_dataset` are loaded in the project. They are needed to have the reference to them (to fill up `t_basket` in the single layers).
- For the layer `t_ili2db_basket` a display expression is created to provide the user a nice selection in the Relation Reference Widget of `t_basket`.

Questions:
- The "technical" tables `t_ili2db_basket` and `t_ili2db_dataset` are needed to be loaded. But where should they be placed? "Domain" would be a nice group since these are the tables the user usually is not interested in, but it's actually the wrong place, since these are no "Domain" tables.
- And should the tables `t_ili2db_basket` and `t_ili2db_dataset` be editable? It's planned to have a Dataset Manager as Model Baker functionality to edit them. But still it might be interesting for the user to edit them.

To Do:
~~- [ ] In case that the tables `t_ili2db_basket` and `t_ili2db_dataset` are editable, then we might care for `t_id` (and maybe `t_ili_tid`) creation, since that is not done by the DB (neither GeoPackage nor PG).~~
- [x] Filter the baskets for the topic the current table is in
- [x] Tests
