### PR TITLE
Create multiple relation editor widgets for same relation

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/dataobjects/form.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/form.py
@@ -110,8 +110,9 @@ class FormFieldWidget(object):
 
 class FormRelationWidget(object):
 
-    def __init__(self, relation):
+    def __init__(self, relation, nmRelation=None):
         self.relation = relation
+        self.nmRelation = nmRelation
 
     def create(self, parent, layer):
         try:
@@ -121,4 +122,6 @@ class FormRelationWidget(object):
             # Feed deprecated API for 3.0.0 and 3.0.1
             widget = QgsAttributeEditorRelation(
                self.relation.id, self.relation.id, parent)
+        if self.nmRelation:
+            widget.setNmRelationId(self.nmRelation.id)
         return widget

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/form.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/form.py
@@ -110,9 +110,9 @@ class FormFieldWidget(object):
 
 class FormRelationWidget(object):
 
-    def __init__(self, relation, nmRelation=None):
+    def __init__(self, relation, nm_relation=None):
         self.relation = relation
-        self.nmRelation = nmRelation
+        self.nm_relation = nm_relation
 
     def create(self, parent, layer):
         try:
@@ -122,6 +122,6 @@ class FormRelationWidget(object):
             # Feed deprecated API for 3.0.0 and 3.0.1
             widget = QgsAttributeEditorRelation(
                self.relation.id, self.relation.id, parent)
-        if self.nmRelation:
-            widget.setNmRelationId(self.nmRelation.id)
+        if self.nm_relation:
+            widget.setNmRelationId(self.nm_relation.id)
         return widget

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
@@ -17,6 +17,7 @@
  *                                                                         *
  ***************************************************************************/
 """
+import logging
 from .form import (
     Form,
     FormTab,
@@ -24,6 +25,7 @@ from .form import (
     FormFieldWidget
 )
 from qgis.core import (
+    Qgis,
     QgsVectorLayer,
     QgsDataSourceUri,
     QgsWkbTypes,
@@ -161,12 +163,36 @@ class Layer(object):
 
             self.__form.add_element(tab)
 
+            relations_to_add = set()
             for relation in project.relations:
                 if relation.referenced_layer == self:
+
+                    # 1:m relation will be added only if does not point to a pure link table
+                    if relation.referencing_layer.isPureLinkTable(project) is False:
+                        relations_to_add.add((relation, None))
+
+                    for nmRelation in project.relations:
+                        if nmRelation == relation:
+                            continue
+
+                        if nmRelation.referencing_layer == relation.referencing_layer:
+                            relations_to_add.add((relation, nmRelation))
+
+            for relation, nmRelation in relations_to_add:
+                if nmRelation and Qgis.QGIS_VERSION_INT < 31600:
+                    logger = logging.getLogger(__name__)
+                    logger.warning('QGIS version older than 3.16. Relation editor widget for relation "{0}" will not be added.'.format(nmRelation.name))
+                    continue
+
+                if nmRelation:
+                    tab = FormTab(nmRelation.referenced_layer.name)
+                else:
                     tab = FormTab(relation.referencing_layer.name)
-                    widget = FormRelationWidget(relation)
-                    tab.addChild(widget)
-                    self.__form.add_element(tab)
+
+                widget = FormRelationWidget(relation, nmRelation)
+                tab.addChild(widget)
+                self.__form.add_element(tab)
+
         else:
             for field in self.fields:
                 if not field.hidden:
@@ -186,3 +212,21 @@ class Layer(object):
             return self.__layer.id()
         else:
             return None
+
+    def isPureLinkTable(self, project):
+        '''
+        Returns True if the layer is a pure link table in a n:m relation.
+        With "pure" it is meant the layer has no more fields than foreign keys and its id.
+        '''
+        remaining_fields = set()
+        for field in self.fields:
+            remaining_fields.add(field.name)
+
+        for relation in project.relations:
+            if relation.referencing_layer != self:
+                continue
+
+            remaining_fields.remove(relation.referencing_field)
+
+        return len(remaining_fields) <= 1
+

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
@@ -37,7 +37,7 @@ from qgis.PyQt.QtCore import QCoreApplication, QSettings
 
 class Layer(object):
 
-    def __init__(self, provider, uri, name, srid, extent, geometry_column=None, wkb_type=QgsWkbTypes.Unknown, alias=None, is_domain=False, is_structure=False, is_nmrel=False, display_expression=None, coordinate_precision=None, is_basket_table=False, is_dataset_table = False, model_topic_name=None):
+    def __init__(self, provider, uri, name, srid, extent, geometry_column=None, wkb_type=QgsWkbTypes.Unknown, alias=None, is_domain=False, is_structure=False, is_nmrel=False, display_expression=None, coordinate_precision=None, is_basket_table=False, is_dataset_table = False, model_topic_name=None, tid='', tilitid=''):
         self.provider = provider
         self.uri = uri
         self.name = name
@@ -76,6 +76,10 @@ class Layer(object):
         self.expanded = True
         self.checked = True
         self.featurecount = False
+
+        # ili column names
+        self.tid = tid
+        self.tilitid = tilitid
 
     def dump(self):
         definition = dict()
@@ -168,7 +172,8 @@ class Layer(object):
                 if relation.referenced_layer == self:
 
                     # 1:m relation will be added only if does not point to a pure link table
-                    if relation.referencing_layer.isPureLinkTable(project) is False:
+                    if (not relation.referencing_layer.isPureLinkTable(project) 
+                       or Qgis.QGIS_VERSION_INT < 31600):
                         relations_to_add.add((relation, None))
 
                     for nm_relation in project.relations:
@@ -234,8 +239,8 @@ class Layer(object):
             remaining_fields.discard(relation.referencing_field)
 
         # Remove Id fields
-        remaining_fields.discard('t_id')
-        remaining_fields.discard('t_ili_tid')
+        remaining_fields.discard(self.tid)
+        remaining_fields.discard(self.tilitid)
 
         return len(remaining_fields) == 0
 

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
@@ -171,25 +171,25 @@ class Layer(object):
                     if relation.referencing_layer.isPureLinkTable(project) is False:
                         relations_to_add.add((relation, None))
 
-                    for nmRelation in project.relations:
-                        if nmRelation == relation:
+                    for nm_relation in project.relations:
+                        if nm_relation == relation:
                             continue
 
-                        if nmRelation.referencing_layer == relation.referencing_layer:
-                            relations_to_add.add((relation, nmRelation))
+                        if nm_relation.referencing_layer == relation.referencing_layer:
+                            relations_to_add.add((relation, nm_relation))
 
-            for relation, nmRelation in relations_to_add:
-                if nmRelation and Qgis.QGIS_VERSION_INT < 31600:
+            for relation, nm_relation in relations_to_add:
+                if nm_relation and Qgis.QGIS_VERSION_INT < 31600:
                     logger = logging.getLogger(__name__)
-                    logger.warning('QGIS version older than 3.16. Relation editor widget for relation "{0}" will not be added.'.format(nmRelation.name))
+                    logger.warning('QGIS version older than 3.16. Relation editor widget for relation "{0}" will not be added.'.format(nm_relation.name))
                     continue
 
-                if nmRelation:
-                    tab = FormTab(nmRelation.referenced_layer.name)
+                if nm_relation:
+                    tab = FormTab(nm_relation.referenced_layer.name)
                 else:
                     tab = FormTab(relation.referencing_layer.name)
 
-                widget = FormRelationWidget(relation, nmRelation)
+                widget = FormRelationWidget(relation, nm_relation)
                 tab.addChild(widget)
                 self.__form.add_element(tab)
 
@@ -220,7 +220,7 @@ class Layer(object):
         '''
 
         # Check if table is a link table
-        if self.is_nmrel is False:
+        if not self.is_nmrel:
             return False
 
         remaining_fields = set()
@@ -231,8 +231,11 @@ class Layer(object):
         for relation in project.relations:
             if relation.referencing_layer != self:
                 continue
-            remaining_fields.remove(relation.referencing_field)
+            remaining_fields.discard(relation.referencing_field)
 
-        # Only Id field left?
-        return len(remaining_fields) <= 1
+        # Remove Id fields
+        remaining_fields.discard('t_id')
+        remaining_fields.discard('t_ili_tid')
+
+        return len(remaining_fields) == 0
 

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/layers.py
@@ -218,15 +218,21 @@ class Layer(object):
         Returns True if the layer is a pure link table in a n:m relation.
         With "pure" it is meant the layer has no more fields than foreign keys and its id.
         '''
+
+        # Check if table is a link table
+        if self.is_nmrel is False:
+            return False
+
         remaining_fields = set()
         for field in self.fields:
             remaining_fields.add(field.name)
 
+        # Remove all fields that are referencing fields
         for relation in project.relations:
             if relation.referencing_layer != self:
                 continue
-
             remaining_fields.remove(relation.referencing_field)
 
+        # Only Id field left?
         return len(remaining_fields) <= 1
 

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -181,9 +181,7 @@ class Generator(QObject):
                 coordinate_precision,
                 is_basket_table,
                 is_dataset_table,
-                model_topic_name,
-                self._db_connector.tid,
-                self._db_connector.tilitid )
+                model_topic_name )
 
             # Configure fields for current table
             fields_info = self.get_fields_info(record['tablename'])

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -181,7 +181,9 @@ class Generator(QObject):
                 coordinate_precision,
                 is_basket_table,
                 is_dataset_table,
-                model_topic_name )
+                model_topic_name,
+                self._db_connector.tid,
+                self._db_connector.tilitid )
 
             # Configure fields for current table
             fields_info = self.get_fields_info(record['tablename'])

--- a/QgisModelBaker/tests/test_projectgen.py
+++ b/QgisModelBaker/tests/test_projectgen.py
@@ -116,8 +116,14 @@ class TestProjectGen(unittest.TestCase):
                                               'bemerkung_de',
                                               't_basket'])
 
-                # This might need to be adjusted if we get better names
-                assert tabs[1].name() == 'deponietyp_'
+                tab_list = [tab.name() for tab in tabs]
+                expected_tab_list = ['General',
+                                     'parzellenidentifikation',
+                                     'egrid_',
+                                     'deponietyp',
+                                     'untersmassn']
+                assert set(tab_list) == set(expected_tab_list)
+                assert len(tab_list) == len(expected_tab_list)
 
             if layer.name == 'belasteter_standort' and layer.geometry_column == 'geo_lage_polygon':
                 belasteter_standort_polygon_layer = layer
@@ -186,8 +192,14 @@ class TestProjectGen(unittest.TestCase):
                                               'geo_lage_punkt',
                                               't_basket'])
 
-                # This might need to be adjusted if we get better names
-                assert tabs[1].name() == 'deponietyp_'
+                tab_list = [tab.name() for tab in tabs]
+                expected_tab_list = ['General',
+                                     'parzellenidentifikation',
+                                     'egrid_',
+                                     'deponietyp',
+                                     'untersmassn']
+                assert set(tab_list) == set(expected_tab_list)
+                assert len(tab_list) == len(expected_tab_list)
 
             if layer.name == 'belasteter_standort' and layer.geometry_column == 'geo_lage_polygon':
                 belasteter_standort_polygon_layer = layer
@@ -264,9 +276,10 @@ class TestProjectGen(unittest.TestCase):
                                      'parzellenidentifikation',
                                      'belasteter_standort_geo_lage_punkt',
                                      'egrid_',
-                                     'deponietyp_',
-                                     'untersmassn_']
+                                     'deponietyp',
+                                     'untersmassn']
                 assert set(tab_list) == set(expected_tab_list)
+                assert len(tab_list) == len(expected_tab_list)
 
                 for tab in tabs:
                     if len(tab.findElements(tab.AeTypeRelation)) == 0:
@@ -357,9 +370,10 @@ class TestProjectGen(unittest.TestCase):
                                      'parzellenidentifikation',
                                      'belasteter_standort_geo_lage_punkt',
                                      'egrid_',
-                                     'deponietyp_',
-                                     'untersmassn_']
+                                     'deponietyp',
+                                     'untersmassn']
                 assert set(tab_list) == set(expected_tab_list)
+                assert len(tab_list) == len(expected_tab_list)
 
                 for tab in tabs:
                     if len(tab.findElements(tab.AeTypeRelation)) == 0:

--- a/QgisModelBaker/tests/test_projectgen.py
+++ b/QgisModelBaker/tests/test_projectgen.py
@@ -116,14 +116,15 @@ class TestProjectGen(unittest.TestCase):
                                               'bemerkung_de',
                                               't_basket'])
 
-                tab_list = [tab.name() for tab in tabs]
-                expected_tab_list = ['General',
-                                     'parzellenidentifikation',
-                                     'egrid_',
-                                     'deponietyp',
-                                     'untersmassn']
-                assert set(tab_list) == set(expected_tab_list)
-                assert len(tab_list) == len(expected_tab_list)
+                if Qgis.QGIS_VERSION_INT >= 31600:
+                    tab_list = [tab.name() for tab in tabs]
+                    expected_tab_list = ['General',
+                                         'parzellenidentifikation',
+                                         'egrid_',
+                                         'deponietyp',
+                                         'untersmassn']
+                    assert set(tab_list) == set(expected_tab_list)
+                    assert len(tab_list) == len(expected_tab_list)
 
             if layer.name == 'belasteter_standort' and layer.geometry_column == 'geo_lage_polygon':
                 belasteter_standort_polygon_layer = layer
@@ -192,14 +193,15 @@ class TestProjectGen(unittest.TestCase):
                                               'geo_lage_punkt',
                                               't_basket'])
 
-                tab_list = [tab.name() for tab in tabs]
-                expected_tab_list = ['General',
-                                     'parzellenidentifikation',
-                                     'egrid_',
-                                     'deponietyp',
-                                     'untersmassn']
-                assert set(tab_list) == set(expected_tab_list)
-                assert len(tab_list) == len(expected_tab_list)
+                if Qgis.QGIS_VERSION_INT >= 31600:
+                    tab_list = [tab.name() for tab in tabs]
+                    expected_tab_list = ['General',
+                                         'parzellenidentifikation',
+                                         'egrid_',
+                                         'deponietyp',
+                                         'untersmassn']
+                    assert set(tab_list) == set(expected_tab_list)
+                    assert len(tab_list) == len(expected_tab_list)
 
             if layer.name == 'belasteter_standort' and layer.geometry_column == 'geo_lage_polygon':
                 belasteter_standort_polygon_layer = layer
@@ -271,15 +273,16 @@ class TestProjectGen(unittest.TestCase):
                                               'bemerkung_de',
                                               'T_basket'])
 
-                tab_list = [tab.name() for tab in tabs]
-                expected_tab_list = ['General',
-                                     'parzellenidentifikation',
-                                     'belasteter_standort_geo_lage_punkt',
-                                     'egrid_',
-                                     'deponietyp',
-                                     'untersmassn']
-                assert set(tab_list) == set(expected_tab_list)
-                assert len(tab_list) == len(expected_tab_list)
+                if Qgis.QGIS_VERSION_INT >= 31600:
+                    tab_list = [tab.name() for tab in tabs]
+                    expected_tab_list = ['General',
+                                         'parzellenidentifikation',
+                                         'belasteter_standort_geo_lage_punkt',
+                                         'egrid_',
+                                         'deponietyp',
+                                         'untersmassn']
+                    assert set(tab_list) == set(expected_tab_list)
+                    assert len(tab_list) == len(expected_tab_list)
 
                 for tab in tabs:
                     if len(tab.findElements(tab.AeTypeRelation)) == 0:
@@ -365,15 +368,16 @@ class TestProjectGen(unittest.TestCase):
                                               'bemerkung_en',
                                               'T_basket'])
 
-                tab_list = [tab.name() for tab in tabs]
-                expected_tab_list = ['General',
-                                     'parzellenidentifikation',
-                                     'belasteter_standort_geo_lage_punkt',
-                                     'egrid_',
-                                     'deponietyp',
-                                     'untersmassn']
-                assert set(tab_list) == set(expected_tab_list)
-                assert len(tab_list) == len(expected_tab_list)
+                if Qgis.QGIS_VERSION_INT >= 31600:
+                    tab_list = [tab.name() for tab in tabs]
+                    expected_tab_list = ['General',
+                                         'parzellenidentifikation',
+                                         'belasteter_standort_geo_lage_punkt',
+                                         'egrid_',
+                                         'deponietyp',
+                                         'untersmassn']
+                    assert set(tab_list) == set(expected_tab_list)
+                    assert len(tab_list) == len(expected_tab_list)
 
                 for tab in tabs:
                     if len(tab.findElements(tab.AeTypeRelation)) == 0:


### PR DESCRIPTION
Create multiple relation editor widgets for same relation close #505

Notes:
- For many to many relations the cardinality is set to the the linked parent table
- If the link table has additional attributes that are not foreign keys (Associations with attributes), an additional relation editor widget pointing to the link table is added