### PR TITLE
Fix Topic parsing

### DIFF
--- a/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -684,6 +684,7 @@ class GPKGConnector(DBConnector):
                     SELECT DISTINCT substr(IliName, 0, instr(IliName, '.')) as model,
                     substr(substr(IliName, instr(IliName, '.')+1),0, instr(substr(IliName, instr(IliName, '.')+1),'.')) as topic
                     FROM T_ILI2DB_CLASSNAME
+					WHERE topic != ''
                 """
             )
             contents = cur.fetchall()

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
@@ -767,6 +767,7 @@ WHERE TABLE_SCHEMA='{schema}'
                     SELECT DISTINCT PARSENAME(iliname,1) as model,
                     PARSENAME(iliname,2) as topic
                     FROM {schema}.t_ili2db_classname
+					WHERE PARSENAME(iliname,3) != ''
                 """.format(
                     schema=self.schema
                 )

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -843,9 +843,10 @@ class PGConnector(DBConnector):
             cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
             cur.execute(
                 """
-                    SELECT DISTINCT split_part(iliname,'.',1) as model,
-                    split_part(iliname,'.',2) as topic
+                    SELECT DISTINCT (string_to_array(iliname, '.'))[1] as model,
+                    (string_to_array(iliname, '.'))[2] as topic
                     FROM {schema}.t_ili2db_classname
+					WHERE array_length(string_to_array(iliname, '.'),1) > 2
                 """.format(
                     schema=self.schema
                 )

--- a/QgisModelBaker/tests/testdata/ilimodels/OeVBasketTest_V1.ili
+++ b/QgisModelBaker/tests/testdata/ilimodels/OeVBasketTest_V1.ili
@@ -4,6 +4,11 @@ MODEL OeVBasketTest (en)
 AT "https://signedav.github.io/usabilitydave/models"
 VERSION "2020-06-22" =
 
+  STRUCTURE Address =
+    Street: TEXT;
+    Number: TEXT;
+  END Address;
+
   TOPIC OeVLinien =
 
     BASKET OID AS INTERLIS.UUIDOID;
@@ -11,6 +16,7 @@ VERSION "2020-06-22" =
     CLASS SingleLinie  =
       Bezeichnung : MANDATORY TEXT*99;
       Code : MANDATORY TEXT*15;
+      Address : Address;
     END SingleLinie;
 
   END OeVLinien;
@@ -22,6 +28,7 @@ VERSION "2020-06-22" =
     CLASS Haltestelle  =
       Name : MANDATORY TEXT*99;
       Code : MANDATORY TEXT*15;
+      Address : Address;
     END Haltestelle;
 
   END Infrastruktur;


### PR DESCRIPTION
The parsing was not stable when there are STRUCTURES in the INTERLIS Model that are not in a Topic.

This fixes the basic problem of #533

Not yet solved is being able to choose the correct basket for the STRUCTURE that could be related from classes from several topics.