### PR TITLE
Correct basket handling of tables having no topic

### DIFF
--- a/QgisModelBaker/gui/panel/dataset_selector.py
+++ b/QgisModelBaker/gui/panel/dataset_selector.py
@@ -118,9 +118,9 @@ class DatasetSelector(QComboBox):
 
         # set the filter of the model according the current uri_identificator
         schema_topic_identificator = (
-            f"{schema_identificator}_{slugify(layer_model_topic_name)}"
+            f"{schema_identificator}_{slugify(layer_model_topic_name or '.*')}"
         )
-        self.filtered_model.setFilterFixedString(schema_topic_identificator)
+        self.filtered_model.setFilterRegExp(schema_topic_identificator)
 
         if not self.basket_model.schema_baskets_loaded(schema_identificator):
             mode, configuration = get_configuration(source_name, source)

--- a/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
+++ b/QgisModelBaker/libqgsprojectgen/dataobjects/project.py
@@ -142,7 +142,9 @@ class Project(QObject):
                         "AllowAddFeatures": False,
                         "FilterExpression": "\"topic\" = '{}'".format(
                             referencing_layer.model_topic_name
-                        ),
+                        )
+                        if referencing_layer.model_topic_name
+                        else "",
                         "FilterFields": list(),
                     },
                 )

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -188,7 +188,8 @@ class Generator(QObject):
 
             model_topic_name = ""
             if "ili_name" in record and record["ili_name"]:
-                model_topic_name = f"{record['ili_name'].split('.')[0]}.{record['ili_name'].split('.')[1]}"
+                if record["ili_name"].count(".") > 1:
+                    model_topic_name = f"{record['ili_name'].split('.')[0]}.{record['ili_name'].split('.')[1]}"
 
             display_expression = ""
             if is_basket_table:

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -193,7 +193,7 @@ class Generator(QObject):
 
             display_expression = ""
             if is_basket_table:
-                display_expression = "coalesce(attribute(get_feature('{dataset_layer_name}', '{tid}', dataset), 'datasetname') || ' (' || topic || ') ', coalesce( attribute(get_feature('{dataset_layer_name}', '{tid}', dataset), 'datasetname'), topic))".format(
+                display_expression = "coalesce(attribute(get_feature('{dataset_layer_name}', '{tid}', dataset), 'datasetname') || ' (' || topic || ') ', coalesce( attribute(get_feature('{dataset_layer_name}', '{tid}', dataset), 'datasetname'), {tilitid}))".format(
                     tid=self._db_connector.tid,
                     tilitid=self._db_connector.tilitid,
                     dataset_layer_name=self._db_connector.dataset_table_name,

--- a/QgisModelBaker/libqgsprojectgen/generator/generator.py
+++ b/QgisModelBaker/libqgsprojectgen/generator/generator.py
@@ -193,7 +193,7 @@ class Generator(QObject):
 
             display_expression = ""
             if is_basket_table:
-                display_expression = "coalesce(attribute(get_feature('{dataset_layer_name}', '{tid}', dataset), 'datasetname') || ' (' || {tilitid} || ') ', coalesce( attribute(get_feature('{dataset_layer_name}', '{tid}', dataset), 'datasetname'), {tilitid}))".format(
+                display_expression = "coalesce(attribute(get_feature('{dataset_layer_name}', '{tid}', dataset), 'datasetname') || ' (' || topic || ') ', coalesce( attribute(get_feature('{dataset_layer_name}', '{tid}', dataset), 'datasetname'), topic))".format(
                     tid=self._db_connector.tid,
                     tilitid=self._db_connector.tilitid,
                     dataset_layer_name=self._db_connector.dataset_table_name,

--- a/QgisModelBaker/tests/test_projectgen.py
+++ b/QgisModelBaker/tests/test_projectgen.py
@@ -2547,7 +2547,7 @@ class TestProjectGen(unittest.TestCase):
                 display_expression = layer.layer.displayExpression()
                 assert (
                     display_expression
-                    == "coalesce(attribute(get_feature('t_ili2db_dataset', 't_id', dataset), 'datasetname') || ' (' || t_ili_tid || ') ', coalesce( attribute(get_feature('t_ili2db_dataset', 't_id', dataset), 'datasetname'), t_ili_tid))"
+                    == "coalesce(attribute(get_feature('t_ili2db_dataset', 't_id', dataset), 'datasetname') || ' (' || topic || ') ', coalesce( attribute(get_feature('t_ili2db_dataset', 't_id', dataset), 'datasetname'), t_ili_tid))"
                 )
 
         # check if the layers have been considered
@@ -2622,7 +2622,7 @@ class TestProjectGen(unittest.TestCase):
                 display_expression = layer.layer.displayExpression()
                 assert (
                     display_expression
-                    == "coalesce(attribute(get_feature('T_ILI2DB_DATASET', 'T_Id', dataset), 'datasetname') || ' (' || T_Ili_Tid || ') ', coalesce( attribute(get_feature('T_ILI2DB_DATASET', 'T_Id', dataset), 'datasetname'), T_Ili_Tid))"
+                    == "coalesce(attribute(get_feature('T_ILI2DB_DATASET', 'T_Id', dataset), 'datasetname') || ' (' || topic || ') ', coalesce( attribute(get_feature('T_ILI2DB_DATASET', 'T_Id', dataset), 'datasetname'), T_Ili_Tid))"
                 )
 
         # check if the layers have been considered


### PR DESCRIPTION
Like structs that are used in multiple topics. E.g. the `parzellenidentifikation` in `KbS_Basis_V1_3` or this simple test model:
```
MODEL NoTopicStruct (en) 
AT "https://signedav.github.io/usabilitydave/models"
VERSION "2020-06-22" =
    STRUCTURE NoTopicStructure =
        Name: TEXT;
        Street: TEXT;
    END NoTopicStructure;

    TOPIC TopicA =
        CLASS PersonInTopicA =
            Address: NoTopicStructure;
            Remark: TEXT*254;
        END PersonInTopicA;
    END TopicA; !! of TOPIC

    TOPIC TopicB =
        CLASS PersonInTopicB =
            Address: NoTopicStructure;
            Remark: TEXT*254;
        END PersonInTopicB;
    END TopicB; !! of TOPIC
    
END NoTopicStruct. !! of MODEL
```
All Baskets of the Dataset are listed in the Dataset Selector:

![image](https://user-images.githubusercontent.com/28384354/132651504-62016ad8-ec90-421a-9490-8ed95c6e777f.png)

And in the display expression of the `t_ili2db_basket` table the topic is shown (instead of mostly abstract id):
![image](https://user-images.githubusercontent.com/28384354/132651916-cb8377f5-fdc8-4f43-ad3b-3724b8db171a.png)

This finalizes the problem in #533
