### PR TITLE
Fix error when trying to connect to an XTF datasource

### DIFF
--- a/QgisModelBaker/gui/panel/dataset_selector.py
+++ b/QgisModelBaker/gui/panel/dataset_selector.py
@@ -143,12 +143,17 @@ class DatasetSelector(QComboBox):
             if valid and mode:
                 db_factory = self.db_simple_factory.create_factory(mode)
                 config_manager = db_factory.get_db_command_config_manager(configuration)
-                self.basket_model.reload_schema_baskets(
-                    db_factory.get_db_connector(
-                        config_manager.get_uri(), configuration.dbschema
-                    ),
-                    schema_identificator,
-                )
+
+                try:
+                    self.basket_model.reload_schema_baskets(
+                        db_factory.get_db_connector(
+                            config_manager.get_uri(), configuration.dbschema
+                        ),
+                        schema_identificator,
+                    )
+                except:
+                    # let it pass, it will have no entries what is okey
+                    pass
 
         if self.filtered_model.rowCount():
             self.currentIndexChanged.connect(self._store_basket_tid)

--- a/QgisModelBaker/utils/db_utils.py
+++ b/QgisModelBaker/utils/db_utils.py
@@ -69,11 +69,11 @@ def get_configuration_from_layersource(layer_source_name, layer_source):
         configuration.database = layer_source.database()
         configuration.dbschema = layer_source.schema()
         valid = bool(
-            configuration.dbusr()
-            and configuration.dbpwd()
-            and configuration.dbhost()
-            and configuration.database()
-            and configuration.schema()
+            configuration.dbusr
+            and configuration.dbpwd
+            and configuration.dbhost
+            and configuration.database
+            and configuration.dbschema
         )
     elif layer_source_name == "ogr":
         mode = DbIliMode.gpkg
@@ -87,11 +87,11 @@ def get_configuration_from_layersource(layer_source_name, layer_source):
         configuration.database = layer_source.database()
         configuration.dbschema = layer_source.schema()
         valid = bool(
-            configuration.dbusr()
-            and configuration.dbpwd()
-            and configuration.dbhost()
-            and configuration.database()
-            and configuration.schema()
+            configuration.dbusr
+            and configuration.dbpwd
+            and configuration.dbhost
+            and configuration.database
+            and configuration.dbschema
         )
     return valid, mode, configuration
 


### PR DESCRIPTION
When connecting to a layer based on an XTF file (what returns as datasourcename OGR), the get db connector failed. This is caught by the try.