### PR TITLE
Smarter parsing for models in xtf

### DIFF
--- a/QgisModelBaker/gui/workflow_wizard/wizard_tools.py
+++ b/QgisModelBaker/gui/workflow_wizard/wizard_tools.py
@@ -425,7 +425,7 @@ class ImportModelsModel(SourceModel):
                 model = item.data(int(SourceModel.Roles.NAME))
                 source = (
                     item.data(int(SourceModel.Roles.PATH))
-                    if type != "model"
+                    if type == "ili"
                     else "repository " + model
                 )
 


### PR DESCRIPTION
Use of more performant xtf parsing function.

No multicheck of same model.

Dont't consider models parsed from xtf as models from a file.


References #529 