### PR TITLE
Only "reuse" existing skipped session-widgets

### DIFF
--- a/QgisModelBaker/gui/panel/dataset_selector.py
+++ b/QgisModelBaker/gui/panel/dataset_selector.py
@@ -25,7 +25,7 @@ from qgis.PyQt.QtWidgets import QComboBox, QWidget
 
 from QgisModelBaker.utils.db_utils import (
     get_configuration_from_layersource,
-    get_schema_identificator,
+    get_schema_identificator_from_layersource,
 )
 from QgisModelBaker.utils.qt_utils import slugify
 
@@ -122,7 +122,9 @@ class DatasetSelector(QComboBox):
 
         source_name = layer.dataProvider().name()
         source = QgsDataSourceUri(layer.dataProvider().dataSourceUri())
-        schema_identificator = get_schema_identificator(source_name, source)
+        schema_identificator = get_schema_identificator_from_layersource(
+            source_name, source
+        )
         layer_model_topic_name = (
             QgsExpressionContextUtils.layerScope(layer).variable("interlis_topic") or ""
         )

--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -29,7 +29,6 @@ from QgisModelBaker.libili2db.ili2dbutils import JavaNotFoundError
 from QgisModelBaker.utils.qt_utils import OverrideCursor
 
 from ...libili2db import iliexecutable, iliexporter, iliimporter
-from ...libqgsprojectgen.db_factory.db_simple_factory import DbSimpleFactory
 from ...utils import ui
 from ...utils.ui import LogColor
 
@@ -107,13 +106,16 @@ class SessionPanel(QWidget, WIDGET_UI):
             )
             self.configuration.dataset = ";".join(self.datasets)
 
-        self.db_simple_factory = DbSimpleFactory()
-
         self.is_skipped_or_done = False
 
     @property
     def id(self):
-        return (self.file, self.models, self.datasets)
+        return (
+            self.file,
+            self.models,
+            self.datasets,
+            db_utils.get_schema_identificator_from_configuration(self.configuration),
+        )
 
     def set_button_to_create(self):
         """

--- a/QgisModelBaker/gui/workflow_wizard/execution_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/execution_page.py
@@ -29,6 +29,7 @@ from qgis.PyQt.QtWidgets import (
     QWizardPage,
 )
 
+import QgisModelBaker.utils.db_utils as db_utils
 from QgisModelBaker.gui.panel.session_panel import SessionPanel
 from QgisModelBaker.libili2db.globals import DbActionType
 
@@ -103,11 +104,16 @@ class ExecutionPage(QWizardPage, PAGE_UI):
                 else None
             )
 
-            existing_widget = self._find_existing_session_widget(
-                (key, models, datasets)
+            skipped_session_widget = self._find_skipped_session_widget(
+                (
+                    key,
+                    models,
+                    datasets,
+                    db_utils.get_schema_identificator_from_configuration(configuration),
+                )
             )
-            if existing_widget:
-                new_sessions.append(existing_widget)
+            if skipped_session_widget:
+                new_sessions.append(skipped_session_widget)
             else:
                 import_session = SessionPanel(
                     copy.deepcopy(configuration),
@@ -148,9 +154,9 @@ class ExecutionPage(QWizardPage, PAGE_UI):
         ]
         self.setComplete(not self.pending_sessions)
 
-    def _find_existing_session_widget(self, id):
+    def _find_skipped_session_widget(self, id):
         for session_widget in self.session_widget_list:
-            if id == session_widget.id:
+            if id == session_widget.id and session_widget.is_skipped_or_done:
                 return session_widget
         return None
 

--- a/QgisModelBaker/utils/db_utils.py
+++ b/QgisModelBaker/utils/db_utils.py
@@ -27,13 +27,23 @@ from ..libqgsprojectgen.db_factory.db_simple_factory import DbSimpleFactory
 from ..libqgsprojectgen.dbconnector.db_connector import DBConnectorError
 
 
-def get_schema_identificator(layer_source_name, layer_source):
+def get_schema_identificator_from_layersource(layer_source_name, layer_source):
     if layer_source_name == "postgres" or layer_source_name == "mssql":
         return slugify(
             f"{layer_source.host()}_{layer_source.database()}_{layer_source.schema()}"
         )
     elif layer_source_name == "ogr":
         return slugify(layer_source.uri().split("|")[0].strip())
+    return ""
+
+
+def get_schema_identificator_from_configuration(configuration):
+    if configuration.tool == DbIliMode.pg or configuration.tool == DbIliMode.mssql:
+        return slugify(
+            f"{configuration.dbhost}_{configuration.database}_{configuration.dbschema}"
+        )
+    elif configuration.tool == DbIliMode.gpkg:
+        return slugify(configuration.dbfile)
     return ""
 
 


### PR DESCRIPTION
In the wizard, the ili2db commands are represented as session-widgets:
![image](https://user-images.githubusercontent.com/28384354/138268226-9618b098-eb58-434e-a7f0-debc0a203d5a.png)
They are session-objects containing the configuration.

Before this PR on getting back and reloading the page, it reused the existing session-objects and added the new ones to the list. But when updating the configuration on the page before, the old configuration persisted in the "reused" session-objects. This is avoided now. All session-objects are created new - except when they have the "skipped" status. Then they stay skipped even when the configuration updated. 
![image](https://user-images.githubusercontent.com/28384354/138268639-814993fa-1105-48f4-8923-e396011654e8.png)
(skipped session)

Only when the database setting updated, they will be not skipped anymore.
This fixes #561