### PR TITLE
allow to drop xml files in the source selection list

### DIFF
--- a/QgisModelBaker/gui/options.py
+++ b/QgisModelBaker/gui/options.py
@@ -208,7 +208,7 @@ class ModelListView(QListView):
 
 class FileDropListView(QListView):
 
-    ValidExtenstions = ["xtf", "XTF", "itf", "ITF", "ili"]
+    ValidExtenstions = ["xtf", "XTF", "itf", "ITF", "ili", "XML", "xml"]
 
     files_dropped = pyqtSignal(list)
 


### PR DESCRIPTION
Resolves #572

On purpose this is only for the source selection list view and not when dropping files in QGIS.
Dropping in QGIS still only opens Model Baker on Interlisish types like ili and xtf.