### PR TITLE
Set dataset from the selector on first layer change

### DIFF
--- a/QgisModelBaker/gui/panel/dataset_selector.py
+++ b/QgisModelBaker/gui/panel/dataset_selector.py
@@ -156,8 +156,9 @@ class DatasetSelector(QComboBox):
                     pass
 
         if self.filtered_model.rowCount():
-            self.currentIndexChanged.connect(self._store_basket_tid)
             self._set_index(self.current_schema_topic_identificator)
+            self._store_basket_tid(self.currentIndex())
+            self.currentIndexChanged.connect(self._store_basket_tid)
             self.setEnabled(True)
 
     def reset_model(self, current_layer):


### PR DESCRIPTION
On selecting the layer the first time the dataset selector contains the first entry (index 0) -> so the dataset on index 0 should be set to the layer properties because otherwise the t_basket default value is empty. 