### PR TITLE
Fix MultilingualText / LocalisedText Element for title in the ilicache

### DIFF
--- a/QgisModelBaker/libili2db/ilicache.py
+++ b/QgisModelBaker/libili2db/ilicache.py
@@ -493,7 +493,7 @@ class IliMetaConfigCache(IliCache):
                         "ili23:title", self.ns
                     ):
                         for multilingual_m_text_element in title_element.findall(
-                            "ili23:DatasetIdx16.MultilingualMText", self.ns
+                            "ili23:DatasetIdx16.MultilingualText", self.ns
                         ):
                             for (
                                 localised_text_element
@@ -503,7 +503,7 @@ class IliMetaConfigCache(IliCache):
                                 for (
                                     localised_m_text_element
                                 ) in localised_text_element.findall(
-                                    "ili23:DatasetIdx16.LocalisedMText", self.ns
+                                    "ili23:DatasetIdx16.LocalisedText", self.ns
                                 ):
                                     title_information = {
                                         "language": localised_m_text_element.find(

--- a/QgisModelBaker/tests/testdata/ilirepo/24/ilidata.xml
+++ b/QgisModelBaker/tests/testdata/ilirepo/24/ilidata.xml
@@ -20,14 +20,14 @@
         <version>2021-01-06</version>
         <owner>mailto:david@opengis.ch</owner>
         <title>
-          <DatasetIdx16.MultilingualMText>
+          <DatasetIdx16.MultilingualText>
             <LocalisedText>
-              <DatasetIdx16.LocalisedMText>
+              <DatasetIdx16.LocalisedText>
                 <Language>de</Language>
                 <Text>Einfaches Styling und Tree und TOML und SH Cat (OPENGIS.ch)</Text>
-              </DatasetIdx16.LocalisedMText>
+              </DatasetIdx16.LocalisedText>
             </LocalisedText>
-          </DatasetIdx16.MultilingualMText>
+          </DatasetIdx16.MultilingualText>
         </title>
         <categories>
           <DatasetIdx16.Code_>
@@ -52,19 +52,19 @@
         </files>
       </DatasetIdx16.DataIndex.DatasetMetadata>
 
-      <DatasetIdx16.DataIndex.DatasetMetadata TID="27414157-9d7c-4fe2-a864-2942fab24f3c">
+      <DatasetIdx16.DataIndex.DatasetMetadata TID="af40a18c-f048-4bf7-93e7-1dac3e10f427">
         <id>ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_gpkg</id>
         <version>2021-01-06</version>
         <owner>mailto:david@opengis.ch</owner>
         <title>
-          <DatasetIdx16.MultilingualMText>
+          <DatasetIdx16.MultilingualText>
             <LocalisedText>
-              <DatasetIdx16.LocalisedMText>
+              <DatasetIdx16.LocalisedText>
                 <Language>de</Language>
                 <Text>Einfaches GPKG Styling und Tree und TOML und SH Cat (OPENGIS.ch)</Text>
-              </DatasetIdx16.LocalisedMText>
+              </DatasetIdx16.LocalisedText>
             </LocalisedText>
-          </DatasetIdx16.MultilingualMText>
+          </DatasetIdx16.MultilingualText>
         </title>
         <categories>
           <DatasetIdx16.Code_>
@@ -94,14 +94,14 @@
         <version>2021-03-12</version>
         <owner>mailto:david@opengis.ch</owner>
         <title>
-          <DatasetIdx16.MultilingualMText>
+          <DatasetIdx16.MultilingualText>
             <LocalisedText>
-              <DatasetIdx16.LocalisedMText>
+              <DatasetIdx16.LocalisedText>
                 <Language>de</Language>
                 <Text>Einfaches Styling (lokal) und Tree (lokal) und TOML (lokal) und SH Cat (OPENGIS.ch)</Text>
-              </DatasetIdx16.LocalisedMText>
+              </DatasetIdx16.LocalisedText>
             </LocalisedText>
-          </DatasetIdx16.MultilingualMText>
+          </DatasetIdx16.MultilingualText>
         </title>
         <categories>
           <DatasetIdx16.Code_>
@@ -131,14 +131,14 @@
         <version>2021-01-06</version>
         <owner>mailto:david@opengis.ch</owner>
         <title>
-          <DatasetIdx16.MultilingualMText>
+          <DatasetIdx16.MultilingualText>
             <LocalisedText>
-              <DatasetIdx16.LocalisedMText>
+              <DatasetIdx16.LocalisedText>
                 <Language>de</Language>
                 <Text>Einfaches GPKG Styling und Tree (lokal) und TOML und SH Cat (OPENGIS.ch)</Text>
-              </DatasetIdx16.LocalisedMText>
+              </DatasetIdx16.LocalisedText>
             </LocalisedText>
-          </DatasetIdx16.MultilingualMText>
+          </DatasetIdx16.MultilingualText>
         </title>
         <categories>
           <DatasetIdx16.Code_>
@@ -168,14 +168,14 @@
         <version>2021-01-06</version>
         <owner>mailto:david@opengis.ch</owner>
         <title>
-          <DatasetIdx16.MultilingualMText>
+          <DatasetIdx16.MultilingualText>
             <LocalisedText>
-              <DatasetIdx16.LocalisedMText>
+              <DatasetIdx16.LocalisedText>
                 <Language>de</Language>
                 <Text>Styling für polygonStructure und falscher Layertree ID (OPENGIS.ch)</Text>
-              </DatasetIdx16.LocalisedMText>
+              </DatasetIdx16.LocalisedText>
             </LocalisedText>
-          </DatasetIdx16.MultilingualMText>
+          </DatasetIdx16.MultilingualText>
         </title>
         <categories>
           <DatasetIdx16.Code_>
@@ -232,14 +232,14 @@
         <version>2021-01-06</version>
         <owner>mailto:david@opengis.ch</owner>
         <title>
-          <DatasetIdx16.MultilingualMText>
+          <DatasetIdx16.MultilingualText>
             <LocalisedText>
-              <DatasetIdx16.LocalisedMText>
+              <DatasetIdx16.LocalisedText>
                 <Language>de</Language>
                 <Text>Metaconfig mit ili2db Params (OPENGIS.ch)</Text>
-              </DatasetIdx16.LocalisedMText>
+              </DatasetIdx16.LocalisedText>
             </LocalisedText>
-          </DatasetIdx16.MultilingualMText>
+          </DatasetIdx16.MultilingualText>
         </title>
         <categories>
           <DatasetIdx16.Code_>
@@ -308,7 +308,7 @@
         </files>
       </DatasetIdx16.DataIndex.DatasetMetadata>
 
-      <DatasetIdx16.DataIndex.DatasetMetadata TID="eeea4152-6a2c-11eb-84dd-43cf319ea780">
+      <DatasetIdx16.DataIndex.DatasetMetadata TID="37d4be2e-ec55-4556-8568-ff4cac6d0a4c">
         <id>ch.opengis.topping.opengisch_KbS_LV95_V1_4_004_GPKG</id>
         <version>2021-01-20</version>
         <owner>mailto:david@opengis.ch</owner>
@@ -431,7 +431,7 @@
       </DatasetIdx16.DataIndex.DatasetMetadata>
 
       <!-- layertree KbS_LV95_V1_4 GPKG -->
-      <DatasetIdx16.DataIndex.DatasetMetadata TID="333a9e68-268e-4ed2-8f8a-eeeeaab43432">
+      <DatasetIdx16.DataIndex.DatasetMetadata TID="a632a38a-1bf7-4a7c-9347-ba9364911e97">
         <id>ch.opengis.config.KbS_LV95_V1_4_layertree_GPKG</id>
         <version>2021-01-06</version>
         <owner>mailto:david@opengis.ch</owner>
@@ -560,14 +560,14 @@
         <version>2021-03-12</version>
         <owner>mailto:david@opengis.ch</owner>
         <title>
-          <DatasetIdx16.MultilingualMText>
+          <DatasetIdx16.MultilingualText>
             <LocalisedText>
-              <DatasetIdx16.LocalisedMText>
+              <DatasetIdx16.LocalisedText>
                 <Language>de</Language>
                 <Text>Mit Cat-Model und Legendenkatalog</Text>
-              </DatasetIdx16.LocalisedMText>
+              </DatasetIdx16.LocalisedText>
             </LocalisedText>
-          </DatasetIdx16.MultilingualMText>
+          </DatasetIdx16.MultilingualText>
         </title>
         <categories>
           <DatasetIdx16.Code_>
@@ -597,14 +597,14 @@
         <version>2021-03-12</version>
         <owner>mailto:david@opengis.ch</owner>
         <title>
-          <DatasetIdx16.MultilingualMText>
+          <DatasetIdx16.MultilingualText>
             <LocalisedText>
-              <DatasetIdx16.LocalisedMText>
+              <DatasetIdx16.LocalisedText>
                 <Language>de</Language>
                 <Text>Mit lokalem Legendenkatalog</Text>
-              </DatasetIdx16.LocalisedMText>
+              </DatasetIdx16.LocalisedText>
             </LocalisedText>
-          </DatasetIdx16.MultilingualMText>
+          </DatasetIdx16.MultilingualText>
         </title>
         <categories>
           <DatasetIdx16.Code_>


### PR DESCRIPTION
In http://models.interlis.ch/core/DatasetIdx16.ili the attribute title is of type `MultilingualText` and not `MultilingualMText`.

What would happen when the fixed ModelBaker parses unfixed ilidata.xml or vice versa? - It would take the id as description. So no problem for me to merge that even when people have invalid ilidata.xml.

![usabilityhub_notitle](https://user-images.githubusercontent.com/28384354/140507984-ae8cb073-f52a-44d2-a284-098b0d3acbd0.jpg)
