### PR TITLE
Avoid crash when text of element cannot be found

### DIFF
--- a/QgisModelBaker/libili2db/ilicache.py
+++ b/QgisModelBaker/libili2db/ilicache.py
@@ -236,7 +236,9 @@ class IliCache(QObject):
                     repo_models.append(model)
 
         self.repositories[netloc] = sorted(
-            repo_models, key=lambda m: m["version"] if m["version"] else 0, reverse=True
+            repo_models,
+            key=lambda m: m["version"] if m["version"] else "0",
+            reverse=True,
         )
 
         self.model.set_repositories(self.repositories)
@@ -593,7 +595,7 @@ class IliDataCache(IliCache):
 
         self.repositories[netloc] = sorted(
             repo_metaconfigs,
-            key=lambda m: m["version"] if m["version"] else 0,
+            key=lambda m: m["version"] if m["version"] else "0",
             reverse=True,
         )
 
@@ -886,7 +888,9 @@ class IliToppingFileCache(IliDataCache):
                                     repo_files.append(toppingfile)
 
         self.repositories[netloc] = sorted(
-            repo_files, key=lambda m: m["version"] if m["version"] else 0, reverse=True
+            repo_files,
+            key=lambda m: m["version"] if m["version"] else "0",
+            reverse=True,
         )
 
         self.model.set_repositories(self.repositories)

--- a/QgisModelBaker/tests/test_ilicache.py
+++ b/QgisModelBaker/tests/test_ilicache.py
@@ -714,3 +714,41 @@ class IliCacheTest(unittest.TestCase):
             "qml/opengisch_KbS_LV95_V1_4_005_parzellenidentifikation.qml",
         }
         assert files == expected_files
+
+    def test_ilimodels_xml_parser_invalid(self):
+        """
+        parse invalid models withouth crashing
+        """
+        ilicache = IliCache([])
+        ilicache._process_informationfile(
+            os.path.join(test_path, "testdata", "ilirepo", "invalid", "ilimodels.xml"),
+            "test_repo",
+            "/testdata/ilirepo/invalid/ilimodels.xml",
+        )
+        assert "test_repo" in ilicache.repositories.keys()
+        models = set(
+            [e["name"] for e in next(elem for elem in ilicache.repositories.values())]
+        )
+        expected_models = set(["CoordSys", "AbstractSymbology"])
+        assert models == expected_models
+
+    def test_ilidata_xml_parser_invalid(self):
+        """
+        parse invalid data withouth crashing
+        """
+        ilimetaconfigcache = IliDataCache(configuration=None, models="KbS_LV95_V1_4")
+        ilimetaconfigcache._process_informationfile(
+            os.path.join(test_path, "testdata", "ilirepo", "invalid", "ilidata.xml"),
+            "test_repo",
+            os.path.join(test_path, "testdata", "ilirepo", "invalid"),
+        )
+        assert "test_repo" in ilimetaconfigcache.repositories.keys()
+        metaconfigs = set(
+            [
+                e["id"]
+                for e in next(elem for elem in ilimetaconfigcache.repositories.values())
+            ]
+        )
+        # not finding invalid metaconfig but the one with none as id
+        expected_metaconfigs = {None, "ch.opengis.ili.config.valid"}
+        assert metaconfigs == expected_metaconfigs

--- a/QgisModelBaker/tests/testdata/ilirepo/invalid/ilidata.xml
+++ b/QgisModelBaker/tests/testdata/ilirepo/invalid/ilidata.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TRANSFER xmlns="http://www.interlis.ch/INTERLIS2.3">
+  <HEADERSECTION SENDER="ceis" VERSION="2.3">
+    <MODELS>
+      <MODEL NAME="DatasetIdx16" VERSION="2018-10-19" URI="mailto:ce@eisenhutinformatik.ch"/>
+    </MODELS>
+  </HEADERSECTION>
+  <DATASECTION>
+    <DatasetIdx16.DataIndex BID="4fd597ad-f2b7-430d-9cc5-1e15f85e4aef">
+      <DatasetIdx16.DataIndex.Metadata TID="72c20986-b358-48da-b5eb-4fe7f3a0fc12">
+        <id>usabilityhub</id>
+        <version>2021-01-06</version>
+        <owner>http://models.opengis.ch</owner>
+        <technicalContact>mailto:david@opengis.ch</technicalContact>
+      </DatasetIdx16.DataIndex.Metadata>
+
+      <!-- invalid element with missing id and version -->
+      <DatasetIdx16.DataIndex.DatasetMetadata TID="be6623c1-aa64-4a07-931e-fc4f0745f025">
+        <owner>mailto:david@opengis.ch</owner>
+        <title>
+          <DatasetIdx16.MultilingualText>
+            <LocalisedText>
+              <DatasetIdx16.LocalisedText>
+                <Language>de</Language>
+                <Text>Einfaches Styling und Tree und TOML und SH Cat (OPENGIS.ch)</Text>
+              </DatasetIdx16.LocalisedText>
+            </LocalisedText>
+          </DatasetIdx16.MultilingualText>
+        </title>
+        <categories>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.interlis.ch/model/KbS_LV95_V1_4</value>
+          </DatasetIdx16.Code_>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.interlis.ch/type/metaconfig</value>
+          </DatasetIdx16.Code_>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.opengis.ch/modelbaker</value>
+          </DatasetIdx16.Code_>
+        </categories>
+        <files>
+          <DatasetIdx16.DataFile>
+            <fileFormat>text/plain;version=2.3</fileFormat>
+            <file>
+              <DatasetIdx16.File>
+                <path>metaconfig/opengisch_KbS_LV95_V1_4.ini</path>
+              </DatasetIdx16.File>
+            </file>
+          </DatasetIdx16.DataFile>
+        </files>
+      </DatasetIdx16.DataIndex.DatasetMetadata>
+
+      <!-- invalid element with missing mandatory attributes version and owner and missing attributes used to work in ilicache-->
+      <DatasetIdx16.DataIndex.DatasetMetadata TID="be6623c1-aa64-4a07-931e-fc4f0745f025">
+        <id>ch.opengis.ili.config.invalid</id>
+        <title>
+          <DatasetIdx16.MultilingualText>
+            <LocalisedText>
+              <DatasetIdx16.LocalisedText>
+              </DatasetIdx16.LocalisedText>
+            </LocalisedText>
+          </DatasetIdx16.MultilingualText>
+        </title>
+        <categories>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.interlis.ch/model/KbS_LV95_V1_4</value>
+          </DatasetIdx16.Code_>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.interlis.ch/type/metaconfig</value>
+          </DatasetIdx16.Code_>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.opengis.ch/modelbaker</value>
+          </DatasetIdx16.Code_>
+        </categories>
+      </DatasetIdx16.DataIndex.DatasetMetadata>
+
+      <DatasetIdx16.DataIndex.DatasetMetadata TID="be6623c1-aa64-4a07-931e-fc4f0745f025">
+        <id>ch.opengis.ili.config.valid</id>
+        <version>2021-01-06</version>
+        <owner>mailto:david@opengis.ch</owner>
+        <title>
+          <DatasetIdx16.MultilingualText>
+            <LocalisedText>
+              <DatasetIdx16.LocalisedText>
+                <Language>de</Language>
+                <Text>Einfaches Styling und Tree und TOML und SH Cat (OPENGIS.ch)</Text>
+              </DatasetIdx16.LocalisedText>
+            </LocalisedText>
+          </DatasetIdx16.MultilingualText>
+        </title>
+        <categories>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.interlis.ch/model/KbS_LV95_V1_4</value>
+          </DatasetIdx16.Code_>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.interlis.ch/type/metaconfig</value>
+          </DatasetIdx16.Code_>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.opengis.ch/modelbaker</value>
+          </DatasetIdx16.Code_>
+        </categories>
+        <files>
+          <DatasetIdx16.DataFile>
+            <fileFormat>text/plain;version=2.3</fileFormat>
+            <file>
+              <DatasetIdx16.File>
+                <path>metaconfig/opengisch_KbS_LV95_V1_4.ini</path>
+              </DatasetIdx16.File>
+            </file>
+          </DatasetIdx16.DataFile>
+        </files>
+      </DatasetIdx16.DataIndex.DatasetMetadata>
+
+      <!--invalid element with wrong name (DatasetMetaHansHuckebein)-->
+      <DatasetIdx16.DataIndex.DatasetMetaHansHuckebein TID="be6623c1-aa64-4a07-931e-fc4f0745f025">
+        <id>ch.opengis.ili.config.hanshuckebein</id>
+        <version>2021-01-06</version>
+        <owner>mailto:david@opengis.ch</owner>
+        <title>
+          <DatasetIdx16.MultilingualText>
+            <LocalisedText>
+              <DatasetIdx16.LocalisedText>
+                <Language>de</Language>
+                <Text>Einfaches Styling und Tree und TOML und SH Cat (OPENGIS.ch)</Text>
+              </DatasetIdx16.LocalisedText>
+            </LocalisedText>
+          </DatasetIdx16.MultilingualText>
+        </title>
+        <categories>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.interlis.ch/model/KbS_LV95_V1_4</value>
+          </DatasetIdx16.Code_>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.interlis.ch/type/metaconfig</value>
+          </DatasetIdx16.Code_>
+          <DatasetIdx16.Code_>
+          	<value>http://codes.opengis.ch/modelbaker</value>
+          </DatasetIdx16.Code_>
+        </categories>
+        <files>
+          <DatasetIdx16.DataFile>
+            <fileFormat>text/plain;version=2.3</fileFormat>
+            <file>
+              <DatasetIdx16.File>
+                <path>metaconfig/opengisch_KbS_LV95_V1_4.ini</path>
+              </DatasetIdx16.File>
+            </file>
+          </DatasetIdx16.DataFile>
+        </files>
+      </DatasetIdx16.DataIndex.DatasetMetaHansHuckebein>
+   </DatasetIdx16.DataIndex>
+  </DATASECTION>
+</TRANSFER>

--- a/QgisModelBaker/tests/testdata/ilirepo/invalid/ilimodels.xml
+++ b/QgisModelBaker/tests/testdata/ilirepo/invalid/ilimodels.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TRANSFER xmlns="http://www.interlis.ch/INTERLIS2.3">
+  <HEADERSECTION SENDER="KOGIS-20200115" VERSION="2.3">
+    <MODELS>
+      <MODEL NAME="IliRepository09" VERSION="2009-12-01" URI="mailto:ce@eisenhutinformatik.ch"/>
+      <MODEL NAME="IliRepository20" VERSION="2020-01-15" URI="http://models.interlis.ch/core"/>
+    </MODELS>
+  </HEADERSECTION>
+  <DATASECTION>
+    <!-- ====================================================================  -->
+    <!-- INTERLIS REFERENCE MODELS OF THE SWISS CONFEDERATION (ili2_4)         -->
+
+    <IliRepository20.RepositoryIndex BID="ch.interlis.ilimodels.b2">
+
+      <IliRepository20.RepositoryIndex.ModelMetadata TID="1001">
+        <Name>AbstractSymbology</Name>
+        <SchemaLanguage>ili2_4</SchemaLanguage>
+        <File>refhb24/AbstractSymbology.ili</File>
+        <Version>2020-02-20</Version>
+        <publishingDate>2020-02-20</publishingDate>
+        <Issuer>http://www.interlis.ch/models/refhb24</Issuer>
+        <technicalContact>mailto:info@interlis.ch</technicalContact>
+        <furtherInformation>https://www.interlis.ch</furtherInformation>
+        <md5>1da81c8764c7fce8e896e7aa36e2d499</md5>
+      </IliRepository20.RepositoryIndex.ModelMetadata>
+
+      <!--invalid element with missing mandatory attributes (only name)-->
+      <IliRepository20.RepositoryIndex.ModelMetadata TID="1002">
+        <Name>CoordSys</Name>
+      </IliRepository20.RepositoryIndex.ModelMetadata>
+
+      <!--invalid element with missing (mandatory) name-->
+      <IliRepository20.RepositoryIndex.ModelMetadata TID="1003">
+        <SchemaLanguage>ili2_4</SchemaLanguage>
+        <File>refhb24/Units.ili</File>
+        <Version>2014-07-09</Version>
+        <publishingDate>2020-02-20</publishingDate>
+        <Issuer>http://www.interlis.ch/models/refhb24</Issuer>
+        <technicalContact>mailto:info@interlis.ch</technicalContact>
+        <furtherInformation>https://www.interlis.ch</furtherInformation>
+        <md5>822579b7bd802a6718cebf0cc1f5d85c</md5>
+      </IliRepository20.RepositoryIndex.ModelMetadata>
+
+      <!--invalid element with wrong name (ModelMetaHansHuckebein)-->
+      <IliRepository20.RepositoryIndex.ModelMetaHansHuckebein TID="1003">
+        <Name>Huckebein</Name>
+        <SchemaLanguage>ili2_4</SchemaLanguage>
+        <File>refhb24/Units.ili</File>
+        <Version>2014-07-09</Version>
+        <publishingDate>2020-02-20</publishingDate>
+        <Issuer>http://www.interlis.ch/models/refhb24</Issuer>
+        <technicalContact>mailto:info@interlis.ch</technicalContact>
+        <furtherInformation>https://www.interlis.ch</furtherInformation>
+        <md5>822579b7bd802a6718cebf0cc1f5d85c</md5>
+      </IliRepository20.RepositoryIndex.ModelMetaHansHuckebein>
+
+    </IliRepository20.RepositoryIndex>
+  </DATASECTION>
+</TRANSFER>


### PR DESCRIPTION
Parsing the `ilimodel.xml` / `ilidata.xml` we sometimes need to check the found element if it's empty before we access it's text. Mostly we trusted that the data has been correctly setup and the elements are there, we are looking for, but in case this is not the case Model Baker crashed. With this helper function `get_element_text` we even can remove some checks for element and make the code slimmer.