### PR TITLE
Fix the importTid/exportTid handling in Wizard

### DIFF
--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -102,6 +102,7 @@ class SessionPanel(QWidget, WIDGET_UI):
         elif self.db_action_type == DbActionType.IMPORT_DATA:
             self.configuration.xtffile = self.file
             self.configuration.ilimodels = ";".join(self.models)
+            self.configuration.with_importtid = self._get_tid_handling()
             self.info_label.setText(
                 self.tr("Import {} of {}").format(", ".join(self.models), self.file)
             )
@@ -109,6 +110,7 @@ class SessionPanel(QWidget, WIDGET_UI):
         elif self.db_action_type == DbActionType.EXPORT:
             self.configuration.xtffile = self.file
             self.configuration.ilimodels = ";".join(self.models)
+            self.configuration.with_exporttid = self._get_tid_handling()
             self.info_label.setText(
                 self.tr('Export of "{}" \nto {}').format(
                     '", "'.join(self.models)
@@ -280,3 +282,7 @@ class SessionPanel(QWidget, WIDGET_UI):
                 ).format(message),
                 LogColor.COLOR_FAIL,
             )
+
+    def _get_tid_handling(self):
+        db_connector = db_utils.get_db_connector(self.configuration)
+        return db_connector.get_tid_handling()

--- a/QgisModelBaker/libili2db/ili2dbconfig.py
+++ b/QgisModelBaker/libili2db/ili2dbconfig.py
@@ -249,6 +249,7 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
             self.append_args(args, ["--createEnumTabsWithId"], True)
             self.append_args(args, ["--createTidCol"], True)
 
+        # version 3 backwards compatibility (not needed in newer versions)
         if self.create_import_tid:
             self.append_args(args, ["--importTid"])
 

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
@@ -312,6 +312,14 @@ class DBConnector(QObject):
         """
         return False, None
 
+    def get_tid_handling(self):
+        """
+        Returns if there is a tid handling enabled according to the settings table.
+        It's the tid handling that has been enabled "manually" (or by a plugin) and
+        not if t_ili_tids are used according the stable id defined in the model.
+        """
+        return False
+
 
 class DBConnectorError(Exception):
     """This error is raised when DbConnector could not connect to database.

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/db_connector.py
@@ -251,7 +251,8 @@ class DBConnector(QObject):
 
     def get_basket_handling(self):
         """
-        Returns if there is a basket handling enabled according to the settings table
+        Returns `True` if a basket handling is enabled according to the settings table.
+        Means when the database has been created with `--createBasketCol`.
         """
         return False
 
@@ -314,9 +315,8 @@ class DBConnector(QObject):
 
     def get_tid_handling(self):
         """
-        Returns if there is a tid handling enabled according to the settings table.
-        It's the tid handling that has been enabled "manually" (or by a plugin) and
-        not if t_ili_tids are used according the stable id defined in the model.
+        Returns `True` if a tid handling is enabled according to the settings table (when the database has been created with `--createTidCol`).
+        If t_ili_tids are used only because of a stable id definition in the model (with `OID as` in the topic or the class definition), this parameter is not set and this function will return `False`.
         """
         return False
 

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -587,10 +587,11 @@ class GPKGConnector(DBConnector):
             cursor.execute(
                 """SELECT setting
                             FROM {}
-                            WHERE tag = 'ch.ehi.ili2db.BasketHandling'
+                            WHERE tag = ?
                             """.format(
                     GPKG_SETTINGS_TABLE
-                )
+                ),
+                ["ch.ehi.ili2db.BasketHandling"],
             )
             content = cursor.fetchone()
             if content:
@@ -736,10 +737,11 @@ class GPKGConnector(DBConnector):
             cursor.execute(
                 """SELECT setting
                             FROM {}
-                            WHERE tag = 'ch.ehi.ili2db.TidHandling'
+                            WHERE tag = ?
                             """.format(
                     GPKG_SETTINGS_TABLE
-                )
+                ),
+                ["ch.ehi.ili2db.TidHandling"],
             )
             content = cursor.fetchone()
             if content:

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/gpkg_connector.py
@@ -729,3 +729,19 @@ class GPKGConnector(DBConnector):
                     'Could not create basket for topic "{}": {}'
                 ).format(topic, error_message)
         return False, self.tr('Could not create basket for topic "{}".').format(topic)
+
+    def get_tid_handling(self):
+        if self._table_exists(GPKG_SETTINGS_TABLE):
+            cursor = self.conn.cursor()
+            cursor.execute(
+                """SELECT setting
+                            FROM {}
+                            WHERE tag = 'ch.ehi.ili2db.TidHandling'
+                            """.format(
+                    GPKG_SETTINGS_TABLE
+                )
+            )
+            content = cursor.fetchone()
+            if content:
+                return content[0] == "property"
+        return False

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
@@ -664,10 +664,11 @@ WHERE TABLE_SCHEMA='{schema}'
             cur.execute(
                 """SELECT setting
                             FROM {schema}.{table}
-                            WHERE tag = 'ch.ehi.ili2db.BasketHandling'
+                            WHERE tag = ?
                             """.format(
                     schema=self.schema, table=SETTINGS_TABLE
-                )
+                ),
+                ("ch.ehi.ili2db.BasketHandling",),
             )
             content = cur.fetchone()
             if content:
@@ -825,10 +826,11 @@ WHERE TABLE_SCHEMA='{schema}'
             cur.execute(
                 """SELECT setting
                             FROM {schema}.{table}
-                            WHERE tag = 'ch.ehi.ili2db.TidHandling'
+                            WHERE tag = ?
                             """.format(
                     schema=self.schema, table=SETTINGS_TABLE
-                )
+                ),
+                ("ch.ehi.ili2db.TidHandling",),
             )
             content = cur.fetchone()
             if content:

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/mssql_connector.py
@@ -818,3 +818,19 @@ WHERE TABLE_SCHEMA='{schema}'
                     'Could not create basket for topic "{}": {}'
                 ).format(topic, error_message)
         return False, self.tr('Could not create basket for topic "{}".').format(topic)
+
+    def get_tid_handling(self):
+        if self.schema and self._table_exists(SETTINGS_TABLE):
+            cur = self.conn.cursor()
+            cur.execute(
+                """SELECT setting
+                            FROM {schema}.{table}
+                            WHERE tag = 'ch.ehi.ili2db.TidHandling'
+                            """.format(
+                    schema=self.schema, table=SETTINGS_TABLE
+                )
+            )
+            content = cur.fetchone()
+            if content:
+                return content[0] == "property"
+        return False

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -746,10 +746,11 @@ class PGConnector(DBConnector):
             cur.execute(
                 """SELECT setting
                            FROM {schema}.{table}
-                           WHERE tag = 'ch.ehi.ili2db.BasketHandling'
+                           WHERE tag = %s
                         """.format(
                     schema=self.schema, table=PG_SETTINGS_TABLE
-                )
+                ),
+                ("ch.ehi.ili2db.BasketHandling",),
             )
             content = cur.fetchone()
             if content:
@@ -904,10 +905,11 @@ class PGConnector(DBConnector):
             cur.execute(
                 """SELECT setting
                            FROM {schema}.{table}
-                           WHERE tag = 'ch.ehi.ili2db.TidHandling'
+                           WHERE tag = %s
                         """.format(
                     schema=self.schema, table=PG_SETTINGS_TABLE
-                )
+                ),
+                ("ch.ehi.ili2db.TidHandling",),
             )
             content = cur.fetchone()
             if content:

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -21,7 +21,7 @@ import re
 
 import psycopg2
 import psycopg2.extras
-from psycopg2 import OperationalError
+from psycopg2 import OperationalError, sql
 from qgis.core import Qgis
 
 from .db_connector import DBConnector, DBConnectorError
@@ -744,11 +744,13 @@ class PGConnector(DBConnector):
         if self.schema and self._table_exists(PG_SETTINGS_TABLE):
             cur = self.conn.cursor()
             cur.execute(
-                """SELECT setting
-                           FROM {schema}.{table}
+                sql.SQL(
+                    """SELECT setting
+                           FROM {}.{}
                            WHERE tag = %s
-                        """.format(
-                    schema=self.schema, table=PG_SETTINGS_TABLE
+                        """
+                ).format(
+                    sql.Identifier(self.schema), sql.Identifier(PG_SETTINGS_TABLE)
                 ),
                 ("ch.ehi.ili2db.BasketHandling",),
             )
@@ -903,11 +905,13 @@ class PGConnector(DBConnector):
         if self.schema and self._table_exists(PG_SETTINGS_TABLE):
             cur = self.conn.cursor()
             cur.execute(
-                """SELECT setting
-                           FROM {schema}.{table}
+                sql.SQL(
+                    """SELECT setting
+                           FROM {}.{}
                            WHERE tag = %s
-                        """.format(
-                    schema=self.schema, table=PG_SETTINGS_TABLE
+                        """
+                ).format(
+                    sql.Identifier(self.schema), sql.Identifier(PG_SETTINGS_TABLE)
                 ),
                 ("ch.ehi.ili2db.TidHandling",),
             )

--- a/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
+++ b/QgisModelBaker/libqgsprojectgen/dbconnector/pg_connector.py
@@ -897,3 +897,19 @@ class PGConnector(DBConnector):
                     'Could not create basket for topic "{}": {}'
                 ).format(topic, error_message)
         return False, self.tr('Could not create basket for topic "{}".').format(topic)
+
+    def get_tid_handling(self):
+        if self.schema and self._table_exists(PG_SETTINGS_TABLE):
+            cur = self.conn.cursor()
+            cur.execute(
+                """SELECT setting
+                           FROM {schema}.{table}
+                           WHERE tag = 'ch.ehi.ili2db.TidHandling'
+                        """.format(
+                    schema=self.schema, table=PG_SETTINGS_TABLE
+                )
+            )
+            content = cur.fetchone()
+            if content:
+                return content[0] == "property"
+        return False


### PR DESCRIPTION
In the wizard, we get the `TidHandling` from settings table to decide if `--importTid` / `--exportTid` needs to be passed on data import/export. `TidHandling` is in the `t_ili2db_settings` table when `--createTidCol` is passed on schema import. This means always when it's created by Model Baker. 

This fixes #601 and keeps the behavior of the single dialogues how it is (a little confusing but as we are used to).