### PR TITLE
Hide create Import Tid in the GUI

### DIFF
--- a/QgisModelBaker/gui/ili2db_options.py
+++ b/QgisModelBaker/gui/ili2db_options.py
@@ -33,7 +33,11 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
     ValidExtensions = ["toml", "TOML"]
     SQLValidExtensions = ["sql", "SQL"]
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, remove_create_tid_group=True):
+        """
+        remove_create_tid_group is to remove the "Create Import Tid" setting because on Schema Import it does nothing (legacy issues).
+        After removing the single dialog for data import, this setting can be removed completely from the GUI.
+        """
         QDialog.__init__(self, parent)
         self.setupUi(self)
         QgsGui.instance().enableAutoGeometryRestore(self)
@@ -95,6 +99,8 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         self.post_script_file_line_edit.textChanged.emit(
             self.post_script_file_line_edit.text()
         )
+
+        self.create_import_tid_groupbox.setHidden(remove_create_tid_group)
 
         self.bar = QgsMessageBar()
         self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -132,7 +132,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
             self.db_layout.addWidget(item_panel)
 
         self.type_combo_box.currentIndexChanged.connect(self.type_changed)
-        self.ili2db_options = Ili2dbOptionsDialog(self)
+        self.ili2db_options = Ili2dbOptionsDialog(self, False)
         self.ili2db_options_button.clicked.connect(self.ili2db_options.open)
         self.ili2db_options.finished.connect(self.fill_toml_file_info_label)
 

--- a/QgisModelBaker/ui/ili2db_options.ui
+++ b/QgisModelBaker/ui/ili2db_options.ui
@@ -57,7 +57,7 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="create_import_tid_groupbox">
      <property name="title">
       <string>Create Import Tid</string>
      </property>


### PR DESCRIPTION
At:
- single dialog to generate project (schema import) because it does not anything
- wizard (where we have it only on schema import) because it does not anything

It's not hidden in single import data to provide the backwards compatibility.

But this setting shouldn't be made anyway. On import we can decide according to the column if we should make `importTid` and on schema import it does not make anything.

It's connected to this implementation #603