### PR TITLE
Info that on basket creation UUIDs are used

### DIFF
--- a/QgisModelBaker/gui/dataset_manager.py
+++ b/QgisModelBaker/gui/dataset_manager.py
@@ -230,7 +230,14 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
                 )
                 info_title = self.tr("Created baskets")
                 info_box.setWindowTitle(info_title)
-                info_box.setText("\n".join([feedback[1] for feedback in feedbacks]))
+                info_box.setText(
+                    "{}{}".format(
+                        "\n".join([feedback[1] for feedback in feedbacks]),
+                        "\n\nBe aware that the IDs of the baskets are created as UUIDs. To change that, edit the t_ili2db_basket table manually."
+                        if len([feedback for feedback in feedbacks if feedback[0]])
+                        else "",
+                    )
+                )
                 info_box.exec_()
 
     def _jump_to_entry(self, datasetname):


### PR DESCRIPTION
For IDs in the Dataset Manager.
This might be not conform with the definition in the model (see #599), so we tell the user about it.

![image](https://user-images.githubusercontent.com/28384354/146749788-0781852a-af82-457b-bd26-a64f1aba835e.png)
