### PR TITLE
Part about BASKET OID and landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
-Model Baker is a QGIS plugin that allows to quickly create a QGIS project from a physical data model. The Model Baker analyzes the existing structure and configures a QGIS project with all available information. This automation can massively reduce the configuration effort.
-
-Models defined in INTERLIS provide additional meta information like domains, units of attributes or object oriented definitions of tables. This can be used to further optimize the project configuration. The Model Baker uses [ili2db](https://github.com/claeis/ili2db/blob/master/docs/ili2db.rst) to import an INTERLIS model into a physical database and the meta information to configure layer tree, field widgets with conditions, form layouts, relations and much more.
-
-Furthermore, the Model Baker can be used as a framework for other projects. The plugin [Asistente LADM-COL](https://github.com/SwissTierrasColombia/Asistente-LADM-COL), created for the [Colombian implementation of the Land Administration Domain Model (LADM)](https://www.proadmintierra.info/), uses the Model Baker as a library to implement as much of the specific solution as possible as QGIS core functionality.
+---
+template: home.html
+title: QGIS Model Baker Documentation
+---

--- a/docs/theme_overrides/404.html
+++ b/docs/theme_overrides/404.html
@@ -1,0 +1,28 @@
+{% extends "main.html" %}
+{% block tabs %}
+  {{ super() }}
+<style>
+  @media screen and (min-width:60em){
+      .md-sidebar--secondary{display:none}
+  }@media screen and (min-width:76.25em){
+      .md-sidebar--primary{display:none}
+  }</style>
+  <section>
+    <div class="md-grid md-typeset">
+      <div>
+        <div>
+            <p/>
+            <h1>404 - Not found</h1>
+            <p>
+            Maybe you landed here because you used a link to the old documentation.
+        </p>
+        <p>
+            <a href="{{ '/' | url }}">Check out the new one!</a>
+        </p>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+{% block content %}{% endblock %}
+{% block footer %}{% endblock %}

--- a/docs/theme_overrides/home.html
+++ b/docs/theme_overrides/home.html
@@ -1,0 +1,30 @@
+{% extends "main.html" %}
+{% block tabs %}
+  {{ super() }}
+<style>
+  @media screen and (min-width:60em){
+      .md-sidebar--secondary{display:none}
+  }@media screen and (min-width:76.25em){
+      .md-sidebar--primary{display:none}
+  }</style>
+  <section>
+    <div class="md-grid md-typeset">
+      <div>
+        <div>
+            <p/>
+            <h1>QGIS Model Baker Documentation</h1>
+            <p>
+                Model Baker is a QGIS plugin that allows to quickly create a QGIS project from a physical data model. The Model Baker analyzes the existing structure and configures a QGIS project with all available information. This automation can massively reduce the configuration effort.</p>
+            <p>
+                Models defined in INTERLIS provide additional meta information like domains, units of attributes or object oriented definitions of tables. This can be used to further optimize the project configuration. The Model Baker uses <a href="https://github.com/claeis/ili2db/blob/master/docs/ili2db.rst">ili2db</a> to import an INTERLIS model into a physical database and the meta information to configure layer tree, field widgets with conditions, form layouts, relations and much more.
+            </p>
+            <p>
+                Furthermore, the Model Baker can be used as a framework for other projects. The plugin <a href="https://github.com/SwissTierrasColombia/Asistente-LADM-COL">Asistente LADM-COL</a>, created for the [Colombian implementation of the Land Administration Domain Model (LADM)](https://www.proadmintierra.info/), uses the Model Baker as a library to implement as much of the specific solution as possible as QGIS core functionality.
+            </p>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
+{% block content %}{% endblock %}
+{% block footer %}{% endblock %}

--- a/docs/theme_overrides/main.html
+++ b/docs/theme_overrides/main.html
@@ -1,0 +1,1 @@
+{% extends "base.html" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: QGIS Model Baker
 site_description: >-
   This site contains documentation about QGIS Model Baker
-site_url: http://127.0.0.1:8000/
+site_url: https://opengisch.github.io/QgisModelBaker/
 
 # Repository
 repo_name: opengisch/QgisModelBaker

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ edit_uri: https://github.com/opengisch/QgisModelBaker/tree/master/docs/
 # Theme configuration
 theme:
   name: material
+  custom_dir: docs/theme_overrides/
   features:
     - navigation.tabs
     - navigation.tabs.sticky

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@
 site_name: QGIS Model Baker
 site_description: >-
   This site contains documentation about QGIS Model Baker
+site_url: http://127.0.0.1:8000/
 
 # Repository
 repo_name: opengisch/QgisModelBaker


### PR DESCRIPTION
- Basket Handling section about BASKET OID
- landing page with Model Baker abstract - it's less confusing anymore
- People following links to the old docu, got a weird 404 page. This is now overridden by a page explaining the issue. This fixes  #636 