### PR TITLE
Join the file to the the url as a path

### DIFF
--- a/QgisModelBaker/libili2db/ilicache.py
+++ b/QgisModelBaker/libili2db/ilicache.py
@@ -81,10 +81,8 @@ class IliCache(QObject):
     def file_url(self, url, file):
         if url is None:
             return file
-        elif os.path.isdir(url):
-            return os.path.join(url, file)
         else:
-            return urllib.parse.urljoin(url, file)
+            return os.path.join(url, file)
 
     def file_path(self, netloc, url, file):
         if url is None:


### PR DESCRIPTION
Means when having `https://models.repo.ch/modeldirectory` it's joined to  `https://models.repo.ch/modeldirectory/ilimodels.xml` instead to follow the logic that a directory needs to end with a `/` what would lead to `https://models.repo.ch/ilimodels.xml` 

fixes #646