### PR TITLE
Set `--exportTid` in validator

### DIFF
--- a/QgisModelBaker/gui/panel/dataset_selector.py
+++ b/QgisModelBaker/gui/panel/dataset_selector.py
@@ -43,9 +43,9 @@ class DatasetSelector(QComboBox):
         self.basket_model = BasketSourceModel()
         self.filtered_model = QSortFilterProxyModel()
         self.filtered_model.setSourceModel(self.basket_model)
-        self.filtered_model.setFilterRole(int(
-            BasketSourceModel.Roles.SCHEMA_TOPIC_IDENTIFICATOR
-        ))
+        self.filtered_model.setFilterRole(
+            int(BasketSourceModel.Roles.SCHEMA_TOPIC_IDENTIFICATOR)
+        )
         self.setModel(self.filtered_model)
         self.setEnabled(False)
 
@@ -141,14 +141,16 @@ class DatasetSelector(QComboBox):
             self._store_default_basket_tid(schema_identificator, model_topic)
 
     def _store_default_basket_tid(self, schema_identificator, model_topic):
-        default_basket_topic = slugify( f"default_basket{'_' if model_topic else ''}{model_topic}")
-        if not QgsExpressionContextUtils.projectScope(QgsProject.instance()).variable(default_basket_topic):
+        default_basket_topic = slugify(
+            f"default_basket{'_' if model_topic else ''}{model_topic}"
+        )
+        if not QgsExpressionContextUtils.projectScope(QgsProject.instance()).variable(
+            default_basket_topic
+        ):
             schema_topic_identificator = slugify(
                 f"{schema_identificator}_{model_topic}"
             )
-            self.filtered_model.setFilterRegExp(
-                f"{schema_topic_identificator}"
-            )
+            self.filtered_model.setFilterRegExp(f"{schema_topic_identificator}")
             first_index = self.model().index(0, 0)
             basket_tid = first_index.data(int(BasketSourceModel.Roles.BASKET_TID))
             QgsExpressionContextUtils.setProjectVariable(

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -232,7 +232,7 @@ class ValidateDock(QDockWidget, DIALOG_UI):
                         self.current_configuration.dbschema,
                     )
                 )
-            
+
             self.current_configuration.with_exporttid = self._get_tid_handling()
 
             if self.schema_validations.get(self.current_schema_identificator):

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -232,6 +232,8 @@ class ValidateDock(QDockWidget, DIALOG_UI):
                         self.current_configuration.dbschema,
                     )
                 )
+            
+            self.current_configuration.with_exporttid = self._get_tid_handling()
 
             if self.schema_validations.get(self.current_schema_identificator):
                 # don't set result if never got a validation (empty ValidateDock.SchemaValidation)
@@ -282,6 +284,12 @@ class ValidateDock(QDockWidget, DIALOG_UI):
         db_connector = db_utils.get_db_connector(self.current_configuration)
         if db_connector:
             return db_connector.get_basket_handling()
+        return False
+
+    def _get_tid_handling(self):
+        db_connector = db_utils.get_db_connector(self.current_configuration)
+        if db_connector:
+            return db_connector.get_tid_handling()
         return False
 
     def _run(self, edited_command=None):

--- a/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
@@ -215,9 +215,7 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
                             "layer-order"
                         ]
                     if "properties" in projecttopping_data:
-                        custom_project_properties = projecttopping_data[
-                            "properties"
-                        ]
+                        custom_project_properties = projecttopping_data["properties"]
                 except yaml.YAMLError as exc:
                     self.workflow_wizard.log_panel.print_info(
                         self.tr("Unable to parse project topping: {}").format(exc),
@@ -228,8 +226,9 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
 
         # on geopackages we don't use the transaction mode on default, since this leaded to troubles, except the topping sais so
         project = Project(
-            auto_transaction=not bool(self.configuration.tool & DbIliMode.gpkg) or
-            custom_project_properties.get("transaction_mode","") == "AutomaticGroups",
+            auto_transaction=not bool(self.configuration.tool & DbIliMode.gpkg)
+            or custom_project_properties.get("transaction_mode", "")
+            == "AutomaticGroups",
             context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
         )
         project.layers = available_layers

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -965,6 +965,5 @@ class BasketSourceModel(QStandardItemModel):
     def model_topics(self, schema_identificator):
         model_topics = {""}
         for basket in self.schema_baskets[schema_identificator]:
-            model_topics.add(basket.get('topic',''))
+            model_topics.add(basket.get("topic", ""))
         return list(model_topics)
-

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "1.1.2")
+MODELBAKER_LIBRARY=("modelbaker" "1.2.0")
 PGSERVICEPARSER=("pgserviceparser" "1.0.1")
 PACKAGING=("packaging" "21.3")
 


### PR DESCRIPTION
We do export the t_ili_tid (OID) with the parameter `--exportTid`. This is done automatically when an OID is defined in the model. If not defined, it needs this parameter to export stable ids.

So those t_ili_tid are checked on validation on export. Because they are not mandatory in the db when not defined in the model. But to provide stable ids they need to be checked.

So the validator should do the same.

This fixes  #699

It requires version 1.2.0 of the modelbaker libray. There it sets as well default values (UUID) for the t_ili_tid of the generated projects. 