### PR TITLE
Fixes and Improvements UsabILIty Hub Topping Exporter

### DIFF
--- a/QgisModelBaker/gui/dataset_manager.py
+++ b/QgisModelBaker/gui/dataset_manager.py
@@ -267,5 +267,4 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
         self.close()
 
     def _rejected(self):
-        self._restore_configuration()
         self.close()

--- a/QgisModelBaker/gui/panel/log_panel.py
+++ b/QgisModelBaker/gui/panel/log_panel.py
@@ -21,7 +21,7 @@
 from PyQt5.QtWidgets import QGridLayout
 from qgis.core import Qgis
 from qgis.gui import QgsMessageBar
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import QSize, Qt
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.QtWidgets import QGridLayout, QSizePolicy, QTextBrowser, QWidget
 
@@ -43,6 +43,11 @@ class LogPanel(QWidget):
         layout = QGridLayout()
         layout.addWidget(self.txtStdout)
         self.setLayout(layout)
+
+    def sizeHint(self):
+        return QSize(
+            self.fontMetrics().lineSpacing() * 48, self.fontMetrics().lineSpacing() * 10
+        )
 
     def print_info(self, text, text_color=LogColor.COLOR_INFO):
         self.txtStdout.setTextColor(QColor(text_color))

--- a/QgisModelBaker/gui/topping_wizard/layers_page.py
+++ b/QgisModelBaker/gui/topping_wizard/layers_page.py
@@ -288,6 +288,9 @@ class LayerModel(QgsLayerTreeModel):
                         self.ili_schema_identificators.append(schema_identificator)
 
     def _is_ili_schema(self, layer):
+        if not layer or not layer.dataProvider() or not layer.dataProvider().isValid():
+            return False
+
         source_provider = layer.dataProvider()
         source = QgsDataSourceUri(layer.dataProvider().dataSourceUri())
         schema_identificator = db_utils.get_schema_identificator_from_layersource(

--- a/QgisModelBaker/gui/topping_wizard/layers_page.py
+++ b/QgisModelBaker/gui/topping_wizard/layers_page.py
@@ -129,13 +129,30 @@ class LayerModel(QgsLayerTreeModel):
     def headerData(self, section, orientation, role):
         if orientation == Qt.Horizontal and role == Qt.DisplayRole:
             if section == LayerModel.Columns.NAME:
-                return self.tr("Node")
+                return self.tr("Layers and Groups")
             if section == LayerModel.Columns.USE_STYLE:
-                return self.tr("Use Style")
+                return self.tr("Style (QML)")
             if section == LayerModel.Columns.USE_DEFINITION:
-                return self.tr("Use Definition")
+                return self.tr("Definition (QLR)")
             if section == LayerModel.Columns.USE_SOURCE:
-                return self.tr("Use Source")
+                return self.tr("Source")
+        if orientation == Qt.Horizontal and role == Qt.ToolTipRole:
+            if section == LayerModel.Columns.NAME:
+                return self.tr(
+                    "The layers/groups listed here will be stored the layertree in the project topping (YAML) file. To remove a layer or a group, remove it in your project."
+                )
+            if section == LayerModel.Columns.USE_STYLE:
+                return self.tr(
+                    "The layer's style (forms, symbology, variables etc.) will be stored into a QML file."
+                )
+            if section == LayerModel.Columns.USE_DEFINITION:
+                return self.tr(
+                    "The layer's/group's definition (complete layer incl. source) will be stored into a QLR file."
+                )
+            if section == LayerModel.Columns.USE_SOURCE:
+                return self.tr(
+                    "The layer's source (provider and uri) will be stored into the project topping (YAML) file directly."
+                )
         return QgsLayerTreeModel.headerData(self, section, orientation, role)
 
     def data(self, index, role):

--- a/QgisModelBaker/gui/topping_wizard/layers_page.py
+++ b/QgisModelBaker/gui/topping_wizard/layers_page.py
@@ -109,7 +109,7 @@ class LayerModel(QgsLayerTreeModel):
 
         self.reload()
 
-    def columnCount(self, parent):
+    def columnCount(self, parent=None):
         return len(LayerModel.Columns)
 
     def flags(self, index):
@@ -222,6 +222,19 @@ class LayerModel(QgsLayerTreeModel):
                         None,
                         bool(data),
                     )
+
+                    if bool(data):
+                        # when the style or source get's checked, the definition become unchecked
+                        self.export_settings.set_setting_values(
+                            ExportSettings.ToppingType.DEFINITION,
+                            node,
+                            None,
+                            False,
+                        )
+
+                        # when something is checked, the parent's definition become unchecked
+                        self._disable_parent_definition(index)
+
                 if index.column() == LayerModel.Columns.USE_DEFINITION:
                     self.export_settings.set_setting_values(
                         ExportSettings.ToppingType.DEFINITION,
@@ -229,6 +242,27 @@ class LayerModel(QgsLayerTreeModel):
                         None,
                         bool(data),
                     )
+
+                    if bool(data):
+                        # when the definition is checked the others become unchecked
+                        self.export_settings.set_setting_values(
+                            ExportSettings.ToppingType.QMLSTYLE,
+                            node,
+                            None,
+                            False,
+                        )
+                        self.export_settings.set_setting_values(
+                            ExportSettings.ToppingType.SOURCE,
+                            node,
+                            None,
+                            False,
+                        )
+
+                        # when something is checked, the parent's definition become unchecked
+                        self._disable_parent_definition(index)
+
+                        # when definition is checked, che children's columns become all unchecked
+                        self._disable_children(index)
                 if (
                     index.column() == LayerModel.Columns.USE_SOURCE
                     and not QgsLayerTree.isGroup(node)
@@ -239,7 +273,22 @@ class LayerModel(QgsLayerTreeModel):
                         None,
                         bool(data),
                     )
-                self.dataChanged.emit(index, index)
+                    if bool(data):
+                        # when the style or source get's checked, the definition become unchecked
+                        self.export_settings.set_setting_values(
+                            ExportSettings.ToppingType.DEFINITION,
+                            node,
+                            None,
+                            False,
+                        )
+
+                        # when something is checked, the parent's definition become unchecked
+                        self._disable_parent_definition(index)
+
+                self.dataChanged.emit(
+                    self.index(index.row(), 0),
+                    self.index(index.row(), self.columnCount()),
+                )
                 return True
 
         if (
@@ -265,6 +314,40 @@ class LayerModel(QgsLayerTreeModel):
     def reload(self):
         self._load_ili_schema_identificators()
         self._set_default_values()
+
+    def _disable_children(self, parent: QModelIndex):
+        for child_row in range(self.rowCount(parent)):
+            self.setData(
+                self.index(child_row, LayerModel.Columns.USE_STYLE, parent),
+                Qt.CheckStateRole,
+                False,
+            )
+            self.setData(
+                self.index(child_row, LayerModel.Columns.USE_DEFINITION, parent),
+                Qt.CheckStateRole,
+                False,
+            )
+            self.setData(
+                self.index(child_row, LayerModel.Columns.USE_SOURCE, parent),
+                Qt.CheckStateRole,
+                False,
+            )
+            self._disable_children(
+                self.index(child_row, LayerModel.Columns.USE_DEFINITION, parent)
+            )
+
+    def _disable_parent_definition(self, index: QModelIndex):
+        if index.parent() == QModelIndex():
+            # parent of index is root
+            return
+        parent_definition_index = self.index(
+            index.parent().row(),
+            LayerModel.Columns.USE_DEFINITION,
+            index.parent().parent(),
+        )
+        self.setData(parent_definition_index, Qt.CheckStateRole, False)
+        if index.parent() != QModelIndex():
+            self._disable_parent_definition(index.parent())
 
     def _load_ili_schema_identificators(self):
         """

--- a/QgisModelBaker/gui/topping_wizard/topping_wizard.py
+++ b/QgisModelBaker/gui/topping_wizard/topping_wizard.py
@@ -19,7 +19,7 @@
 """
 
 
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import QSize, Qt
 from qgis.PyQt.QtWidgets import QDialog, QSplitter, QVBoxLayout, QWizard
 
 from QgisModelBaker.gui.panel.log_panel import LogPanel
@@ -81,6 +81,11 @@ class ToppingWizard(QWizard):
 
         self.currentIdChanged.connect(self.id_changed)
 
+    def sizeHint(self):
+        return QSize(
+            self.fontMetrics().lineSpacing() * 48, self.fontMetrics().lineSpacing() * 48
+        )
+
     def id_changed(self, new_id):
         self.current_id = new_id
 
@@ -116,8 +121,6 @@ class ToppingWizardDialog(QDialog):
         self.topping_wizard = ToppingWizard(self.iface, self.base_config, self)
         self.topping_wizard.setStartId(ToppingWizardPageIds.Target)
         self.topping_wizard.setWindowFlags(Qt.Widget)
-        self.topping_wizard.setFixedHeight(self.fontMetrics().lineSpacing() * 48)
-        self.topping_wizard.setMinimumWidth(self.fontMetrics().lineSpacing() * 48)
         self.topping_wizard.show()
 
         self.topping_wizard.finished.connect(self.done)

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -177,7 +177,7 @@ class ValidateDock(QDockWidget, DIALOG_UI):
         self.setDisabled(True)
 
     def set_current_layer(self, layer):
-        if not layer or layer and not layer.dataProvider().isValid():
+        if not layer or not layer.dataProvider() or not layer.dataProvider().isValid():
             self.setDisabled(True)
             return
 

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -21,7 +21,7 @@ import os
 import pathlib
 import re
 
-from qgis.PyQt.QtCore import QEventLoop, Qt, QTimer
+from qgis.PyQt.QtCore import QEventLoop, QSize, Qt, QTimer
 from qgis.PyQt.QtWidgets import QDialog, QSplitter, QVBoxLayout, QWizard
 
 import QgisModelBaker.libs.modelbaker.utils.db_utils as db_utils
@@ -196,6 +196,11 @@ class WorkflowWizard(QWizard):
         self.setPage(PageIds.ExportDataExecution, self.export_data_execution_page)
 
         self.currentIdChanged.connect(self.id_changed)
+
+    def sizeHint(self):
+        return QSize(
+            self.fontMetrics().lineSpacing() * 48, self.fontMetrics().lineSpacing() * 48
+        )
 
     def next_id(self):
         # this is called on the nextId overrides of the pages - so after the next-button is pressed
@@ -530,8 +535,6 @@ class WorkflowWizardDialog(QDialog):
         self.workflow_wizard = WorkflowWizard(self.iface, self.base_config, self)
         self.workflow_wizard.setStartId(PageIds.Intro)
         self.workflow_wizard.setWindowFlags(Qt.Widget)
-        self.workflow_wizard.setFixedHeight(self.fontMetrics().lineSpacing() * 48)
-        self.workflow_wizard.setMinimumWidth(self.fontMetrics().lineSpacing() * 48)
         self.workflow_wizard.show()
 
         self.workflow_wizard.finished.connect(self.done)

--- a/QgisModelBaker/ui/topping_wizard/layers.ui
+++ b/QgisModelBaker/ui/topping_wizard/layers.ui
@@ -29,7 +29,9 @@
       </font>
      </property>
      <property name="text">
-      <string>The layertree and the layerorder are exported as configured in the Model </string>
+      <string>The layertree and the layerorder are exported as configured in the QGIS project.
+Choose if styles should be exported and which style categories (form, symbology, variables etc.) should be used.
+As well as in what way the layer source should be stored (None, if it's loaded from INTERLIS).</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/QgisModelBaker/ui/workflow_wizard/database_selection.ui
+++ b/QgisModelBaker/ui/workflow_wizard/database_selection.ui
@@ -6,90 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>799</width>
+    <height>265</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Select Files</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QFrame" name="content_frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_10">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>88</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Source</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="type_combo_box">
-        <item>
-         <property name="text">
-          <string>Interlis (PostGIS)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Interlis (GeoPackage)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>PostGIS</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>GeoPackage</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QGroupBox" name="db_wrapper_group_box">
-        <property name="title">
-         <string/>
-        </property>
-        <layout class="QVBoxLayout" name="db_layout"/>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>167</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="description">
      <property name="minimumSize">
@@ -113,6 +37,89 @@
      <property name="wordWrap">
       <bool>true</bool>
      </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>779</width>
+        <height>222</height>
+       </rect>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>88</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Source</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="type_combo_box">
+         <item>
+          <property name="text">
+           <string>Interlis (PostGIS)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Interlis (GeoPackage)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>PostGIS</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>GeoPackage</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QGroupBox" name="db_wrapper_group_box">
+         <property name="title">
+          <string/>
+         </property>
+         <layout class="QVBoxLayout" name="db_layout"/>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>462</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
- check layer before getting dataSource. fixes #726
- Better column naming / tooltips and description on layer page of
- Logic on layer page that when definition is selected, the style and source get deselected (and the other way around) See movie below.
- Locic on layer page that when a parent has the definition selected the children get deselected (and the other way around) See movie below.
- make the wizard dialog expandable and shrinkable what fixes #725

[Screencast from 14.09.2022 13:39:08.webm](https://user-images.githubusercontent.com/28384354/190144816-f5537cf7-e4b9-468f-97d1-71633d8fb114.webm)

Not scope here:
- Layer Page: Settings Button of Categories should be closer to checkbox
- Layer Page: Style checkbox should be tristated when not having all categories to be exported
