### PR TITLE
Use functions with source provider instead of converted QgsDataSource

### DIFF
--- a/QgisModelBaker/gui/panel/dataset_selector.py
+++ b/QgisModelBaker/gui/panel/dataset_selector.py
@@ -17,7 +17,7 @@
  ***************************************************************************/
 """
 
-from qgis.core import QgsDataSourceUri, QgsExpressionContextUtils, QgsProject
+from qgis.core import QgsExpressionContextUtils, QgsProject
 from qgis.PyQt.QtCore import QSortFilterProxyModel, Qt
 from qgis.PyQt.QtWidgets import QComboBox, QWidget
 
@@ -26,8 +26,8 @@ from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbconfig import (
     Ili2DbCommandConfiguration,
 )
 from QgisModelBaker.libs.modelbaker.utils.db_utils import (
-    get_configuration_from_layersource,
-    get_schema_identificator_from_layersource,
+    get_configuration_from_sourceprovider,
+    get_schema_identificator_from_sourceprovider,
 )
 from QgisModelBaker.libs.modelbaker.utils.qt_utils import slugify
 from QgisModelBaker.utils.gui_utils import BasketSourceModel
@@ -58,9 +58,8 @@ class DatasetSelector(QComboBox):
             return
 
         source_provider = layer.dataProvider()
-        source = QgsDataSourceUri(layer.dataProvider().dataSourceUri())
-        schema_identificator = get_schema_identificator_from_layersource(
-            source_provider, source
+        schema_identificator = get_schema_identificator_from_sourceprovider(
+            source_provider
         )
         if not schema_identificator:
             return
@@ -79,8 +78,8 @@ class DatasetSelector(QComboBox):
 
         if not self.basket_model.schema_baskets_loaded(schema_identificator):
             configuration = Ili2DbCommandConfiguration()
-            valid, mode = get_configuration_from_layersource(
-                source_provider, source, configuration
+            valid, mode = get_configuration_from_sourceprovider(
+                source_provider, configuration
             )
             if valid and mode:
                 db_factory = self.db_simple_factory.create_factory(mode)

--- a/QgisModelBaker/gui/topping_wizard/ili2dbsettings_page.py
+++ b/QgisModelBaker/gui/topping_wizard/ili2dbsettings_page.py
@@ -19,7 +19,7 @@
 """
 from enum import IntEnum
 
-from qgis.core import QgsDataSourceUri, QgsMapLayer, QgsProject
+from qgis.core import QgsMapLayer, QgsProject
 from qgis.PyQt.QtCore import QAbstractItemModel, QModelIndex, Qt
 from qgis.PyQt.QtWidgets import QHeaderView, QTableView, QWizardPage
 
@@ -245,10 +245,9 @@ class Ili2dbSettingsPage(QWizardPage, PAGE_UI):
         for layer in QgsProject.instance().mapLayers().values():
             if layer.type() == QgsMapLayer.VectorLayer:
                 source_provider = layer.dataProvider()
-                source = QgsDataSourceUri(layer.dataProvider().dataSourceUri())
                 schema_identificator = (
-                    db_utils.get_schema_identificator_from_layersource(
-                        source_provider, source
+                    db_utils.get_schema_identificator_from_sourceprovider(
+                        source_provider
                     )
                 )
                 if (
@@ -258,8 +257,8 @@ class Ili2dbSettingsPage(QWizardPage, PAGE_UI):
                     continue
 
                 configuration = Ili2DbCommandConfiguration()
-                valid, mode = db_utils.get_configuration_from_layersource(
-                    source_provider, source, configuration
+                valid, mode = db_utils.get_configuration_from_sourceprovider(
+                    source_provider, configuration
                 )
                 if valid and mode:
                     configuration.tool = mode

--- a/QgisModelBaker/gui/topping_wizard/layers_page.py
+++ b/QgisModelBaker/gui/topping_wizard/layers_page.py
@@ -23,7 +23,6 @@ from enum import IntEnum
 
 from qgis.core import (
     QgsApplication,
-    QgsDataSourceUri,
     QgsLayerTree,
     QgsLayerTreeModel,
     QgsMapLayer,
@@ -359,10 +358,9 @@ class LayerModel(QgsLayerTreeModel):
         for layer in QgsProject.instance().mapLayers().values():
             if layer.type() == QgsMapLayer.VectorLayer:
                 source_provider = layer.dataProvider()
-                source = QgsDataSourceUri(layer.dataProvider().dataSourceUri())
                 schema_identificator = (
-                    db_utils.get_schema_identificator_from_layersource(
-                        source_provider, source
+                    db_utils.get_schema_identificator_from_sourceprovider(
+                        source_provider
                     )
                 )
                 if (
@@ -373,8 +371,8 @@ class LayerModel(QgsLayerTreeModel):
 
                 checked_schema_identificator.append(schema_identificator)
                 configuration = Ili2DbCommandConfiguration()
-                valid, mode = db_utils.get_configuration_from_layersource(
-                    source_provider, source, configuration
+                valid, mode = db_utils.get_configuration_from_sourceprovider(
+                    source_provider, configuration
                 )
                 if valid and mode:
                     configuration.tool = mode
@@ -392,9 +390,8 @@ class LayerModel(QgsLayerTreeModel):
             return False
 
         source_provider = layer.dataProvider()
-        source = QgsDataSourceUri(layer.dataProvider().dataSourceUri())
-        schema_identificator = db_utils.get_schema_identificator_from_layersource(
-            source_provider, source
+        schema_identificator = db_utils.get_schema_identificator_from_sourceprovider(
+            source_provider
         )
         return schema_identificator in self.ili_schema_identificators
 

--- a/QgisModelBaker/gui/topping_wizard/models_page.py
+++ b/QgisModelBaker/gui/topping_wizard/models_page.py
@@ -18,7 +18,7 @@
  ***************************************************************************/
 """
 
-from qgis.core import QgsDataSourceUri, QgsMapLayer, QgsProject
+from qgis.core import QgsMapLayer, QgsProject
 from qgis.PyQt.QtWidgets import QWizardPage
 
 import QgisModelBaker.libs.modelbaker.utils.db_utils as db_utils
@@ -83,10 +83,9 @@ class ModelsPage(QWizardPage, PAGE_UI):
         for layer in QgsProject.instance().mapLayers().values():
             if layer.type() == QgsMapLayer.VectorLayer:
                 source_provider = layer.dataProvider()
-                source = QgsDataSourceUri(layer.dataProvider().dataSourceUri())
                 schema_identificator = (
-                    db_utils.get_schema_identificator_from_layersource(
-                        source_provider, source
+                    db_utils.get_schema_identificator_from_sourceprovider(
+                        source_provider
                     )
                 )
                 if schema_identificator in checked_identificators:
@@ -94,8 +93,8 @@ class ModelsPage(QWizardPage, PAGE_UI):
                 else:
                     checked_identificators.append(schema_identificator)
                     current_configuration = Ili2DbCommandConfiguration()
-                    valid, mode = db_utils.get_configuration_from_layersource(
-                        source_provider, source, current_configuration
+                    valid, mode = db_utils.get_configuration_from_sourceprovider(
+                        source_provider, current_configuration
                     )
                     if valid and mode:
                         current_configuration.tool = mode

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -22,7 +22,6 @@ import os
 from PyQt5.QtGui import QColor, QGuiApplication
 from qgis.core import (
     QgsApplication,
-    QgsDataSourceUri,
     QgsGeometry,
     QgsMapLayer,
     QgsPointXY,
@@ -185,9 +184,8 @@ class ValidateDock(QDockWidget, DIALOG_UI):
             return
 
         source_provider = layer.dataProvider()
-        source = QgsDataSourceUri(layer.dataProvider().dataSourceUri())
-        schema_identificator = db_utils.get_schema_identificator_from_layersource(
-            source_provider, source
+        schema_identificator = db_utils.get_schema_identificator_from_sourceprovider(
+            source_provider
         )
         if not schema_identificator:
             self.setDisabled(True)
@@ -199,8 +197,8 @@ class ValidateDock(QDockWidget, DIALOG_UI):
         self._reset_gui()
 
         self.current_schema_identificator = schema_identificator
-        valid, mode = db_utils.get_configuration_from_layersource(
-            source_provider, source, self.current_configuration
+        valid, mode = db_utils.get_configuration_from_sourceprovider(
+            source_provider, self.current_configuration
         )
         if valid and mode:
             output_file_name = "{}.xtf".format(self.current_schema_identificator)

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "1.3.1")
+MODELBAKER_LIBRARY=("modelbaker" "1.3.2")
 PACKAGING=("packaging" "21.3")
 
 PACKAGES=(


### PR DESCRIPTION
Because QgsDataSource::uri does return unproper filepath when having spaces in the path.

Needs modelbaker 1.3.2