### PR TITLE
Validate Pan Zoom improvements and error count

### DIFF
--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -162,6 +162,7 @@ class ValidateDock(QDockWidget, DIALOG_UI):
         self._reset_current_values()
         self.info_label.setText("")
         self.progress_bar.setTextVisible(False)
+        self._set_count_label(0)
         self.setStyleSheet(gui_utils.DEFAULT_STYLE)
         self.result_table_view.setModel(
             ValidationResultTableModel(self.requested_roles)
@@ -369,10 +370,19 @@ class ValidateDock(QDockWidget, DIALOG_UI):
             self.setStyleSheet(gui_utils.INVALID_STYLE)
         self.progress_bar.setTextVisible(True)
         self.result_table_view.setDisabled(valid)
+        self._set_count_label(
+            self.schema_validations[
+                self.current_schema_identificator
+            ].result_model.rowCount()
+        )
 
     def _disable_controls(self, disable):
         self.run_button.setDisabled(disable)
         self.result_table_view.setDisabled(disable)
+
+    def _set_count_label(self, count):
+        text = self.tr("{} Errors".format(count))
+        self.error_count_label.setText(text)
 
     def _table_context_menu_requested(self, pos):
         if not self.result_table_view.indexAt(pos).isValid():

--- a/QgisModelBaker/ui/validator.ui
+++ b/QgisModelBaker/ui/validator.ui
@@ -107,6 +107,13 @@
     <item row="5" column="0">
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
+       <widget class="QLabel" name="error_count_label">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
First there is an error count:
![image](https://user-images.githubusercontent.com/28384354/193032012-de7cc7d7-f78e-4d56-af25-a74c9ec28066.png)

On zoom to coordinates, the get highlighted.

And second I changed the behavior that on having coordinates zoom to feature and flash features are now zooming and flashing the coordinates. Only pan, does pan the features.
