### PR TITLE
Session panel improvements (cancel java, re-run process)

### DIFF
--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -48,6 +48,7 @@ class SessionPanel(QWidget, WIDGET_UI):
     on_process_started = pyqtSignal(str)
     on_process_finished = pyqtSignal(int, int)
     on_done_or_skipped = pyqtSignal(object)
+    cancel_session = pyqtSignal()
 
     def __init__(
         self,
@@ -92,11 +93,15 @@ class SessionPanel(QWidget, WIDGET_UI):
         self.skip_action = QAction(self.tr("Skip"), None)
         self.skip_action.triggered.connect(self.skip)
 
+        self.cancel_action = QAction(self.tr("Cancel"), None)
+        self.cancel_action.triggered.connect(lambda: self.cancel_session.emit())
+
         self.create_tool_button.addAction(
             self.set_button_to_create_without_constraints_action
         )
         self.create_tool_button.addAction(self.edit_command_action)
         self.create_tool_button.addAction(self.skip_action)
+        self.create_tool_button.addAction(self.cancel_action)
         self.create_tool_button.setText(self.create_text)
         self.create_tool_button.clicked.connect(self.run)
 
@@ -225,7 +230,7 @@ class SessionPanel(QWidget, WIDGET_UI):
 
         with OverrideCursor(Qt.WaitCursor):
             self.progress_bar.setValue(10)
-            self.setDisabled(True)
+            # self.setDisabled(True)
 
             porter.stdout.connect(
                 lambda str: self.print_info.emit(str, LogColor.COLOR_INFO)
@@ -233,6 +238,7 @@ class SessionPanel(QWidget, WIDGET_UI):
             porter.stderr.connect(self.on_stderr)
             porter.process_started.connect(self.on_process_started)
             porter.process_finished.connect(self.on_process_finished)
+            self.cancel_session.connect(porter.cancel_process)
             self.progress_bar.setValue(20)
             try:
                 if porter.run(edited_command) != iliexecutable.IliExecutable.SUCCESS:

--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -47,7 +47,7 @@ class SessionPanel(QWidget, WIDGET_UI):
     on_stderr = pyqtSignal(str)
     on_process_started = pyqtSignal(str)
     on_process_finished = pyqtSignal(int, int)
-    on_done_or_skipped = pyqtSignal(object)
+    on_done_or_skipped = pyqtSignal(object, bool)
     cancel_session = pyqtSignal()
 
     def __init__(
@@ -86,24 +86,22 @@ class SessionPanel(QWidget, WIDGET_UI):
         self.set_button_to_create_without_constraints_action.triggered.connect(
             self.set_button_to_create_without_constraints
         )
-
         self.edit_command_action = QAction(self.tr("Edit ili2db command"), None)
         self.edit_command_action.triggered.connect(self.edit_command)
 
         self.skip_action = QAction(self.tr("Skip"), None)
-        self.skip_action.triggered.connect(self.skip)
-
-        self.cancel_action = QAction(self.tr("Cancel"), None)
-        self.cancel_action.triggered.connect(lambda: self.cancel_session.emit())
+        self.skip_action.triggered.connect(self._skip)
 
         self.create_tool_button.addAction(
             self.set_button_to_create_without_constraints_action
         )
         self.create_tool_button.addAction(self.edit_command_action)
         self.create_tool_button.addAction(self.skip_action)
-        self.create_tool_button.addAction(self.cancel_action)
+
         self.create_tool_button.setText(self.create_text)
         self.create_tool_button.clicked.connect(self.run)
+
+        self.is_running = False
 
         # set up the values
         self.configuration = general_configuration
@@ -136,6 +134,8 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.configuration.dataset = ";".join(self.datasets)
             self.configuration.baskets = self.baskets
 
+        self.on_process_started.connect(self._on_process_started)
+        self.on_process_finished.connect(self._on_process_finished)
         self.is_skipped_or_done = False
 
     @property
@@ -157,10 +157,12 @@ class SessionPanel(QWidget, WIDGET_UI):
         self.configuration.disable_validation = False
         self.create_tool_button.removeAction(self.set_button_to_create_action)
         self.create_tool_button.removeAction(self.edit_command_action)
+        self.create_tool_button.removeAction(self.skip_action)
         self.create_tool_button.addAction(
             self.set_button_to_create_without_constraints_action
         )
         self.create_tool_button.addAction(self.edit_command_action)
+        self.create_tool_button.addAction(self.skip_action)
         self.create_tool_button.setText(self.create_text)
 
     def set_button_to_create_without_constraints(self):
@@ -174,15 +176,48 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.set_button_to_create_without_constraints_action
         )
         self.create_tool_button.removeAction(self.edit_command_action)
+        self.create_tool_button.removeAction(self.skip_action)
         self.create_tool_button.addAction(self.set_button_to_create_action)
         self.create_tool_button.addAction(self.edit_command_action)
+        self.create_tool_button.addAction(self.skip_action)
         self.create_tool_button.setText(self.create_without_constraints_text)
 
-    def skip(self):
-        self.setDisabled(True)
-        self.print_info.emit(f'{self.tr("Import skipped!")}\n', LogColor.COLOR_INFO)
+    def set_button_to_last_create_state(self):
+        if self.configuration.disable_validation:
+            self.set_button_to_create_without_constraints()
+        else:
+            self.set_button_to_create()
+
+    def set_button_to_cancel(self):
+        self.create_tool_button.removeAction(self.set_button_to_create_action)
+        self.create_tool_button.removeAction(
+            self.set_button_to_create_without_constraints_action
+        )
+        self.create_tool_button.removeAction(self.edit_command_action)
+        self.create_tool_button.removeAction(self.skip_action)
+        self.create_tool_button.setText(self.tr("Cancel"))
+
+    def _skip(self):
+        self.create_tool_button.removeAction(self.skip_action)
+
+        self.progress_bar.setValue(100)
+        self.progress_bar.setFormat(self.tr("SKIPPED"))
+        self.progress_bar.setTextVisible(True)
+        self.setStyleSheet(gui_utils.INACTIVE_STYLE)
+
         self.is_skipped_or_done = True
-        self.on_done_or_skipped.emit(self.id)
+        self.on_done_or_skipped.emit(self.id, True)
+
+    def _done(self):
+        self.create_tool_button.removeAction(self.skip_action)
+
+        self.progress_bar.setValue(100)
+        self.progress_bar.setFormat(self.tr("DONE"))
+        self.progress_bar.setTextVisible(True)
+        self.setStyleSheet(gui_utils.SUCCESS_STYLE)
+
+        self.is_skipped_or_done = True
+        self.on_done_or_skipped.emit(self.id, True)
 
     def _get_porter(self):
         porter = None
@@ -220,8 +255,18 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.run(edited_command)
 
     def run(self, edited_command=None):
-        if self.is_skipped_or_done:
-            return True
+        if self.is_running:
+            # means this is called by "cancel" option
+            self.print_info.emit(self.tr("Cancel session..."), LogColor.COLOR_INFO)
+            self.set_button_to_last_create_state()
+            self.cancel_session.emit()
+            self.is_running = False
+            return
+        else:
+            self.on_done_or_skipped.emit(self.id, False)
+            self.setStyleSheet(gui_utils.DEFAULT_STYLE)
+            self.set_button_to_cancel()
+            self.is_running = True
 
         if self.db_action_type == DbActionType.GENERATE:
             self._pre_generate_project()
@@ -229,8 +274,8 @@ class SessionPanel(QWidget, WIDGET_UI):
         porter = self._get_porter()
 
         with OverrideCursor(Qt.WaitCursor):
+            self.progress_bar.setTextVisible(False)
             self.progress_bar.setValue(10)
-            # self.setDisabled(True)
 
             porter.stdout.connect(
                 lambda str: self.print_info.emit(str, LogColor.COLOR_INFO)
@@ -239,32 +284,37 @@ class SessionPanel(QWidget, WIDGET_UI):
             porter.process_started.connect(self.on_process_started)
             porter.process_finished.connect(self.on_process_finished)
             self.cancel_session.connect(porter.cancel_process)
+
             self.progress_bar.setValue(20)
             try:
                 if porter.run(edited_command) != iliexecutable.IliExecutable.SUCCESS:
+                    self.is_running = False
                     self.progress_bar.setValue(0)
-                    self.setDisabled(False)
                     if not self.db_action_type == DbActionType.GENERATE:
                         self.set_button_to_create_without_constraints()
                     return False
             except JavaNotFoundError as e:
                 self.print_info.emit(e.error_string, LogColor.COLOR_FAIL)
+                self.is_running = False
                 self.progress_bar.setValue(0)
-                self.setDisabled(False)
+                self.set_button_to_create_without_constraints()
                 return False
 
             self.progress_bar.setValue(90)
 
+            # an user interaction (cancel) here cannot interupt the process, why it's disabled (and enabled again below). This part might come to a seperate page anyway in future.
+            self.setDisabled(True)
             if (
                 self.db_action_type == DbActionType.GENERATE
                 and self.configuration.create_basket_col
             ):
                 self._create_default_dataset()
+            self.setDisabled(False)
 
-            self.progress_bar.setValue(100)
+            self.set_button_to_last_create_state()
+            self.is_running = False
             self.print_info.emit(f'{self.tr("Done!")}\n', LogColor.COLOR_SUCCESS)
-            self.on_done_or_skipped.emit(self.id)
-            self.is_skipped_or_done = True
+            self._done()
             return True
 
     def _create_default_dataset(self):
@@ -314,3 +364,12 @@ class SessionPanel(QWidget, WIDGET_UI):
     def _get_tid_handling(self):
         db_connector = db_utils.get_db_connector(self.configuration)
         return db_connector.get_tid_handling()
+
+    def _on_process_started(self, command):
+        print("_on_process_started")
+
+    def _on_process_finished(self, exit_code, result):
+        if exit_code == 0:
+            print("_on_process_finished 1")
+        else:
+            print("_on_process_finished 2")

--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -60,7 +60,7 @@ class SessionPanel(QWidget, WIDGET_UI):
         db_action_type,
         parent=None,
     ):
-        QWidget.__init__(self, parent)
+        super().__init__(parent)
         self.setupUi(self)
         self.setStyleSheet(gui_utils.DEFAULT_STYLE)
         self.db_simple_factory = DbSimpleFactory()
@@ -135,6 +135,14 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.configuration.baskets = self.baskets
 
         self.is_skipped_or_done = False
+
+    def hideEvent(self, event):
+        """
+        When widget gets hidden, we emit the cancel_session to terminate running java processes.
+        This is called on every hide (including the one right before getting destroyed because of dialog close.
+        """
+        self.cancel_session.emit()
+        super().hideEvent(event)
 
     @property
     def id(self):
@@ -287,14 +295,12 @@ class SessionPanel(QWidget, WIDGET_UI):
             try:
                 if porter.run(edited_command) != iliexecutable.IliExecutable.SUCCESS:
                     self.is_running = False
-                    self.progress_bar.setValue(0)
                     if not self.db_action_type == DbActionType.GENERATE:
                         self.set_button_to_create_without_constraints()
                     return False
             except JavaNotFoundError as e:
                 self.print_info.emit(e.error_string, LogColor.COLOR_FAIL)
                 self.is_running = False
-                self.progress_bar.setValue(0)
                 self.set_button_to_create_without_constraints()
                 return False
 

--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -134,8 +134,6 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.configuration.dataset = ";".join(self.datasets)
             self.configuration.baskets = self.baskets
 
-        self.on_process_started.connect(self._on_process_started)
-        self.on_process_finished.connect(self._on_process_finished)
         self.is_skipped_or_done = False
 
     @property
@@ -364,12 +362,3 @@ class SessionPanel(QWidget, WIDGET_UI):
     def _get_tid_handling(self):
         db_connector = db_utils.get_db_connector(self.configuration)
         return db_connector.get_tid_handling()
-
-    def _on_process_started(self, command):
-        print("_on_process_started")
-
-    def _on_process_finished(self, exit_code, result):
-        if exit_code == 0:
-            print("_on_process_finished 1")
-        else:
-            print("_on_process_finished 2")

--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -49,6 +49,7 @@ class SessionPanel(QWidget, WIDGET_UI):
     on_process_finished = pyqtSignal(int, int)
     on_done_or_skipped = pyqtSignal(object, bool)
     cancel_session = pyqtSignal()
+    run_finished = pyqtSignal()
 
     def __init__(
         self,
@@ -135,15 +136,6 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.configuration.baskets = self.baskets
 
         self.is_skipped_or_done = False
-
-    def hideEvent(self, event):
-        """
-        When widget gets hidden, we emit the cancel_session to terminate running java processes.
-        This is called on every hide (including the one right before getting destroyed because of dialog close.
-        """
-        self.print_info.emit(self.tr("Cancel session..."), LogColor.COLOR_INFO)
-        self.cancel_session.emit()
-        super().hideEvent(event)
 
     @property
     def id(self):
@@ -267,7 +259,6 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.print_info.emit(self.tr("Cancel session..."), LogColor.COLOR_INFO)
             self.set_button_to_last_create_state()
             self.cancel_session.emit()
-            self.is_running = False
             return
         else:
             self.on_done_or_skipped.emit(self.id, False)
@@ -296,13 +287,17 @@ class SessionPanel(QWidget, WIDGET_UI):
             try:
                 if porter.run(edited_command) != iliexecutable.IliExecutable.SUCCESS:
                     self.is_running = False
+                    self.progress_bar.setValue(0)
                     if not self.db_action_type == DbActionType.GENERATE:
                         self.set_button_to_create_without_constraints()
+                    self.run_finished.emit()
                     return False
             except JavaNotFoundError as e:
                 self.print_info.emit(e.error_string, LogColor.COLOR_FAIL)
                 self.is_running = False
+                self.progress_bar.setValue(0)
                 self.set_button_to_create_without_constraints()
+                self.run_finished.emit()
                 return False
 
             self.progress_bar.setValue(90)
@@ -320,6 +315,7 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.is_running = False
             self.print_info.emit(f'{self.tr("Done!")}\n', LogColor.COLOR_SUCCESS)
             self._done()
+            self.run_finished.emit()
             return True
 
     def _create_default_dataset(self):

--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -141,6 +141,7 @@ class SessionPanel(QWidget, WIDGET_UI):
         When widget gets hidden, we emit the cancel_session to terminate running java processes.
         This is called on every hide (including the one right before getting destroyed because of dialog close.
         """
+        self.print_info.emit(self.tr("Cancel session..."), LogColor.COLOR_INFO)
         self.cancel_session.emit()
         super().hideEvent(event)
 

--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -136,15 +136,6 @@ class SessionPanel(QWidget, WIDGET_UI):
 
         self.is_skipped_or_done = False
 
-    def hideEvent(self, event):
-        """
-        When widget gets hidden, we emit the cancel_session to terminate running java processes.
-        This is called on every hide (including the one right before getting destroyed because of dialog close.
-        """
-        self.print_info.emit(self.tr("Cancel session..."), LogColor.COLOR_INFO)
-        self.cancel_session.emit()
-        super().hideEvent(event)
-
     @property
     def id(self):
         return (
@@ -267,7 +258,6 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.print_info.emit(self.tr("Cancel session..."), LogColor.COLOR_INFO)
             self.set_button_to_last_create_state()
             self.cancel_session.emit()
-            self.is_running = False
             return
         else:
             self.on_done_or_skipped.emit(self.id, False)
@@ -295,14 +285,16 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.progress_bar.setValue(20)
             try:
                 if porter.run(edited_command) != iliexecutable.IliExecutable.SUCCESS:
-                    self.is_running = False
+                    self.progress_bar.setValue(0)
                     if not self.db_action_type == DbActionType.GENERATE:
                         self.set_button_to_create_without_constraints()
+                    self.is_running = False
                     return False
             except JavaNotFoundError as e:
                 self.print_info.emit(e.error_string, LogColor.COLOR_FAIL)
-                self.is_running = False
+                self.progress_bar.setValue(0)
                 self.set_button_to_create_without_constraints()
+                self.is_running = False
                 return False
 
             self.progress_bar.setValue(90)

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -74,9 +74,9 @@ class ValidationResultTableModel(ValidationResultModel):
                 return item.data(int(self.roles[index.column()]))
             if role == Qt.DecorationRole:
                 return (
-                    QColor(gui_utils.VALID_COLOR)
+                    QColor(gui_utils.SUCCESS_COLOR)
                     if item.data(int(ValidationResultModel.Roles.FIXED))
-                    else QColor(gui_utils.INVALID_COLOR)
+                    else QColor(gui_utils.ERROR_COLOR)
                 )
             if role == Qt.ToolTipRole:
                 tooltip_text = "{type} at {tid} in {object}".format(
@@ -366,10 +366,10 @@ class ValidateDock(QDockWidget, DIALOG_UI):
 
         if valid:
             self.progress_bar.setFormat(self.tr("Schema is valid"))
-            self.setStyleSheet(gui_utils.VALID_STYLE)
+            self.setStyleSheet(gui_utils.SUCCESS_STYLE)
         else:
             self.progress_bar.setFormat(self.tr("Schema is not valid"))
-            self.setStyleSheet(gui_utils.INVALID_STYLE)
+            self.setStyleSheet(gui_utils.ERROR_STYLE)
         self.progress_bar.setTextVisible(True)
         self.result_table_view.setDisabled(valid)
         self._set_count_label(

--- a/QgisModelBaker/gui/workflow_wizard/execution_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/execution_page.py
@@ -20,7 +20,7 @@
 
 import copy
 
-from qgis.PyQt.QtCore import QCoreApplication, QEventLoop
+from qgis.PyQt.QtCore import QCoreApplication, QEventLoop, pyqtSignal
 from qgis.PyQt.QtWidgets import (
     QSizePolicy,
     QSpacerItem,
@@ -39,6 +39,9 @@ PAGE_UI = gui_utils.get_ui_class("workflow_wizard/execution.ui")
 
 
 class ExecutionPage(QWizardPage, PAGE_UI):
+
+    cancel_current_session = pyqtSignal()
+
     def __init__(self, parent, title, db_action_type):
         QWizardPage.__init__(self, parent)
 
@@ -159,6 +162,7 @@ class ExecutionPage(QWizardPage, PAGE_UI):
         loop = QEventLoop()
         for session_widget in self.session_widget_list:
             session_widget.on_done_or_skipped.connect(lambda: loop.quit())
+            self.cancel_current_session.connect(session_widget.cancel_session)
             # fall in a loop on fail untill the user skipped it or it has been successful
             if not session_widget.run():
                 loop.exec()

--- a/QgisModelBaker/gui/workflow_wizard/execution_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/execution_page.py
@@ -153,10 +153,12 @@ class ExecutionPage(QWizardPage, PAGE_UI):
                 return session_widget
         return None
 
-    def _on_done_or_skipped_received(self, id):
-        self.pending_sessions.remove(id)
-        if not self.pending_sessions:
-            self.setComplete(True)
+    def _on_done_or_skipped_received(self, id, state=True):
+        if state and id in self.pending_sessions:
+            self.pending_sessions.remove(id)
+        if not state and id not in self.pending_sessions:
+            self.pending_sessions.append(id)
+        self.setComplete(not self.pending_sessions)
 
     def _run(self):
         loop = QEventLoop()

--- a/QgisModelBaker/gui/workflow_wizard/execution_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/execution_page.py
@@ -20,7 +20,7 @@
 
 import copy
 
-from qgis.PyQt.QtCore import QCoreApplication, QEventLoop, QTimer
+from qgis.PyQt.QtCore import QCoreApplication, QEventLoop
 from qgis.PyQt.QtWidgets import (
     QSizePolicy,
     QSpacerItem,
@@ -74,21 +74,6 @@ class ExecutionPage(QWizardPage, PAGE_UI):
         self.run_command_button.clicked.connect(self._run)
         self.is_complete = False
         self.pending_sessions = []
-
-    def cancel_sessions(self):
-        for session in self.session_widget_list:
-            if session.is_running:
-                loop = QEventLoop()
-                session.run_finished.connect(lambda: loop.quit())
-                timer = QTimer()
-                timer.setSingleShot(True)
-                timer.timeout.connect(lambda: loop.quit())
-                self.workflow_wizard.log_panel.print_info(
-                    self.tr("- Cancel current session...")
-                )
-                timer.start(10000)
-                session.cancel_session.emit()
-                loop.exec()
 
     def isComplete(self):
         return self.is_complete

--- a/QgisModelBaker/gui/workflow_wizard/execution_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/execution_page.py
@@ -20,7 +20,7 @@
 
 import copy
 
-from qgis.PyQt.QtCore import QCoreApplication, QEventLoop
+from qgis.PyQt.QtCore import QCoreApplication, QEventLoop, QTimer
 from qgis.PyQt.QtWidgets import (
     QSizePolicy,
     QSpacerItem,
@@ -74,6 +74,21 @@ class ExecutionPage(QWizardPage, PAGE_UI):
         self.run_command_button.clicked.connect(self._run)
         self.is_complete = False
         self.pending_sessions = []
+
+    def cancel_sessions(self):
+        for session in self.session_widget_list:
+            if session.is_running:
+                loop = QEventLoop()
+                session.run_finished.connect(lambda: loop.quit())
+                timer = QTimer()
+                timer.setSingleShot(True)
+                timer.timeout.connect(lambda: loop.quit())
+                self.workflow_wizard.log_panel.print_info(
+                    self.tr("- Cancel current session...")
+                )
+                timer.start(10000)
+                session.cancel_session.emit()
+                loop.exec()
 
     def isComplete(self):
         return self.is_complete

--- a/QgisModelBaker/gui/workflow_wizard/execution_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/execution_page.py
@@ -20,7 +20,7 @@
 
 import copy
 
-from qgis.PyQt.QtCore import QCoreApplication, QEventLoop, pyqtSignal
+from qgis.PyQt.QtCore import QCoreApplication, QEventLoop
 from qgis.PyQt.QtWidgets import (
     QSizePolicy,
     QSpacerItem,
@@ -39,9 +39,6 @@ PAGE_UI = gui_utils.get_ui_class("workflow_wizard/execution.ui")
 
 
 class ExecutionPage(QWizardPage, PAGE_UI):
-
-    cancel_current_session = pyqtSignal()
-
     def __init__(self, parent, title, db_action_type):
         QWizardPage.__init__(self, parent)
 
@@ -164,7 +161,6 @@ class ExecutionPage(QWizardPage, PAGE_UI):
         loop = QEventLoop()
         for session_widget in self.session_widget_list:
             session_widget.on_done_or_skipped.connect(lambda: loop.quit())
-            self.cancel_current_session.connect(session_widget.cancel_session)
             # fall in a loop on fail untill the user skipped it or it has been successful
             if not session_widget.run():
                 loop.exec()

--- a/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
@@ -300,6 +300,7 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
                         layer.layer.loadNamedStyle(style_file_path)
 
         self.progress_bar.setValue(100)
+        self.setStyleSheet(gui_utils.SUCCESS_STYLE)
         self.workflow_wizard.log_panel.print_info(self.tr("It's served!"))
 
     def ilidata_path_resolver(self, base_path, path):

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -71,7 +71,7 @@ from QgisModelBaker.utils.gui_utils import (
 
 class WorkflowWizard(QWizard):
     def __init__(self, iface, base_config, parent):
-        super().__init__(parent)
+        QWizard.__init__(self, parent)
 
         self.setWindowTitle(self.tr("QGIS Model Baker Wizard"))
         self.setWizardStyle(QWizard.ModernStyle)
@@ -523,20 +523,10 @@ class WorkflowWizard(QWizard):
                     dropped_file, self.tr("Added by user with drag'n'drop.")
                 )
 
-    def reject(self) -> None:
-        # if sessions running, the dialog is blocked until everything is cleaned up
-        if self.current_id == PageIds.ImportSchemaExecution:
-            self.import_schema_execution_page.cancel_sessions()
-        if self.current_id == PageIds.ImportDataExecution:
-            self.import_data_execution_page.cancel_sessions()
-        if self.current_id == PageIds.ExportDataExecution:
-            self.export_data_execution_page.cancel_sessions()
-        return super().reject()
-
 
 class WorkflowWizardDialog(QDialog):
     def __init__(self, iface, base_config, parent):
-        super().__init__(parent)
+        QDialog.__init__(self, parent)
         self.iface = iface
         self.base_config = base_config
 
@@ -562,12 +552,3 @@ class WorkflowWizardDialog(QDialog):
         self.workflow_wizard.append_dropped_files(dropped_files)
         self.workflow_wizard.restart()
         self.workflow_wizard.next()
-
-    def reject(self) -> None:
-        """
-        Cancel Button -> Wizard Reject
-        X -> Dialog Reject (and Close Event)
-        Escape -> sometimes Wizard Reject / sometimes Dialog Reject
-        """
-        self.workflow_wizard.reject()
-        return super().reject()

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -101,9 +101,9 @@ BLUE = "#9BCADE"
 PURPLE = "#B18BC9"
 RED = "#EBB3A4"
 
-VALID_COLOR = GREEN
+SUCCESS_COLOR = GREEN
 
-VALID_STYLE = """
+SUCCESS_STYLE = """
     QProgressBar {border: 2px solid grey;border-radius: 5px;}
     QProgressBar::chunk {background-color: #A1DE9B; width: 20px;}
     QProgressBar {
@@ -113,9 +113,9 @@ VALID_STYLE = """
     }
     """
 
-INVALID_COLOR = RED
+ERROR_COLOR = RED
 
-INVALID_STYLE = """
+ERROR_STYLE = """
     QProgressBar {border: 2px solid grey;border-radius: 5px;}
     QProgressBar::chunk {background-color: #EBB3A4; width: 20px;}
     QProgressBar {
@@ -128,6 +128,16 @@ INVALID_STYLE = """
 DEFAULT_STYLE = """
     QProgressBar {border: 2px solid grey;border-radius: 5px;}
     QProgressBar::chunk {background-color: #9BCADE; width: 20px;}
+    QProgressBar {
+        border: 2px solid grey;
+        border-radius: 5px;
+        text-align: center;
+    }
+    """
+
+INACTIVE_STYLE = """
+    QProgressBar {border: 2px solid grey;border-radius: 5px;}
+    QProgressBar::chunk {background-color: #ECECEC; width: 20px;}
     QProgressBar {
         border: 2px solid grey;
         border-radius: 5px;


### PR DESCRIPTION
This PR resolves three topics:
- [x] Cancel button appears while running and cancels the current process. Resolves #714
~- [x] Canceling all session when closing the wizard dialog. Resolves #714~
- [x] When a session is done or skipped it's possible to re-run them (they don't get disabled). Resolves #748

![grafik](https://user-images.githubusercontent.com/28384354/207384559-e93782b5-c0ed-46b3-8cca-5f7e488d95e9.png)

Requires https://github.com/opengisch/QgisModelBakerLibrary/pull/39