### PR TITLE
Topping Exporter: Additive Project Settings (MapThemes, Variables and Layouts)

### DIFF
--- a/QgisModelBaker/gui/topping_wizard/additives_page.py
+++ b/QgisModelBaker/gui/topping_wizard/additives_page.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+                              -------------------
+        begin                : 2022-12-07
+        git sha              : :%H$
+        copyright            : (C) 2022 by Dave Signer
+        email                : david at opengis ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from qgis.core import QgsProject
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QWizardPage
+
+from QgisModelBaker.utils import gui_utils
+from QgisModelBaker.utils.gui_utils import CheckEntriesModel
+
+PAGE_UI = gui_utils.get_ui_class("topping_wizard/additives.ui")
+
+
+class AdditivesPage(QWizardPage, PAGE_UI):
+    def __init__(self, parent, title):
+        QWizardPage.__init__(self)
+
+        self.topping_wizard = parent
+
+        self.setupUi(self)
+
+        self.setStyleSheet(gui_utils.DEFAULT_STYLE)
+        self.setTitle(title)
+
+        self.mapthemes_model = CheckEntriesModel()
+        self.mapthemes_view.setModel(self.mapthemes_model)
+        self.mapthemes_view.clicked.connect(self.mapthemes_view.model().check)
+        self.mapthemes_view.space_pressed.connect(self.mapthemes_view.model().check)
+        self.variables_model = CheckEntriesModel()
+        self.variables_view.setModel(self.variables_model)
+        self.variables_view.clicked.connect(self.variables_view.model().check)
+        self.variables_view.space_pressed.connect(self.variables_view.model().check)
+        self.layouts_model = CheckEntriesModel()
+        self.layouts_view.setModel(self.layouts_model)
+        self.layouts_view.clicked.connect(self.layouts_view.model().check)
+        self.layouts_view.space_pressed.connect(self.layouts_view.model().check)
+
+    def initializePage(self) -> None:
+        maptheme_collection = QgsProject.instance().mapThemeCollection()
+        self.mapthemes_model.setStringList(maptheme_collection.mapThemes())
+        self.mapthemes_model.check_all(Qt.Checked)
+        self.mapthemes_view.setEnabled(self.mapthemes_model.rowCount())
+
+        variables_keys = []
+        variables_keys = QgsProject.instance().customVariables().keys()
+        self.variables_model.setStringList(variables_keys)
+        self.variables_model.check_all(Qt.Checked)
+        self.mapthemes_view.setEnabled(self.variables_model.rowCount())
+
+        layout_manager = QgsProject.instance().layoutManager()
+        layout_names = [layout.name() for layout in layout_manager.printLayouts()]
+        self.layouts_model.setStringList(layout_names)
+        self.layouts_model.check_all(Qt.Checked)
+        self.layouts_view.setEnabled(self.layouts_model.rowCount())
+        return super().initializePage()
+
+    def validatePage(self) -> bool:
+        self.topping_wizard.topping.export_settings.mapthemes = (
+            self.mapthemes_model.checked_entries()
+        )
+        self.topping_wizard.topping.export_settings.variables = (
+            self.variables_model.checked_entries()
+        )
+        self.topping_wizard.topping.export_settings.layouts = (
+            self.layouts_model.checked_entries()
+        )
+        return super().validatePage()

--- a/QgisModelBaker/gui/topping_wizard/layers_page.py
+++ b/QgisModelBaker/gui/topping_wizard/layers_page.py
@@ -216,7 +216,7 @@ class LayerModel(QgsLayerTreeModel):
                     index.column() == LayerModel.Columns.USE_STYLE
                     and not QgsLayerTree.isGroup(node)
                 ):
-                    self.export_settings._set_export_settings_values_for_all_styles(
+                    self._set_export_settings_values_for_all_styles(
                         ExportSettings.ToppingType.QMLSTYLE,
                         node,
                         None,
@@ -245,7 +245,7 @@ class LayerModel(QgsLayerTreeModel):
 
                     if bool(data):
                         # when the definition is checked the others become unchecked
-                        self.export_settings._set_export_settings_values_for_all_styles(
+                        self._set_export_settings_values_for_all_styles(
                             ExportSettings.ToppingType.QMLSTYLE,
                             node,
                             None,
@@ -297,7 +297,7 @@ class LayerModel(QgsLayerTreeModel):
         ):
             node = self.index2node(index)
             if node:
-                self.export_settings._set_export_settings_values_for_all_styles(
+                self._set_export_settings_values_for_all_styles(
                     ExportSettings.ToppingType.QMLSTYLE, node, None, True, data
                 )
                 return True

--- a/QgisModelBaker/gui/topping_wizard/topping_wizard.py
+++ b/QgisModelBaker/gui/topping_wizard/topping_wizard.py
@@ -23,6 +23,7 @@ from qgis.PyQt.QtCore import QSize, Qt
 from qgis.PyQt.QtWidgets import QDialog, QSplitter, QVBoxLayout, QWizard
 
 from QgisModelBaker.gui.panel.log_panel import LogPanel
+from QgisModelBaker.gui.topping_wizard.additives_page import AdditivesPage
 from QgisModelBaker.gui.topping_wizard.generation_page import GenerationPage
 from QgisModelBaker.gui.topping_wizard.ili2dbsettings_page import Ili2dbSettingsPage
 from QgisModelBaker.gui.topping_wizard.layers_page import LayersPage
@@ -62,6 +63,9 @@ class ToppingWizard(QWizard):
         self.layers_page = LayersPage(
             self, self._current_page_title(ToppingWizardPageIds.Layers)
         )
+        self.additives_page = AdditivesPage(
+            self, self._current_page_title(ToppingWizardPageIds.Additives)
+        )
         self.referencedata_page = ReferencedataPage(
             self, self._current_page_title(ToppingWizardPageIds.ReferenceData)
         )
@@ -75,6 +79,7 @@ class ToppingWizard(QWizard):
         self.setPage(ToppingWizardPageIds.Target, self.target_page)
         self.setPage(ToppingWizardPageIds.Models, self.models_page)
         self.setPage(ToppingWizardPageIds.Layers, self.layers_page)
+        self.setPage(ToppingWizardPageIds.Additives, self.additives_page)
         self.setPage(ToppingWizardPageIds.ReferenceData, self.referencedata_page)
         self.setPage(ToppingWizardPageIds.Ili2dbSettings, self.ili2dbsettings_page)
         self.setPage(ToppingWizardPageIds.Generation, self.generation_page)
@@ -100,6 +105,8 @@ class ToppingWizard(QWizard):
             return self.tr("Model Selection")
         elif id == ToppingWizardPageIds.Layers:
             return self.tr("Layer Configuration")
+        elif id == ToppingWizardPageIds.Additives:
+            return self.tr("Additive Project Settings")
         elif id == ToppingWizardPageIds.ReferenceData:
             return self.tr("Reference Data Selection")
         elif id == ToppingWizardPageIds.Ili2dbSettings:

--- a/QgisModelBaker/ui/topping_wizard/additives.ui
+++ b/QgisModelBaker/ui/topping_wizard/additives.ui
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Models</class>
+ <widget class="QDialog" name="Models">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select Files</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="description">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Select the Map Themes that should be exported, as well as the custom project variables and the print layouts.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="SpaceCheckListView" name="mapthemes_view" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="variables_label">
+     <property name="text">
+      <string>Custom Project Variables</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="SpaceCheckListView" name="layouts_view" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="SpaceCheckListView" name="variables_view" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="layouts_label">
+     <property name="text">
+      <string>Print Layouts (exported as templates)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="mapthemes_label">
+     <property name="text">
+      <string>Map Themes</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SpaceCheckListView</class>
+   <extends></extends>
+   <header>QgisModelBaker.utils.gui_utils</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -169,9 +169,10 @@ class ToppingWizardPageIds:
     Target = 1
     Models = 2
     Layers = 3
-    ReferenceData = 4
-    Ili2dbSettings = 5
-    Generation = 6
+    Additives = 4
+    ReferenceData = 5
+    Ili2dbSettings = 6
+    Generation = 7
 
 
 # Util functions
@@ -793,14 +794,17 @@ class CheckEntriesModel(QStringListModel):
 
     def __init__(self):
         super().__init__()
-        self._checked_entries = None
+        self._checked_entries = {}
 
     def flags(self, index):
         return Qt.ItemIsSelectable | Qt.ItemIsEnabled
 
     def data(self, index, role):
         if role == Qt.CheckStateRole:
-            return self._checked_entries[self.data(index, Qt.DisplayRole)]
+            if self.data(index, Qt.DisplayRole) in self._checked_entries:
+                return self._checked_entries[self.data(index, Qt.DisplayRole)]
+            else:
+                return Qt.Unchecked
         else:
             return QStringListModel.data(self, index, role)
 


### PR DESCRIPTION
And it exports all the styles (with category settings per layer).

![grafik](https://user-images.githubusercontent.com/28384354/206215730-a6f513df-7d24-4f42-ad06-024ab2118606.png)

This is a very basic page to export those settings. It can be improved:
- [ ] don't show the panels that have no settings in the project
- [ ] show variable values

*But the request was to export them without any settings. But it was possible to make this with a small effort.*

**Concerning Styles:**
It would really, really make sense to be able to control what styles need to be exported *how* (what categories). For that I opened an issue #766 
