### PR TITLE
Validator: Pan and zoom to coordinate (whenever possible)

### DIFF
--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -466,19 +466,21 @@ class ValidateDock(QDockWidget, DIALOG_UI):
             return
 
         if self.auto_pan_button.isChecked():
-            if valid_feature:
+            if valid_coords:
+                # prefering coordinates when having both
+                QTimer.singleShot(1, lambda: self._pan_to_coordinate(coord_x, coord_y))
+
+            else:
+                # otherwise it has a valid feature
                 QTimer.singleShot(
                     1,
                     lambda: self.iface.mapCanvas().panToFeatureIds(
                         layer, [feature.id()], False
                     ),
                 )
-            else:
-                # otherwise it has valid coordinates
-                QTimer.singleShot(1, lambda: self._pan_to_coordinate(coord_x, coord_y))
-
         if self.auto_zoom_button.isChecked():
             if valid_feature:
+                # prefering coordinates when having both
                 QTimer.singleShot(
                     1,
                     lambda: self.iface.mapCanvas().zoomToFeatureIds(

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -478,20 +478,21 @@ class ValidateDock(QDockWidget, DIALOG_UI):
                         layer, [feature.id()], False
                     ),
                 )
+
         if self.auto_zoom_button.isChecked():
-            if valid_feature:
+            if valid_coords:
                 # prefering coordinates when having both
+                QTimer.singleShot(
+                    1,
+                    lambda: self._set_extend(coord_x, coord_y),
+                )
+            else:
+                # otherwise it has a valid feature
                 QTimer.singleShot(
                     1,
                     lambda: self.iface.mapCanvas().zoomToFeatureIds(
                         layer, [feature.id()]
                     ),
-                )
-            else:
-                # otherwise it has valid coordinates
-                QTimer.singleShot(
-                    1,
-                    lambda: self._set_extend(coord_x, coord_y),
                 )
 
         if self.flash_button.isChecked():

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -473,6 +473,9 @@ class ValidateDock(QDockWidget, DIALOG_UI):
                         layer, [feature.id()], False
                     ),
                 )
+            else:
+                # otherwise it has valid coordinates
+                QTimer.singleShot(1, lambda: self._pan_to_coordinate(coord_x, coord_y))
 
         if self.auto_zoom_button.isChecked():
             if valid_feature:
@@ -522,6 +525,10 @@ class ValidateDock(QDockWidget, DIALOG_UI):
             float(x) - scale, float(y) - scale, float(x) + scale, float(y) + scale
         )
         self.iface.mapCanvas().setExtent(rect)
+        self.iface.mapCanvas().refresh()
+
+    def _pan_to_coordinate(self, x, y):
+        self.iface.mapCanvas().setCenter(QgsPointXY(float(x), float(y)))
         self.iface.mapCanvas().refresh()
 
     def _open_form(self, t_ili_tid):

--- a/QgisModelBaker/ui/validator.ui
+++ b/QgisModelBaker/ui/validator.ui
@@ -90,7 +90,7 @@
       <item>
        <widget class="QToolButton" name="auto_pan_button">
         <property name="toolTip">
-         <string>Automatically pan to the current feature</string>
+         <string>Automatically pan to the current coordinates / feature</string>
         </property>
         <property name="text">
          <string>...</string>

--- a/docs/user_guide/validation.md
+++ b/docs/user_guide/validation.md
@@ -39,10 +39,10 @@ With *right click* on the error a menu is opened with the following options:
 - Copy (to copy the message text)
 
 Automatic pan, zoom and highlight features or coordinates are performed by clicking on the result tables entry.
+On automatic pan and zoom, the coordinates are taken into account if they are provided by ili2db, if not, then the geometry of the feature (according to the OID provided by ili2db). On automatic zoom on the features geometry, it's extent is taken and on coordinates an extend of 10 map units instead.
 
 !!! Note
-    On automatic pan it pans to the coordinates, if provided by ili2db, if not then to the features geometry (according to the OID provided by ili2db). On automatic zoom it zooms to the features geometry, if the OID is provided by ili2db, and if not then to the coordinates with the extend of 10 map units.
-    On geometry layer, ili2db provides coordinates even on text value errors. It can be confusing, when it zooms / pans to the coordinates there. Still it's preverable to not zoom / pan to the coordinates on geometry errors (currently the validator cannot make a difference between those error-types).
+    Since ili2db sometimes on non-geometry errors provides the coordinates as well, there could be a confusion when it zooms or pans to the coordinates there. Still it's preverable to not zoom or pan to the coordinates on geometry errors when they provide an OID. Currently the validator cannot make a difference between those error-types.
 
 ## Using of Meta Attributes in the Validation
 As well as configuring [meta attributes](../../background_info/meta_attributes/) used for the physical database implementation and for QGIS project generation, meta attributes can be used for additional configuration of the validation like e.g. disable specific checks generally or on specific objects as well as naming of the constraints.

--- a/docs/user_guide/validation.md
+++ b/docs/user_guide/validation.md
@@ -41,7 +41,8 @@ With *right click* on the error a menu is opened with the following options:
 Automatic pan, zoom and highlight features or coordinates are performed by clicking on the result tables entry.
 
 !!! Note
-    On automatic pan it pans to the feature geometry centroid, if the OID is provided by ili2db, and if not then to the coordinates. On automatic zoom it zooms to the features geometry, if the OID is provided by ili2db, and if not then to the coordinates with the extend of 10 map units.
+    On automatic pan it pans to the coordinates, if provided by ili2db, if not then to the features geometry (according to the OID provided by ili2db). On automatic zoom it zooms to the features geometry, if the OID is provided by ili2db, and if not then to the coordinates with the extend of 10 map units.
+    On geometry layer, ili2db provides coordinates even on text value errors. It can be confusing, when it zooms / pans to the coordinates there. Still it's preverable to not zoom / pan to the coordinates on geometry errors (currently the validator cannot make a difference between those error-types).
 
 ## Using of Meta Attributes in the Validation
 As well as configuring [meta attributes](../../background_info/meta_attributes/) used for the physical database implementation and for QGIS project generation, meta attributes can be used for additional configuration of the validation like e.g. disable specific checks generally or on specific objects as well as naming of the constraints.

--- a/docs/user_guide/validation.md
+++ b/docs/user_guide/validation.md
@@ -41,7 +41,7 @@ With *right click* on the error a menu is opened with the following options:
 Automatic pan, zoom and highlight features or coordinates are performed by clicking on the result tables entry.
 
 !!! Note
-    On automatic pan it pans to the feature geometry centroid, if the OID is provided by ili2db, and if not then no pan is performed (no pan to coordinates yet). On automatic zoom it zooms to the features geometry, if the OID is provided by ili2db, and if not then to the coordinates with the extend of 10 map units.
+    On automatic pan it pans to the feature geometry centroid, if the OID is provided by ili2db, and if not then to the coordinates. On automatic zoom it zooms to the features geometry, if the OID is provided by ili2db, and if not then to the coordinates with the extend of 10 map units.
 
 ## Using of Meta Attributes in the Validation
 As well as configuring [meta attributes](../../background_info/meta_attributes/) used for the physical database implementation and for QGIS project generation, meta attributes can be used for additional configuration of the validation like e.g. disable specific checks generally or on specific objects as well as naming of the constraints.

--- a/docs/user_guide/validation.md
+++ b/docs/user_guide/validation.md
@@ -42,7 +42,7 @@ Automatic pan, zoom and highlight features or coordinates are performed by click
 On automatic pan and zoom, the coordinates are taken into account if they are provided by ili2db, if not, then the geometry of the feature (according to the OID provided by ili2db). On automatic zoom on the features geometry, it's extent is taken and on coordinates an extend of 10 map units instead.
 
 !!! Note
-    Since ili2db sometimes on non-geometry errors provides the coordinates as well, there could be a confusion when it zooms or pans to the coordinates there. Still it's preverable to not zoom or pan to the coordinates on geometry errors when they provide an OID. Currently the validator cannot make a difference between those error-types.
+    Since ili2db sometimes on non-geometry errors provides the coordinates as well, there could be a confusion when it zooms or pans to the coordinates there. Still it's preferable to not zoom or pan to the coordinates on geometry errors when they provide an OID. Currently the validator cannot make a difference between those error-types.
 
 ## Using of Meta Attributes in the Validation
 As well as configuring [meta attributes](../../background_info/meta_attributes/) used for the physical database implementation and for QGIS project generation, meta attributes can be used for additional configuration of the validation like e.g. disable specific checks generally or on specific objects as well as naming of the constraints.


### PR DESCRIPTION
With this change we pan to the coordinates. When no coordinate available, then we pan to the feature geometry (according to the provided OID). Same for zoom. On zooming to a feature geometry, we take it's extent.

1. Coord and OID available
2. Only OID available
3. Only Coord available

### Pan
**Status before:**
1. Pan to features centroid
2. Pan to features centroid
3. Nothing

**Implemented here*
1. Pan to coordinates
2. Pan to features
3. Pan to coordinates

Because we do receive error messages concerning text value but providing coordinates as well as geometry errors  providing OID, sometimes it can be confusing why it pans to the coordinates. See the discussion here #747

### Zoom
**Status before:**
1. Zoom to features
2. Zoom to features
3. Zoom to coordinates

**Implemented here*
1. Zoom to coordinates
2. Zoom to features
3. Zoom to coordinates

- [x] Pan to coord function
- [x] Priorize what should be taken first (coord, then OID feature geom)
- [x] Docu