### PR TITLE
Allow `ini` for the Extra Meta Attribute File

### DIFF
--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -1251,7 +1251,7 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
     def fill_toml_file_info_label(self):
         text = None
         if self.ili2db_options.toml_file():
-            text = self.tr("Extra Model Information File: {}").format(
+            text = self.tr("Extra Meta Attribute File: {}").format(
                 (
                     "…"
                     + self.ili2db_options.toml_file()[

--- a/QgisModelBaker/gui/ili2db_options.py
+++ b/QgisModelBaker/gui/ili2db_options.py
@@ -59,7 +59,7 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         self.toml_file_browse_button.clicked.connect(
             make_file_selector(
                 self.toml_file_line_edit,
-                title=self.tr("Open Extra Model Information File (*.toml *.ini)"),
+                title=self.tr("Open Extra Meta Attribute File (*.toml *.ini)"),
                 file_filter=self.tr(
                     "Extra Model Info File (*.toml *.TOML *.ini *.INI)"
                 ),

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -545,7 +545,7 @@ class ImportDataDialog(QDialog, DIALOG_UI):
     def fill_toml_file_info_label(self):
         text = None
         if self.ili2db_options.toml_file():
-            text = self.tr("Extra Model Information File: {}").format(
+            text = self.tr("Extra Meta Attribute File: {}").format(
                 (
                     "…"
                     + self.ili2db_options.toml_file()[

--- a/QgisModelBaker/gui/topping_wizard/ili2dbsettings_page.py
+++ b/QgisModelBaker/gui/topping_wizard/ili2dbsettings_page.py
@@ -134,7 +134,9 @@ class Ili2dbSettingsPage(QWizardPage, PAGE_UI):
             make_file_selector(
                 self.toml_file_line_edit,
                 title=self.tr("Open Extra Meta Attribute File (*.toml *.ini)"),
-                file_filter=self.tr("Extra Meta Attribute File (*.toml *.TOML *.ini *.INI)"),
+                file_filter=self.tr(
+                    "Extra Meta Attribute File (*.toml *.TOML *.ini *.INI)"
+                ),
             )
         )
         self.pre_script_file_browse_button.clicked.connect(

--- a/QgisModelBaker/gui/topping_wizard/ili2dbsettings_page.py
+++ b/QgisModelBaker/gui/topping_wizard/ili2dbsettings_page.py
@@ -133,8 +133,8 @@ class Ili2dbSettingsPage(QWizardPage, PAGE_UI):
         self.toml_file_browse_button.clicked.connect(
             make_file_selector(
                 self.toml_file_line_edit,
-                title=self.tr("Open Extra Model Information File (*.toml)"),
-                file_filter=self.tr("Extra Model Info File (*.toml *.TOML)"),
+                title=self.tr("Open Extra Meta Attribute File (*.toml *.ini)"),
+                file_filter=self.tr("Extra Meta Attribute File (*.toml *.TOML *.ini *.INI)"),
             )
         )
         self.pre_script_file_browse_button.clicked.connect(
@@ -235,7 +235,7 @@ class Ili2dbSettingsPage(QWizardPage, PAGE_UI):
         if self.topping_wizard.topping.metaconfig.ili2db_settings.metaattr_path:
             self.topping_wizard.log_panel.print_info(
                 self.tr(
-                    "Extra Model Information File: {path}".format(
+                    "Extra Meta Attribute File: {path}".format(
                         path=self.topping_wizard.topping.metaconfig.ili2db_settings.metaattr_path
                     )
                 ),

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -199,7 +199,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
     def _fill_toml_file_info_label(self):
         text = None
         if self.ili2db_options.toml_file():
-            text = self.tr("Extra Model Information File: {}").format(
+            text = self.tr("Extra Meta Attribute File: {}").format(
                 (
                     "…"
                     + self.ili2db_options.toml_file()[

--- a/QgisModelBaker/ui/ili2db_options.ui
+++ b/QgisModelBaker/ui/ili2db_options.ui
@@ -153,7 +153,7 @@ strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
       <item row="0" column="0">
        <widget class="QLabel" name="toml_file_label">
         <property name="text">
-         <string>Extra Model Information File</string>
+         <string>Extra Meta Attribute File</string>
         </property>
        </widget>
       </item>

--- a/QgisModelBaker/ui/topping_wizard/ili2dbsettings.ui
+++ b/QgisModelBaker/ui/topping_wizard/ili2dbsettings.ui
@@ -70,7 +70,7 @@
          <item row="0" column="0">
           <widget class="QLabel" name="toml_file_label">
            <property name="text">
-            <string>Extra Model Information File</string>
+            <string>Extra Meta Attribute File</string>
            </property>
           </widget>
          </item>

--- a/docs/background_info/meta_attributes.md
+++ b/docs/background_info/meta_attributes.md
@@ -60,7 +60,7 @@ Some additional non standard meta attributes are understood by the Model Baker a
 Used as the display expression for a layer. The display expression is the *name* that is used to identify a feature by text. One of the places where this is used is the combobox that is shown for a Relation Reference Widget on feature forms. ![relation reference](../assets/meta_attributes_relation_reference.png)
 
 
-## Extra Model Information File
+## Extra Meta Attribute File
 
 In these external files the meta attributes can be stored instead of having them directly in the INTERLIS files.
 

--- a/docs/background_info/usabilityhub/user_guide.md
+++ b/docs/background_info/usabilityhub/user_guide.md
@@ -50,7 +50,7 @@ Or with a ili2db metaattribute `toml`/`ini` file.
 
 ![raw_import_toml](../../assets/usabilityhub_raw_import_toml.png)
 
-The metaatribute `toml` / `ini` file was created for the Nutzungsplan project. This file is specified in the Model Baker under "Advanced Options" and "Extra Model Information File" and will also be included via the UsabILIty Hub in the following steps:
+The metaatribute `toml` / `ini` file was created for the Nutzungsplan project. This file is specified in the Model Baker under "Advanced Options" and "Extra Meta Attribute File" and will also be included via the UsabILIty Hub in the following steps:
 
 ![toml_config](../../assets/usabilityhub_toml_config.png)
 

--- a/docs/user_guide/import_workflow.md
+++ b/docs/user_guide/import_workflow.md
@@ -89,7 +89,7 @@ If this option is activated, circular arcs are stroked when importing the data.
 ### SQL Scripts
 
 You can define `sql` scripts that runs before and after the (schema) import.
-### Extra Model Information File
+### Extra Meta Attribute File
 
 A `toml` or `ini` file can contain values for [meta attributes](../../background_info/meta_attributes/) (like `dispExpression`) instead of having them directly in the `ili` file.
 


### PR DESCRIPTION
And name it everywhere Extra Meta Attribute File instead of Extra Model Information File or similar.

But main change is that it should allow `ini` in the file selector of the usabilityhub exporter here https://github.com/opengisch/QgisModelBaker/compare/master...getridoftoml#diff-07f6e644349cc8752fc57b115d4e2d8dc52e913dcb53b53a742373e4d6ba5b14L137