### PR TITLE
Reset Metaconfig on Data Import / Update

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -12,10 +12,12 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # MSSQL: client side
+RUN apt-get update
+RUN apt-get install -y unixodbc unixodbc-dev odbcinst odbcinst1debian2 libodbc1 libqt5sql5-odbc
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list
 RUN apt-get update
-RUN ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools unixodbc unixodbc-dev libqt5sql5-odbc
+RUN ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools
 
 COPY ./requirements.txt /tmp/
 RUN pip3 install -r /tmp/requirements.txt

--- a/QgisModelBaker/gui/workflow_wizard/import_data_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_data_configuration_page.py
@@ -213,6 +213,14 @@ class ImportDataConfigurationPage(QWizardPage, PAGE_UI):
     def nextId(self):
         return self.workflow_wizard.next_id()
 
+    def update_configuration(self, configuration):
+        # reset metaconfig_id because it's not yet implemented to pass the metaconfig to ili2db
+        configuration.metaconfig_id = None
+
+    def save_configuration(self, configuration):
+        # no configuration at the moment
+        pass
+
     def order_list(self):
         order_list = []
         for visual_index in range(0, self.file_table_view.verticalHeader().count()):

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -267,6 +267,7 @@ class WorkflowWizard(QWizard):
             return PageIds.ProjectCreation
 
         if self.current_id == PageIds.ImportDataConfiguration:
+            self._update_configurations(self.data_configuration_page)
             return PageIds.ImportDataExecution
 
         if self.current_id == PageIds.ImportDataExecution:

--- a/docs/background_info/usabilityhub/modelbaker_integration.md
+++ b/docs/background_info/usabilityhub/modelbaker_integration.md
@@ -62,7 +62,7 @@ qgis.modelbaker.metaConfigParamsOnly = True
 When this parameter is set the *Advanced Options* and *CRS* settings are disabled in the input mask.
 
 !!! Warning
-    Be aware that the UsabILIty Hub Repository (located at https://models.opengis.ch) is not found by ili2db what means that when using `qgis.modelbaker.metaConfigParamsOnly` toppingfiles referenced in metaconfig file with `ilidata:` should not be located there. Other repositories (like e.g. from the cantons) can be used without any restrictions. Still you can add https://models.opengis.ch as a directory/repository in the [Model Baker Settings](../../../user_guide/plugin_configuration/#custom-model-directories).
+    Be aware that the UsabILIty Hub Repository (located at https://models.opengis.ch) is not found by ili2db when it's not passed additionally to it with `--modelDir`. Currently we do that automatically. Means when you choose a metaconfig file to pass, `--modelDir https://models.opengis.ch` is automatically added to the command. Concerning custom directory/repository, you have to add it manually in the [Model Baker Settings](../../../user_guide/plugin_configuration/#custom-model-directories).
 
 ### Refrencing other INTERLIS models
 Using the ili2db settings, it is possible to reference other models from *metaconfiguration files*. If the setting contains the value `models=KbS_LV95_v1_4;KbS_Basis`, then this is also adjusted in the Model Baker input mask. Of course, a search for possible *metaconfiguration files* on UsabILIty Hub will be started again, according to the currently set models. See also for that [Multiple Models and their Toppings](#multiple-models-and-their-toppings).

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "1.4.0")
+MODELBAKER_LIBRARY=("modelbaker" "1.4.1")
 PACKAGING=("packaging" "21.3")
 
 PACKAGES=(


### PR DESCRIPTION
Because it leads to issues. It's not removed from the backend, since it's still a valid parameter to use there.

See issue for possible enhancement https://github.com/opengisch/QgisModelBaker/issues/786