### PR TITLE
Graphical user interface to pass `--exportModels` to ili2db on export or validation.

### DIFF
--- a/QgisModelBaker/gui/panel/export_models_panel.py
+++ b/QgisModelBaker/gui/panel/export_models_panel.py
@@ -1,0 +1,76 @@
+"""
+/***************************************************************************
+        begin                : 22.11.2021
+        git sha              : :%H$
+        copyright            : (C) 2021 by Dave Signer
+        email                : david at opengis ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from qgis.PyQt.QtWidgets import QWidget
+
+import QgisModelBaker.utils.gui_utils as gui_utils
+from QgisModelBaker.utils import gui_utils
+
+WIDGET_UI = gui_utils.get_ui_class("export_models_panel.ui")
+
+
+# could be renamed since it's not only model - it's dataset and basket as well
+class ExportModelsPanel(QWidget, WIDGET_UI):
+    def __init__(self, parent=None):
+        QWidget.__init__(self, parent)
+        self.setupUi(self)
+        self.parent = parent
+
+    def setup_dialog(self, validation=False):
+        self._generate_texts(validation)
+        self.export_models_checkbox.setChecked(False)
+        self.items_view.setVisible(False)
+        if self.parent:
+            self.items_view.setModel(self.parent.current_export_models_model)
+            self.items_view.clicked.connect(self.items_view.model().check)
+            self.items_view.space_pressed.connect(self.items_view.model().check)
+
+            self.export_models_checkbox.stateChanged.connect(self._active_state_changed)
+            self.export_models_checkbox.setChecked(
+                self.parent.current_export_models_active
+            )
+            self._active_state_changed(self.parent.current_export_models_active)
+
+    def _generate_texts(self, validation):
+        self.export_models_checkbox.setText(
+            self.tr(
+                "{verb} the data in a model other than the one where it is stored"
+            ).format(verb="Validate" if validation else "Export")
+        )
+        self.export_models_checkbox.setToolTip(
+            self.tr(
+                """
+            <html><head/><body>
+            <p>If your data is in the format of the cantonal model, but you want to {verb} it in the format of the national model.</p>
+            <p>The data that cannot be {pastverb} in the selected model is {pastverb} in the model it is stored.</p>
+            <p>Usually, this is one single model. However, it is also possible to pass multiple models, which makes sense if there are multiple base models in the schema you want to {verb}.</p>
+            <p>This is the value passed to <span style=" font-family:'monospace';">--exportModels</span></p>
+            </body></html>
+            """
+            ).format(
+                verb="validate" if validation else "export",
+                pastverb="validated" if validation else "exported",
+            )
+        )
+
+    def _active_state_changed(self, checked):
+        self.items_view.setVisible(checked)
+        if not checked:
+            # on uncheck disable all
+            self.items_view.model().check_all([])
+        self.parent.current_export_models_active = checked

--- a/QgisModelBaker/gui/panel/export_models_panel.py
+++ b/QgisModelBaker/gui/panel/export_models_panel.py
@@ -40,10 +40,10 @@ class ExportModelsPanel(QWidget, WIDGET_UI):
             self.items_view.clicked.connect(self.items_view.model().check)
             self.items_view.space_pressed.connect(self.items_view.model().check)
 
-            self.export_models_checkbox.stateChanged.connect(self._active_state_changed)
             self.export_models_checkbox.setChecked(
                 self.parent.current_export_models_active
             )
+            self.export_models_checkbox.stateChanged.connect(self._active_state_changed)
             self._active_state_changed(self.parent.current_export_models_active)
 
     def _generate_texts(self, validation):

--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -56,6 +56,7 @@ class SessionPanel(QWidget, WIDGET_UI):
         models,
         datasets,
         baskets,
+        export_models,
         db_action_type,
         parent=None,
     ):
@@ -68,6 +69,7 @@ class SessionPanel(QWidget, WIDGET_UI):
         self.models = models
         self.datasets = datasets
         self.baskets = baskets
+        self.export_models = export_models
 
         # set up the gui
         self.create_text = self.tr("Run")
@@ -109,27 +111,70 @@ class SessionPanel(QWidget, WIDGET_UI):
             if os.path.isfile(self.file):
                 self.configuration.ilifile = self.file
             self.configuration.ilimodels = ";".join(self.models)
-            self.info_label.setText(self.tr("Import {}").format(", ".join(self.models)))
+            self.info_label.setText(
+                self.tr(
+                    """
+                    <html><head/><body>
+                    <p>Import <b>{models}</b></p>
+                    </body></html>
+                    """
+                ).format(models=", ".join(self.models))
+            )
         elif self.db_action_type == DbActionType.IMPORT_DATA:
             self.configuration.xtffile = self.file
             self.configuration.ilimodels = ";".join(self.models)
             self.configuration.with_importtid = self._get_tid_handling()
-            self.info_label.setText(
-                self.tr("Import {} of {}").format(", ".join(self.models), self.file)
-            )
+            if self.datasets:
+
+                self.info_label.setText(
+                    self.tr(
+                        """
+                        <html><head/><body>
+                        <p>Update the data in dataset <b>{dataset}</b></p>
+                        <p>with the data from <i>{file}</i></p>
+                        </body></html>
+                        """
+                    ).format(dataset=self.datasets[0], file=self.file)
+                )
+            else:
+                self.info_label.setText(
+                    self.tr(
+                        """
+                        <html><head/><body>
+                        <p>Import the data from <i>{file}</i></p>
+                        </body></html>
+                        """
+                    ).format(file=self.file)
+                )
+
             self.configuration.dataset = self.datasets[0] if self.datasets else None
         elif self.db_action_type == DbActionType.EXPORT:
             self.configuration.xtffile = self.file
-            self.configuration.ilimodels = ";".join(self.models)
             self.configuration.with_exporttid = self._get_tid_handling()
+            self.configuration.iliexportmodels = ";".join(self.export_models)
             self.info_label.setText(
-                self.tr('Export of "{}" \nto {}').format(
-                    '", "'.join(self.models)
-                    or '", "'.join(self.datasets)
-                    or '", "'.join(self.baskets),
-                    self.file,
+                self.tr(
+                    """
+                    <html><head/><body>
+                    <p>Export the data of <b>{filtered_data}</b></p>
+                    {export_model_part}
+                    <p>to file <i>{file}</i></p>
+                    </body></html>
+                    """
+                ).format(
+                    filtered_data=", ".join(self.models)
+                    or ", ".join(self.datasets)
+                    or ", ".join(self.baskets),
+                    export_model_part=self.tr(
+                        "<p>in the format of <b>{export_models}</b></p>"
+                    ).format(export_models=", ".join(self.export_models))
+                    if self.export_models
+                    else "",
+                    file=self.file,
                 )
             )
+
+            self.configuration.ilimodels = ";".join(self.models)
             self.configuration.dataset = ";".join(self.datasets)
             self.configuration.baskets = self.baskets
 

--- a/QgisModelBaker/gui/workflow_wizard/execution_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/execution_page.py
@@ -97,12 +97,19 @@ class ExecutionPage(QWizardPage, PAGE_UI):
             )
             baskets = sessions[key]["baskets"] if "baskets" in sessions[key] else None
 
+            export_models = (
+                sessions[key]["export_models"]
+                if "export_models" in sessions[key]
+                else None
+            )
+
             skipped_session_widget = self._find_skipped_session_widget(
                 (
                     key,
                     models,
                     datasets,
                     baskets,
+                    export_models,
                     db_utils.get_schema_identificator_from_configuration(configuration),
                 )
             )
@@ -115,6 +122,7 @@ class ExecutionPage(QWizardPage, PAGE_UI):
                     models,
                     datasets,
                     baskets,
+                    export_models,
                     self.db_action_type,
                 )
                 session.on_done_or_skipped.connect(self._on_done_or_skipped_received)

--- a/QgisModelBaker/gui/workflow_wizard/export_data_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/export_data_configuration_page.py
@@ -22,6 +22,7 @@ from qgis.PyQt.QtGui import QValidator
 from qgis.PyQt.QtWidgets import QWizardPage
 
 import QgisModelBaker.utils.gui_utils as gui_utils
+from QgisModelBaker.gui.panel.export_models_panel import ExportModelsPanel
 from QgisModelBaker.gui.panel.filter_data_panel import FilterDataPanel
 from QgisModelBaker.libs.modelbaker.utils.qt_utils import (
     FileValidator,
@@ -44,6 +45,9 @@ class ExportDataConfigurationPage(QWizardPage, PAGE_UI):
 
         self.filter_data_panel = FilterDataPanel(self.workflow_wizard)
         self.filter_layout.addWidget(self.filter_data_panel)
+
+        self.export_models_panel = ExportModelsPanel(self.workflow_wizard)
+        self.export_models_layout.addWidget(self.export_models_panel)
 
         self.is_complete = False
 
@@ -84,6 +88,7 @@ class ExportDataConfigurationPage(QWizardPage, PAGE_UI):
 
     def setup_dialog(self, basket_handling):
         self.filter_data_panel.setup_dialog(basket_handling)
+        self.export_models_panel.setup_dialog()
 
     def _set_current_export_target(self, text):
         self.setComplete(

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -362,14 +362,11 @@ class WorkflowWizard(QWizard):
 
             if self.current_export_models_active:
                 export_models = self.current_export_models_model.checked_entries()
-                self.export_data_configuration.iliexportmodels = ";".join(export_models)
-                # or (needs to be checked): sessions[self.current_export_target]["export_models"] = export_models
-            else:
-                self.export_data_configuration.iliexportmodels = ""
 
             sessions[self.current_export_target]["models"] = models
             sessions[self.current_export_target]["datasets"] = datasets
             sessions[self.current_export_target]["baskets"] = baskets
+            sessions[self.current_export_target]["export_models"] = export_models
 
             self.export_data_execution_page.setup_sessions(
                 self.export_data_configuration, sessions

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -126,6 +126,10 @@ class WorkflowWizard(QWizard):
         self.current_export_target = ""
         self.current_filter_mode = SchemaDataFilterMode.NO_FILTER
 
+        # the current_export_models_model keeps every single model found in the current database and keeps the selected models
+        self.current_export_models_model = SchemaModelsModel()
+        self.current_export_models_active = False
+
         # pages setup
         self.intro_page = IntroPage(self, self._current_page_title(PageIds.Intro))
         self.source_selection_page = ImportSourceSelectionPage(
@@ -345,6 +349,7 @@ class WorkflowWizard(QWizard):
             models = []
             datasets = []
             baskets = []
+            export_models = []
             if self.current_filter_mode == SchemaDataFilterMode.MODEL:
                 models = self.current_models_model.checked_entries()
             elif self.current_filter_mode == SchemaDataFilterMode.DATASET:
@@ -354,6 +359,13 @@ class WorkflowWizard(QWizard):
             else:
                 # no filter - export all models
                 models = self.current_models_model.stringList()
+
+            if self.current_export_models_active:
+                export_models = self.current_export_models_model.checked_entries()
+                self.export_data_configuration.iliexportmodels = ";".join(export_models)
+                # or (needs to be checked): sessions[self.current_export_target]["export_models"] = export_models
+            else:
+                self.export_data_configuration.iliexportmodels = ""
 
             sessions[self.current_export_target]["models"] = models
             sessions[self.current_export_target]["datasets"] = datasets
@@ -413,6 +425,7 @@ class WorkflowWizard(QWizard):
         self.current_models_model.refresh_model([db_connector])
         self.current_datasets_model.refresh_model(db_connector)
         self.current_baskets_model.refresh_model(db_connector)
+        self.current_export_models_model.refresh_model([db_connector])
         return
 
     def refresh_import_models(self, silent=False):

--- a/QgisModelBaker/ui/export_models_panel.ui
+++ b/QgisModelBaker/ui/export_models_panel.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>605</width>
-    <height>123</height>
+    <width>603</width>
+    <height>176</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Form</string>
@@ -26,25 +32,25 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="1" column="0" colspan="2">
-    <widget class="SemiTristateCheckbox" name="select_all_checkbox" native="true">
-     <property name="text" stdset="0">
-      <string>Select all models</string>
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="export_models_checkbox">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If your data is in the format of the cantonal model, but you want to export it in the format of the national model.&lt;/p&gt;&lt;p&gt;Usually, this is one single model. However, it is also possible to pass multiple models, which makes sense if there are multiple base models in the schema you want to export.&lt;/p&gt;&lt;p&gt;This is the value passed to &lt;span style=&quot; font-family:'monospace';&quot;&gt;--exportModels&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Export the data in a model other than the one where it is stored</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="1" column="0">
     <widget class="SpaceCheckListView" name="items_view" native="true">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
     </widget>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QComboBox" name="filter_combobox"/>
    </item>
   </layout>
  </widget>
@@ -54,11 +60,6 @@
    <extends></extends>
    <header>QgisModelBaker.utils.gui_utils</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>SemiTristateCheckbox</class>
-   <extends>QWidget</extends>
-   <header>QgisModelBaker.utils.gui_utils</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/QgisModelBaker/ui/validator.ui
+++ b/QgisModelBaker/ui/validator.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>834</width>
+    <height>804</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,28 +15,7 @@
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QGridLayout" name="gridLayout">
-    <item row="5" column="0" colspan="2">
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
-       <widget class="QLineEdit" name="validator_config_file_line_edit">
-        <property name="toolTip">
-         <string>ili2db option --validConfig</string>
-        </property>
-        <property name="placeholderText">
-         <string>Validator config file (--validConfig)</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QToolButton" name="validator_config_file_tool_button">
-        <property name="text">
-         <string>...</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </item>
-    <item row="7" column="0" colspan="2">
+    <item row="9" column="0" colspan="2">
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
        <widget class="QLabel" name="error_count_label">
@@ -115,7 +94,21 @@
       </item>
      </layout>
     </item>
-    <item row="4" column="0" colspan="2">
+    <item row="5" column="0" colspan="2">
+     <layout class="QVBoxLayout" name="export_models_layout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+     </layout>
+    </item>
+    <item row="1" column="0" rowspan="4" colspan="2">
+     <layout class="QVBoxLayout" name="filter_layout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+     </layout>
+    </item>
+    <item row="6" column="0" colspan="2">
      <widget class="QCheckBox" name="skip_geometry_errors_check_box">
       <property name="toolTip">
        <string>Ignores geometry errors (--skipGeometryErrors) and AREA topology validation (--disableAreaValidation)</string>
@@ -125,7 +118,7 @@
       </property>
      </widget>
     </item>
-    <item row="6" column="0" colspan="2">
+    <item row="8" column="0" colspan="2">
      <widget class="QWidget" name="validation_layout" native="true">
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <property name="leftMargin">
@@ -164,7 +157,28 @@
       </layout>
      </widget>
     </item>
-    <item row="2" column="0" colspan="2">
+    <item row="7" column="0" colspan="2">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QLineEdit" name="validator_config_file_line_edit">
+        <property name="toolTip">
+         <string>ili2db option --validConfig</string>
+        </property>
+        <property name="placeholderText">
+         <string>Validator config file (--validConfig)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="validator_config_file_tool_button">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="0" column="0" colspan="2">
      <widget class="QLabel" name="info_label">
       <property name="text">
        <string/>
@@ -173,13 +187,6 @@
        <bool>true</bool>
       </property>
      </widget>
-    </item>
-    <item row="3" column="0" colspan="2">
-     <layout class="QVBoxLayout" name="filter_layout">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-     </layout>
     </item>
    </layout>
   </widget>

--- a/QgisModelBaker/ui/workflow_wizard/export_data_configuration.ui
+++ b/QgisModelBaker/ui/workflow_wizard/export_data_configuration.ui
@@ -54,16 +54,6 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0" colspan="4">
-       <layout class="QVBoxLayout" name="filter_layout">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-       </layout>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QLineEdit" name="xtf_file_line_edit"/>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="xtf_file_label">
         <property name="text">
@@ -71,7 +61,10 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="3">
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="xtf_file_line_edit"/>
+      </item>
+      <item row="0" column="2">
        <widget class="QToolButton" name="xtf_file_browse_button">
         <property name="toolTip">
          <string>Browse XTF files</string>
@@ -81,7 +74,21 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="1" column="0" colspan="3">
+       <layout class="QVBoxLayout" name="filter_layout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+       </layout>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <layout class="QVBoxLayout" name="export_models_layout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+       </layout>
+      </item>
+      <item row="3" column="0">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -864,8 +864,27 @@ class SchemaModelsModel(CheckEntriesModel):
     Multiple db_connectors can be passed to scan multiple sources.
     """
 
+    class Roles(Enum):
+        PARENT_MODELS = Qt.UserRole + 1
+
+        def __int__(self):
+            return self.value
+
     def __init__(self):
         super().__init__()
+        self._parent_models = {}
+
+    def data(self, index, role):
+        if role == int(SchemaModelsModel.Roles.PARENT_MODELS):
+            return self._parent_models[self.data(index, Qt.DisplayRole)]
+        else:
+            return CheckEntriesModel.data(self, index, role)
+
+    def setData(self, index, role, data):
+        if role == int(SchemaModelsModel.Roles.PARENT_MODELS):
+            self._parent_models[self.data(index, Qt.DisplayRole)] = data
+        else:
+            CheckEntriesModel.setData(self, index, role, data)
 
     def refresh_model(self, db_connectors=[]):
         modelnames = []
@@ -887,6 +906,7 @@ class SchemaModelsModel(CheckEntriesModel):
                             and name not in modelnames
                         ):
                             modelnames.append(name)
+                            self._parent_models[name] = db_model["parents"]
 
         self.setStringList(modelnames)
 

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -875,6 +875,16 @@ class SchemaModelsModel(CheckEntriesModel):
         self._parent_models = {}
 
     def data(self, index, role):
+        if role == Qt.ToolTipRole:
+            model_name = self.data(index, Qt.DisplayRole)
+            if self._parent_models[model_name]:
+                return self.tr(
+                    """
+                <html><head/><body>
+                <p><b>{}</b> is an extension of <b>{}</b></p>
+                </body></html>
+                """
+                ).format(model_name, ", ".join(self._parent_models[model_name]))
         if role == int(SchemaModelsModel.Roles.PARENT_MODELS):
             return self._parent_models[self.data(index, Qt.DisplayRole)]
         else:

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -880,10 +880,10 @@ class SchemaModelsModel(CheckEntriesModel):
             if self._parent_models[model_name]:
                 return self.tr(
                     """
-                <html><head/><body>
-                <p><b>{}</b> is an extension of <b>{}</b></p>
-                </body></html>
-                """
+                    <html><head/><body>
+                    <p><b>{}</b> is an extension of <b>{}</b></p>
+                    </body></html>
+                    """
                 ).format(model_name, ", ".join(self._parent_models[model_name]))
         if role == int(SchemaModelsModel.Roles.PARENT_MODELS):
             return self._parent_models[self.data(index, Qt.DisplayRole)]

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "1.4.2")
+MODELBAKER_LIBRARY=("modelbaker" "1.4.3")
 PACKAGING=("packaging" "21.3")
 
 PACKAGES=(


### PR DESCRIPTION
Resolves #665

If your data is in the format of the cantonal model, but you want to export/validate it in the format of the national model, you have to pass `--exportModels`, otherwise (or if the data cannot be exported/validated in the selected model because it's not an extension of it) the data is exported/validated in the model it is stored.

Usually, this is one single model. However, it is also possible to pass multiple models, which makes sense if there are multiple base models in the schema you want to export/validate.

### On export
Looks like this:
![image](https://user-images.githubusercontent.com/28384354/230119462-a2c26f6e-43e6-4424-88fc-143b9240d534.png)

as well there is a tooltip listing all the relevant parent models (the ones that are listed as well, means are exportable):
![image](https://user-images.githubusercontent.com/28384354/230125723-deae8535-5a9e-4b72-b091-2105c12e41b6.png)

and there is the info on the session:
![image](https://user-images.githubusercontent.com/28384354/230132923-0e22368f-b0bc-4440-9c71-36d4599fddc7.png)

### On validation
When **validating** it without without `--exportModels` all the constraints must be fulfilled. 
![image](https://user-images.githubusercontent.com/28384354/230120196-d809dba4-635f-46e0-be2c-c0539a858e6a.png)

On validating it only for a parent model, only the constraints of the parent model must be fulfilled. Here with the cantonal model:
![image](https://user-images.githubusercontent.com/28384354/230120381-34553d31-9fce-4d16-bc25-3c38135502a8.png)

And with the national model, all constraints are fulfilled:
![image](https://user-images.githubusercontent.com/28384354/230120746-5d859e86-84eb-41bd-9042-5f3268480ae8.png)
