### PR TITLE
Fix broken export models gui on validator.

### DIFF
--- a/QgisModelBaker/gui/panel/export_models_panel.py
+++ b/QgisModelBaker/gui/panel/export_models_panel.py
@@ -31,7 +31,18 @@ class ExportModelsPanel(QWidget, WIDGET_UI):
         self.setupUi(self)
         self.parent = parent
 
+    def setup_dialog(self, validation=False):
+        self._generate_texts(validation)
+        self.export_models_checkbox.setChecked(False)
+        self.items_view.setVisible(False)
+
         if self.parent:
+            try:
+                self.items_view.clicked.disconnect()
+                self.items_view.space_pressed.disconnect()
+            except Exception:
+                pass
+
             self.items_view.setModel(self.parent.current_export_models_model)
             self.items_view.clicked.connect(self.items_view.model().check)
             self.items_view.space_pressed.connect(self.items_view.model().check)
@@ -41,11 +52,6 @@ class ExportModelsPanel(QWidget, WIDGET_UI):
             )
             self.export_models_checkbox.stateChanged.connect(self._active_state_changed)
             self._active_state_changed(self.parent.current_export_models_active)
-
-    def setup_dialog(self, validation=False):
-        self._generate_texts(validation)
-        self.export_models_checkbox.setChecked(False)
-        self.items_view.setVisible(False)
 
     def _generate_texts(self, validation):
         self.export_models_checkbox.setText(


### PR DESCRIPTION
This here https://github.com/opengisch/QgisModelBaker/pull/800/commits/21604c6159ccf1d572d233b7a0cf74562c09fb0e introduced the error that the model is not loaded according to the layer in the validator.

It needs to set the model new and it needs to disconnect and reconnect the sloths. Now it does re-set the model on setup dialog to be stable on validation gui and on export data page.

