### PR TITLE
Sort models / toppings in autocompleter box 

### DIFF
--- a/QgisModelBaker/gui/topping_wizard/referencedata_page.py
+++ b/QgisModelBaker/gui/topping_wizard/referencedata_page.py
@@ -180,6 +180,7 @@ class ReferencedataPage(QWizardPage, PAGE_UI):
                         QCompleter.PopupCompletion
                     )
                     self.input_line_edit.completer().complete()
+            self.input_line_edit.completer().popup().scrollToTop()
 
     def _valid_source(self):
         match_contains = (

--- a/QgisModelBaker/gui/topping_wizard/referencedata_page.py
+++ b/QgisModelBaker/gui/topping_wizard/referencedata_page.py
@@ -81,10 +81,11 @@ class ReferencedataPage(QWizardPage, PAGE_UI):
             self.tr("[Search referenced data files from Repositories or Local System]")
         )
         completer = QCompleter(
-            self.ilireferencedatacache.model,
+            self.ilireferencedatacache.sorted_model,
             self.input_line_edit,
         )
         completer.setCaseSensitivity(Qt.CaseInsensitive)
+        completer.setModelSorting(QCompleter.ModelSorting.CaseInsensitivelySortedModel)
         completer.setFilterMode(Qt.MatchContains)
         completer.popup().setItemDelegate(self.ilireferencedata_delegate)
         self.input_line_edit.setCompleter(completer)

--- a/QgisModelBaker/gui/workflow_wizard/import_data_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_data_configuration_page.py
@@ -135,10 +135,11 @@ class ImportDataConfigurationPage(QWizardPage, PAGE_UI):
         )
         self.ilireferencedata_line_edit.setEnabled(False)
         completer = QCompleter(
-            self.workflow_wizard.ilireferencedatacache.model,
+            self.workflow_wizard.ilireferencedatacache.sorted_model,
             self.ilireferencedata_line_edit,
         )
         completer.setCaseSensitivity(Qt.CaseInsensitive)
+        completer.setModelSorting(QCompleter.ModelSorting.CaseInsensitivelySortedModel)
         completer.setFilterMode(Qt.MatchContains)
         completer.popup().setItemDelegate(self.ilireferencedata_delegate)
         self.ilireferencedata_line_edit.setCompleter(completer)

--- a/QgisModelBaker/gui/workflow_wizard/import_data_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_data_configuration_page.py
@@ -134,15 +134,6 @@ class ImportDataConfigurationPage(QWizardPage, PAGE_UI):
             self.tr("[Search referenced data files from UsabILIty Hub]")
         )
         self.ilireferencedata_line_edit.setEnabled(False)
-        completer = QCompleter(
-            self.workflow_wizard.ilireferencedatacache.sorted_model,
-            self.ilireferencedata_line_edit,
-        )
-        completer.setCaseSensitivity(Qt.CaseInsensitive)
-        completer.setModelSorting(QCompleter.ModelSorting.CaseInsensitivelySortedModel)
-        completer.setFilterMode(Qt.MatchContains)
-        completer.popup().setItemDelegate(self.ilireferencedata_delegate)
-        self.ilireferencedata_line_edit.setCompleter(completer)
         self.ilireferencedata_line_edit.textChanged.emit(
             self.ilireferencedata_line_edit.text()
         )
@@ -333,9 +324,15 @@ class ImportDataConfigurationPage(QWizardPage, PAGE_UI):
         return bool(self.file_table_view.selectedIndexes())
 
     def _update_referencedata_completer(self):
-        self.ilireferencedata_line_edit.completer().setModel(
-            self.workflow_wizard.ilireferencedatacache.model
+        completer = QCompleter(
+            self.workflow_wizard.ilireferencedatacache.sorted_model,
+            self.ilireferencedata_line_edit,
         )
+        completer.setCaseSensitivity(Qt.CaseInsensitive)
+        completer.setModelSorting(QCompleter.ModelSorting.CaseInsensitivelySortedModel)
+        completer.setFilterMode(Qt.MatchContains)
+        completer.popup().setItemDelegate(self.ilireferencedata_delegate)
+        self.ilireferencedata_line_edit.setCompleter(completer)
         self.ilireferencedata_line_edit.setEnabled(
             bool(self.workflow_wizard.ilireferencedatacache.model.rowCount())
         )

--- a/QgisModelBaker/gui/workflow_wizard/import_data_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_data_configuration_page.py
@@ -311,6 +311,7 @@ class ImportDataConfigurationPage(QWizardPage, PAGE_UI):
                         QCompleter.PopupCompletion
                     )
                     self.ilireferencedata_line_edit.completer().complete()
+            self.ilireferencedata_line_edit.completer().popup().scrollToTop()
 
     def _valid_referencedata(self):
         match_contains = (

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -281,6 +281,8 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                 )
                 self.ili_metaconfig_line_edit.completer().complete()
 
+            self.ili_metaconfig_line_edit.completer().popup().scrollToTop()
+
     def _update_metaconfig_completer(self, rows):
         self.ili_metaconfig_line_edit.completer().setModel(
             self.ilimetaconfigcache.sorted_model

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -80,9 +80,10 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         )
         self.ili_metaconfig_line_edit.setEnabled(False)
         completer = QCompleter(
-            self.ilimetaconfigcache.model, self.ili_metaconfig_line_edit
+            self.ilimetaconfigcache.sorted_model, self.ili_metaconfig_line_edit
         )
         completer.setCaseSensitivity(Qt.CaseInsensitive)
+        completer.setModelSorting(QCompleter.ModelSorting.CaseInsensitivelySortedModel)
         completer.setFilterMode(Qt.MatchContains)
         completer.popup().setItemDelegate(self.metaconfig_delegate)
         self.ili_metaconfig_line_edit.setCompleter(completer)
@@ -282,7 +283,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
 
     def _update_metaconfig_completer(self, rows):
         self.ili_metaconfig_line_edit.completer().setModel(
-            self.ilimetaconfigcache.model
+            self.ilimetaconfigcache.sorted_model
         )
         self.ili_metaconfig_line_edit.setEnabled(bool(rows))
 

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -79,14 +79,6 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             self.tr("[Search metaconfig / topping from UsabILIty Hub]")
         )
         self.ili_metaconfig_line_edit.setEnabled(False)
-        completer = QCompleter(
-            self.ilimetaconfigcache.sorted_model, self.ili_metaconfig_line_edit
-        )
-        completer.setCaseSensitivity(Qt.CaseInsensitive)
-        completer.setModelSorting(QCompleter.ModelSorting.CaseInsensitivelySortedModel)
-        completer.setFilterMode(Qt.MatchContains)
-        completer.popup().setItemDelegate(self.metaconfig_delegate)
-        self.ili_metaconfig_line_edit.setCompleter(completer)
         self.ili_metaconfig_line_edit.textChanged.emit(
             self.ili_metaconfig_line_edit.text()
         )
@@ -284,9 +276,14 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             self.ili_metaconfig_line_edit.completer().popup().scrollToTop()
 
     def _update_metaconfig_completer(self, rows):
-        self.ili_metaconfig_line_edit.completer().setModel(
-            self.ilimetaconfigcache.sorted_model
+        completer = QCompleter(
+            self.ilimetaconfigcache.sorted_model, self.ili_metaconfig_line_edit
         )
+        completer.setCaseSensitivity(Qt.CaseInsensitive)
+        completer.setModelSorting(QCompleter.ModelSorting.CaseInsensitivelySortedModel)
+        completer.setFilterMode(Qt.MatchContains)
+        completer.popup().setItemDelegate(self.metaconfig_delegate)
+        self.ili_metaconfig_line_edit.setCompleter(completer)
         self.ili_metaconfig_line_edit.setEnabled(bool(rows))
 
     def _on_metaconfig_completer_activated(self, text=None):

--- a/QgisModelBaker/gui/workflow_wizard/import_source_selection_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_source_selection_page.py
@@ -143,6 +143,7 @@ class ImportSourceSelectionPage(QWizardPage, PAGE_UI):
                         QCompleter.PopupCompletion
                     )
                     self.input_line_edit.completer().complete()
+            self.input_line_edit.completer().popup().scrollToTop()
 
     def _valid_source(self):
         match_contains = (

--- a/QgisModelBaker/gui/workflow_wizard/import_source_selection_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_source_selection_page.py
@@ -166,8 +166,9 @@ class ImportSourceSelectionPage(QWizardPage, PAGE_UI):
         return bool(self.source_list_view.selectedIndexes())
 
     def update_models_completer(self):
-        completer = QCompleter(self.ilicache.model, self.input_line_edit)
+        completer = QCompleter(self.ilicache.sorted_model, self.input_line_edit)
         completer.setCaseSensitivity(Qt.CaseInsensitive)
+        completer.setModelSorting(QCompleter.ModelSorting.CaseInsensitivelySortedModel)
         completer.setFilterMode(Qt.MatchContains)
         completer.popup().setItemDelegate(self.model_delegate)
         self.input_line_edit.setCompleter(completer)

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -505,12 +505,15 @@ class WorkflowWizard(QWizard):
             for downloaded_file_id in topping_file_cache.downloaded_files:
                 if downloaded_file_id in missing_file_ids:
                     missing_file_ids.remove(downloaded_file_id)
-            self.log_panel.print_info(
-                self.tr(
-                    "- - Some topping files where not successfully downloaded: {}"
-                ).format(" ".join(missing_file_ids)),
-                LogColor.COLOR_TOPPING,
-            )
+            try:
+                self.log_panel.print_info(
+                    self.tr(
+                        "- - Some topping files where not successfully downloaded: {}"
+                    ).format(" ".join(missing_file_ids)),
+                    LogColor.COLOR_TOPPING,
+                )
+            except Exception:
+                pass
 
         return topping_file_cache.model
 


### PR DESCRIPTION
Before it has been sorted like it has been added to the model. Means mostly it had kind of unstable sorting according the repository. This repository sorting is gone, but I think it's fine, mostly you look after a model name you know.

[Screencast from 05.05.2023 08:36:48.webm](https://user-images.githubusercontent.com/28384354/236391540-b8a0cff4-916f-46fe-8f7d-baa2e9587f98.webm)

First model on a punch is now AGNES, what is kind of nice, since it's a female name and the title of quite a nice novel by Peter Stamm.

This requires https://github.com/opengisch/QgisModelBakerLibrary/pull/58 and resolves https://github.com/opengisch/QgisModelBaker/issues/471