### PR TITLE
print short description when a metaconfig has been selected

### DIFF
--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -305,9 +305,14 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                 return
             self.current_metaconfig_id = metaconfig_id
             self.metaconfig_file_info_label.setText(
-                self.tr("Current Metaconfig File: {} ({})").format(
+                self.tr(
+                    "<html><head/><body><p><b>Current Metaconfig File: {} ({})</b><br><i>{}</i></p></body></html>"
+                ).format(
                     self.ilimetaconfigcache.model.data(model_index, Qt.DisplayRole),
                     metaconfig_id,
+                    self.ilimetaconfigcache.model.data(
+                        model_index, int(IliDataItemModel.Roles.SHORT_DESCRIPTION) or ""
+                    ),
                 )
             )
             self.metaconfig_file_info_label.setStyleSheet("color: #341d5c")

--- a/QgisModelBaker/ui/workflow_wizard/import_schema_configuration.ui
+++ b/QgisModelBaker/ui/workflow_wizard/import_schema_configuration.ui
@@ -100,6 +100,9 @@
         <property name="text">
          <string/>
         </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item row="6" column="1">

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "1.4.3")
+MODELBAKER_LIBRARY=("modelbaker" "1.4.4")
 PACKAGING=("packaging" "21.3")
 
 PACKAGES=(


### PR DESCRIPTION
Together with https://github.com/opengisch/QgisModelBakerLibrary/pull/59 it resolves #756

1. The UsabILIty Hub Exporter generates the `title` according to the project name and additionally the `shortDescription` in the way it created the `title` before.
2. The `shortDescription` is now provided as Tooltip
3. The `shortDescription` is added to the GUI when the metaconfig is selected.
![image](https://user-images.githubusercontent.com/28384354/236411251-0c766fcb-99d2-4051-9bb6-bfac34668a0d.png)

