### PR TITLE
Set current layer only if validate dock is visible

### DIFF
--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -192,6 +192,9 @@ class ValidateDock(QDockWidget, DIALOG_UI):
         self.setDisabled(True)
 
     def set_current_layer(self, layer):
+        if self.isHidden():
+            return
+
         if not layer or not layer.dataProvider() or not layer.dataProvider().isValid():
             self.setDisabled(True)
             return


### PR DESCRIPTION
I think the current layer should be set only if the dock widget is visible.

@signedav this change would mitigate the symptoms of an error that I saw. Maybe do you understand the root cause?

```
An error has occurred while executing Python code: 

sqlite3.OperationalError: near "take": syntax error 
Traceback (most recent call last):
  File "C:\Users/lunic/AppData/Roaming/QGIS/QGIS3\profiles\lucie/python/plugins\QgisModelBaker\gui\validate.py", line 229, in set_current_layer
    self.current_configuration.with_exporttid = self._get_tid_handling()
  File "C:\Users/lunic/AppData/Roaming/QGIS/QGIS3\profiles\lucie/python/plugins\QgisModelBaker\gui\validate.py", line 283, in _get_tid_handling
    db_connector = db_utils.get_db_connector(self.current_configuration)
  File "C:\Users/lunic/AppData/Roaming/QGIS/QGIS3\profiles\lucie/python/plugins\QgisModelBaker\libs\modelbaker\utils\db_utils.py", line 160, in get_db_connector
    return db_factory.get_db_connector(uri_string, schema)
  File "C:\Users/lunic/AppData/Roaming/QGIS/QGIS3\profiles\lucie/python/plugins\QgisModelBaker\libs\modelbaker\db_factory\gpkg_factory.py", line 29, in get_db_connector
    return GPKGConnector(uri, None)
  File "C:\Users/lunic/AppData/Roaming/QGIS/QGIS3\profiles\lucie/python/plugins\QgisModelBaker\libs\modelbaker\dbconnector\gpkg_connector.py", line 52, in __init__
    self._tables_info = self._get_tables_info()
  File "C:\Users/lunic/AppData/Roaming/QGIS/QGIS3\profiles\lucie/python/plugins\QgisModelBaker\libs\modelbaker\dbconnector\gpkg_connector.py", line 201, in _get_tables_info
    cursor.execute(
sqlite3.OperationalError: near "take": syntax error


Python version: 3.9.5 (tags/v3.9.5:0a7dcbd, May  3 2021, 17:27:52) [MSC v.1928 64 bit (AMD64)] 
QGIS version: 3.30.1-'s-Hertogenbosch 's-Hertogenbosch, 9035a01e 

Python Path:
C:/OSGeo4W/apps/qgis/./python
C:/Users/lunic/AppData/Roaming/QGIS/QGIS3\profiles\lucie/python
C:/Users/lunic/AppData/Roaming/QGIS/QGIS3\profiles\lucie/python/plugins
C:/OSGeo4W/apps/qgis/./python/plugins
C:\OSGeo4W\bin\python39.zip
C:\OSGeo4W\apps\Python39\DLLs
C:\OSGeo4W\apps\Python39\lib
C:\OSGeo4W\bin
C:\Users\lunic\AppData\Roaming\Python\Python39\site-packages
C:\OSGeo4W\apps\Python39
C:\OSGeo4W\apps\Python39\lib\site-packages
C:/Users/lunic/AppData/Roaming/QGIS/QGIS3\profiles\lucie/python
C:\Users\lunic\AppData\Roaming\QGIS\QGIS3\profiles\lucie\python\plugins\HCMGIS/forms
C:\Users\lunic\AppData\Roaming\QGIS\QGIS3\profiles\lucie\python\plugins\vector_tiles_reader\ext-libs
C:/Users/lunic/QField/cloud/demo_barcelona
```