### PR TITLE
Add a visible error dialog in case Java is not installed. Fix #785

### DIFF
--- a/QgisModelBaker/gui/export.py
+++ b/QgisModelBaker/gui/export.py
@@ -470,6 +470,12 @@ class ExportDialog(QDialog, DIALOG_UI):
                 self.txtStdout.setText(e.error_string)
                 self.enable()
                 self.progress_bar.hide()
+
+                QApplication.restoreOverrideCursor()
+                QMessageBox.critical(
+                    self, self.tr("Java not found error"), e.error_string
+                )
+
                 return
 
             self.buttonBox.clear()

--- a/QgisModelBaker/gui/generate_project.py
+++ b/QgisModelBaker/gui/generate_project.py
@@ -393,6 +393,12 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
                     self.txtStdout.setText(e.error_string)
                     self.enable()
                     self.progress_bar.hide()
+
+                    QApplication.restoreOverrideCursor()
+                    QMessageBox.critical(
+                        self, self.tr("Java not found error"), e.error_string
+                    )
+
                     return
 
             try:
@@ -682,6 +688,14 @@ class GenerateProjectDialog(QDialog, DIALOG_UI):
                                 self.txtStdout.setText(e.error_string)
                                 self.enable()
                                 self.progress_bar.hide()
+
+                                QApplication.restoreOverrideCursor()
+                                QMessageBox.critical(
+                                    self,
+                                    self.tr("Java not found error"),
+                                    e.error_string,
+                                )
+
                                 return
 
             self.buttonBox.clear()

--- a/QgisModelBaker/gui/import_data.py
+++ b/QgisModelBaker/gui/import_data.py
@@ -30,6 +30,7 @@ from qgis.PyQt.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QGridLayout,
+    QMessageBox,
     QSizePolicy,
 )
 
@@ -293,6 +294,12 @@ class ImportDataDialog(QDialog, DIALOG_UI):
                 self.txtStdout.setText(e.error_string)
                 self.enable()
                 self.progress_bar.hide()
+
+                QApplication.restoreOverrideCursor()
+                QMessageBox.critical(
+                    self, self.tr("Java not found error"), e.error_string
+                )
+
                 return
 
             self.buttonBox.clear()

--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -20,7 +20,7 @@
 import os
 
 from qgis.PyQt.QtCore import Qt, pyqtSignal
-from qgis.PyQt.QtWidgets import QAction, QWidget
+from qgis.PyQt.QtWidgets import QAction, QMessageBox, QWidget
 
 import QgisModelBaker.libs.modelbaker.utils.db_utils as db_utils
 import QgisModelBaker.utils.gui_utils as gui_utils
@@ -344,6 +344,12 @@ class SessionPanel(QWidget, WIDGET_UI):
                 else:
                     self.set_button_to_create()
                 self.is_running = False
+
+                QApplication.restoreOverrideCursor()
+                QMessageBox.critical(
+                    self, self.tr("Java not found error"), e.error_string
+                )
+
                 return False
 
             self.progress_bar.setValue(90)

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -29,7 +29,14 @@ from qgis.core import (
 )
 from qgis.gui import QgsGui
 from qgis.PyQt.QtCore import QStandardPaths, Qt, QTimer
-from qgis.PyQt.QtWidgets import QAction, QDockWidget, QFileDialog, QHeaderView, QMenu
+from qgis.PyQt.QtWidgets import (
+    QAction,
+    QDockWidget,
+    QFileDialog,
+    QHeaderView,
+    QMenu,
+    QMessageBox,
+)
 
 import QgisModelBaker.libs.modelbaker.utils.db_utils as db_utils
 from QgisModelBaker.gui.panel.export_models_panel import ExportModelsPanel
@@ -360,11 +367,17 @@ class ValidateDock(QDockWidget, DIALOG_UI):
                     validator.run(edited_command) == ilivalidator.Validator.SUCCESS
                 )
                 # debug info: print( validator.command(True) )
-            except JavaNotFoundError:
+            except JavaNotFoundError as e:
                 self.progress_bar.setValue(0)
                 self.progress_bar.setFormat(self.tr("Ili2db validation problems"))
                 self.progress_bar.setTextVisible(True)
                 self._disable_controls(False)
+
+                QApplication.restoreOverrideCursor()
+                QMessageBox.critical(
+                    self, self.tr("Java not found error"), e.error_string
+                )
+
                 return
 
         self.progress_bar.setValue(50)


### PR DESCRIPTION
![image](https://github.com/opengisch/QgisModelBaker/assets/9881900/262b8850-ffe0-4202-9d6b-f877b0268340)
