### PR TITLE
Validation of Schemas based on ili2db 3.x.x

### DIFF
--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -230,6 +230,10 @@ class ValidateDock(QDockWidget, DIALOG_UI):
                 QStandardPaths.writableLocation(QStandardPaths.TempLocation),
                 output_file_name,
             )
+            self.current_configuration.xtffile = os.path.join(
+                QStandardPaths.writableLocation(QStandardPaths.TempLocation),
+                f"dataexport_{output_file_name}",
+            )
             self.current_configuration.tool = mode
             if mode == DbIliMode.gpkg:
                 self.info_label.setText(

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -367,10 +367,10 @@ class ValidateDock(QDockWidget, DIALOG_UI):
         validation_result_state = False
         with OverrideCursor(Qt.WaitCursor):
             try:
+                self._validator_stdout(f"Run: {validator.command(True)}")
                 validation_result_state = (
                     validator.run(edited_command) == ilivalidator.Validator.SUCCESS
                 )
-                # debug info: print( validator.command(True) )
             except JavaNotFoundError as e:
                 self.progress_bar.setValue(0)
                 self.progress_bar.setFormat(self.tr("Ili2db validation problems"))


### PR DESCRIPTION
Still there are schemas based on 3.x.x we want to export and as well *validate*.

Requires https://github.com/opengisch/QgisModelBakerLibrary/pull/65