### PR TITLE
Don't handle xml files 2 times

### DIFF
--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -530,11 +530,6 @@ class DropFileFilter(QObject):
                 if pathlib.Path(url.toLocalFile()).suffix[1:]
                 in FileDropListView.ValidExtenstions
             ]
-            additional_xml_files = [
-                url.toLocalFile()
-                for url in event.mimeData().urls()
-                if pathlib.Path(url.toLocalFile()).suffix[1:] in ["xml", "XML"]
-            ]
             additional_ini_files = [
                 url.toLocalFile()
                 for url in event.mimeData().urls()
@@ -542,11 +537,9 @@ class DropFileFilter(QObject):
                 in FileDropListView.ValidIniExtensions
             ]
             if dropped_files:
-                if self._is_handling_requested(
-                    dropped_files + additional_xml_files + additional_ini_files
-                ):
+                if self._is_handling_requested(dropped_files + additional_ini_files):
                     if self.parent.handle_dropped_files(
-                        dropped_files + additional_xml_files, additional_ini_files
+                        dropped_files, additional_ini_files
                     ):
                         return True
         return False

--- a/QgisModelBaker/qgismodelbaker.py
+++ b/QgisModelBaker/qgismodelbaker.py
@@ -524,22 +524,18 @@ class DropFileFilter(QObject):
         When files are dropped, then ask to use it in the model baker.
         """
         if event.type() == QEvent.Drop:
-            dropped_files = [
-                url.toLocalFile()
-                for url in event.mimeData().urls()
-                if pathlib.Path(url.toLocalFile()).suffix[1:]
-                in FileDropListView.ValidExtenstions
-            ]
-            additional_ini_files = [
-                url.toLocalFile()
-                for url in event.mimeData().urls()
-                if pathlib.Path(url.toLocalFile()).suffix[1:]
-                in FileDropListView.ValidIniExtensions
-            ]
+            (
+                dropped_files,
+                dropped_xml_files,
+                dropped_ini_files,
+            ) = FileDropListView.extractDroppedFiles(event.mimeData().urls())
+
+            # Outside wizard, accept drops only for "real" interlis files, as xml and ini are too generic to assume must be handled by MB
             if dropped_files:
-                if self._is_handling_requested(dropped_files + additional_ini_files):
+                dropped_files.extend(dropped_xml_files)
+                if self._is_handling_requested(dropped_files + dropped_ini_files):
                     if self.parent.handle_dropped_files(
-                        dropped_files, additional_ini_files
+                        dropped_files, dropped_ini_files
                     ):
                         return True
         return False

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -244,7 +244,8 @@ class FileDropListView(QListView):
     List view allowing to drop ili and transfer files.
     """
 
-    ValidExtenstions = ["xtf", "XTF", "itf", "ITF", "ili", "XML", "xml"]
+    ValidExtenstions = ["xtf", "XTF", "itf", "ITF", "ili"]
+    ValidXmlExtensions = ["XML", "xml"]
     ValidIniExtensions = ["ini", "INI", "toml", "TOML"]
 
     files_dropped = pyqtSignal(list, list)
@@ -265,20 +266,34 @@ class FileDropListView(QListView):
                 break
 
     def dropEvent(self, event):
-        dropped_files = [
-            url.toLocalFile()
-            for url in event.mimeData().urls()
-            if pathlib.Path(url.toLocalFile()).suffix[1:]
-            in FileDropListView.ValidExtenstions
-        ]
-        dropped_ini_files = [
-            url.toLocalFile()
-            for url in event.mimeData().urls()
-            if pathlib.Path(url.toLocalFile()).suffix[1:]
-            in FileDropListView.ValidIniExtensions
-        ]
+        dropped_files, dropped_xml_files, dropped_ini_files = self.extractDroppedFiles(
+            event.mimeData().urls()
+        )
+
+        dropped_files.extend(dropped_xml_files)
         self.files_dropped.emit(dropped_files, dropped_ini_files)
         event.acceptProposedAction()
+
+    @staticmethod
+    def extractDroppedFiles(url_list):
+        dropped_interlis_files = []
+        dropped_xml_files = []
+        dropped_ini_files = []
+        for url in url_list:
+            local_file = url.toLocalFile()
+            suffix = pathlib.Path(local_file).suffix[1:]
+            if suffix in FileDropListView.ValidExtenstions:
+                dropped_interlis_files.append(local_file)
+                continue
+
+            if suffix in FileDropListView.ValidXmlExtensions:
+                dropped_xml_files.append(local_file)
+                continue
+
+            if suffix in FileDropListView.ValidIniExtensions:
+                dropped_ini_files.append(local_file)
+
+        return dropped_interlis_files, dropped_xml_files, dropped_ini_files
 
 
 class SourceModel(QStandardItemModel):


### PR DESCRIPTION
They are already handled by FileDropListView.ValidExtenstions

Fix #837