### PR TITLE
UsabILItyHub: Filter Toppings according to the Database Source

### DIFF
--- a/QgisModelBaker/gui/topping_wizard/models_page.py
+++ b/QgisModelBaker/gui/topping_wizard/models_page.py
@@ -67,6 +67,9 @@ class ModelsPage(QWizardPage, PAGE_UI):
                 self.tr("No models set."),
                 gui_utils.LogColor.COLOR_SUCCESS,
             )
+        self.topping_wizard.topping.preferred_datasource = (
+            self.source_combobox.currentData()
+        )
         return super().validatePage()
 
     def _refresh(self):

--- a/QgisModelBaker/gui/topping_wizard/referencedata_page.py
+++ b/QgisModelBaker/gui/topping_wizard/referencedata_page.py
@@ -27,8 +27,8 @@ from qgis.PyQt.QtWidgets import QCompleter, QWizardPage
 import QgisModelBaker.utils.gui_utils as gui_utils
 from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
     IliDataCache,
+    IliDataFileCompleterDelegate,
     IliDataItemModel,
-    MetaConfigCompleterDelegate,
 )
 from QgisModelBaker.libs.modelbaker.utils.qt_utils import (
     FileValidator,
@@ -76,7 +76,7 @@ class ReferencedataPage(QWizardPage, PAGE_UI):
             self.topping_wizard.log_panel.show_message
         )
 
-        self.ilireferencedata_delegate = MetaConfigCompleterDelegate()
+        self.ilireferencedata_delegate = IliDataFileCompleterDelegate()
         self.input_line_edit.setPlaceholderText(
             self.tr("[Search referenced data files from Repositories or Local System]")
         )

--- a/QgisModelBaker/gui/topping_wizard/topping_wizard.py
+++ b/QgisModelBaker/gui/topping_wizard/topping_wizard.py
@@ -101,7 +101,7 @@ class ToppingWizard(QWizard):
         if id == ToppingWizardPageIds.Target:
             return self.tr("Target Folder Selection")
         elif id == ToppingWizardPageIds.Models:
-            return self.tr("Model Selection")
+            return self.tr("Model and Source Selection")
         elif id == ToppingWizardPageIds.Layers:
             return self.tr("Layer Configuration")
         elif id == ToppingWizardPageIds.Additives:

--- a/QgisModelBaker/gui/workflow_wizard/import_data_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_data_configuration_page.py
@@ -36,8 +36,8 @@ import QgisModelBaker.libs.modelbaker.utils.db_utils as db_utils
 import QgisModelBaker.utils.gui_utils as gui_utils
 from QgisModelBaker.gui.dataset_manager import DatasetManagerDialog
 from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
+    IliDataFileCompleterDelegate,
     IliDataItemModel,
-    MetaConfigCompleterDelegate,
 )
 from QgisModelBaker.utils.globals import CATALOGUE_DATASETNAME, DEFAULT_DATASETNAME
 from QgisModelBaker.utils.gui_utils import CheckDelegate, LogColor
@@ -118,7 +118,7 @@ class ImportDataConfigurationPage(QWizardPage, PAGE_UI):
         self.workflow_wizard.ilireferencedatacache.file_download_failed.connect(
             self._on_referencedata_failed
         )
-        self.ilireferencedata_delegate = MetaConfigCompleterDelegate()
+        self.ilireferencedata_delegate = IliDataFileCompleterDelegate()
         self.ilireferencedata_line_edit.setPlaceholderText(
             self.tr("[Search referenced data files from UsabILIty Hub]")
         )

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -29,8 +29,8 @@ from qgis.PyQt.QtWidgets import QCompleter, QWizardPage
 from QgisModelBaker.gui.ili2db_options import Ili2dbOptionsDialog
 from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
     IliDataCache,
+    IliDataFileCompleterDelegate,
     IliDataItemModel,
-    MetaConfigCompleterDelegate,
 )
 from QgisModelBaker.utils import gui_utils
 from QgisModelBaker.utils.globals import CRS_PATTERNS
@@ -71,7 +71,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self.ilimetaconfigcache = IliDataCache(
             self.workflow_wizard.import_schema_configuration.base_configuration
         )
-        self.metaconfig_delegate = MetaConfigCompleterDelegate()
+        self.metaconfig_delegate = IliDataFileCompleterDelegate()
         self.metaconfig = configparser.ConfigParser()
         self.current_models = []
         self.current_metaconfig_id = None

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -27,6 +27,7 @@ from qgis.PyQt.QtCore import QSettings, Qt
 from qgis.PyQt.QtWidgets import QCompleter, QWizardPage
 
 from QgisModelBaker.gui.ili2db_options import Ili2dbOptionsDialog
+from QgisModelBaker.libs.modelbaker.iliwrapper.globals import DbIliMode
 from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
     IliDataCache,
     IliDataFileCompleterDelegate,
@@ -158,8 +159,6 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         - Calls update of ilireferencedata cache to load referenced
         """
         model_list = self.model_list_view.model().checked_models()
-        if set(model_list) == set(self.current_models):
-            return
         self.current_models = model_list
         for pattern, crs in CRS_PATTERNS.items():
             if re.search(pattern, ", ".join(model_list)):
@@ -173,6 +172,11 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self.ilimetaconfigcache = IliDataCache(
             self.workflow_wizard.import_schema_configuration.base_configuration,
             models=";".join(self.model_list_view.model().checked_models()),
+            datasources=["pg"]
+            if (self.workflow_wizard.import_schema_configuration.tool & DbIliMode.pg)
+            else ["gpkg"]
+            if (self.workflow_wizard.import_schema_configuration.tool & DbIliMode.gpkg)
+            else None,
         )
         self.ilimetaconfigcache.file_download_succeeded.connect(
             lambda dataset_id, path: self._on_metaconfig_received(path)

--- a/QgisModelBaker/ui/topping_wizard/models.ui
+++ b/QgisModelBaker/ui/topping_wizard/models.ui
@@ -45,7 +45,7 @@
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Select the type for which this topping should be made or specify none (allow all). This value will be written into  the categories and the toppings will be filtered accordingly.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>Select the Models of Interest. These are the models on what you will find the metaconfiguration / topping at UsabILIty Hub.</string>
+      <string>Select the models for which you want to find this  topping at UsabILIty Hub.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -97,7 +97,7 @@
       <string/>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select the type for which this topping should be made or specify none (allow all).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select the database type for which you want to find this topping (or specify none to be visible for all).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/QgisModelBaker/ui/topping_wizard/models.ui
+++ b/QgisModelBaker/ui/topping_wizard/models.ui
@@ -14,6 +14,19 @@
    <string>Select Files</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="4" column="0">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>693</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="description">
      <property name="minimumSize">
@@ -28,6 +41,9 @@
        <bold>true</bold>
       </font>
      </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Select the type for which this topping should be made or specify none (allow all). This value will be written into  the categories and the toppings will be filtered accordingly.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
       <string>Select the Models of Interest. These are the models on what you will find the metaconfiguration / topping at UsabILIty Hub.</string>
      </property>
@@ -36,6 +52,13 @@
      </property>
      <property name="wordWrap">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QPushButton" name="refresh_button">
+     <property name="text">
+      <string>Refresh</string>
      </property>
     </widget>
    </item>
@@ -49,23 +72,35 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>693</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
+   <item row="3" column="0" colspan="2">
+    <widget class="QComboBox" name="source_combobox">
+     <item>
+      <property name="text">
+       <string>Allow all sources</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>PostGIS</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>GeoPackage</string>
+      </property>
+     </item>
+    </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="refresh_button">
+   <item row="2" column="0">
+    <widget class="QLabel" name="source_description">
+     <property name="toolTip">
+      <string/>
+     </property>
      <property name="text">
-      <string>Refresh</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select the type for which this topping should be made or specify none (allow all).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/docs/background_info/usabilityhub/technical_concept.md
+++ b/docs/background_info/usabilityhub/technical_concept.md
@@ -41,7 +41,7 @@ Additional servers/repositories can be linked via the `ilisite.xml`. The `Datase
     </DatasetIdx16.Code_>
     <DatasetIdx16.Code_>
       <!--  Codes können auch generisch sein  -->
-    	<value>http://codes.opengis.ch/modelbaker</value>
+    	<value>http://codes.modelbaker.ch/preferredDataSource/gpkg</value>
       <!--  müssen aber eine URL sein  -->
     </DatasetIdx16.Code_>
   </categories>


### PR DESCRIPTION
In the `ilidata` it's the `category` with the key `http://codes.modelbaker.ch/preferredDataSource` describing what db the file is made for. If there is no such category it's always displayed.

### Means on import
Filters UsabILIty Hub Metaconfig Files according to the current database.

### Means on topping export
It detects what db sources are used and suggests you to optimize. But you can choose none - means the topping will be displayed on every db source...
![Screenshot from 2023-12-01 09-09-18](https://github.com/opengisch/QgisModelBaker/assets/28384354/da16bde1-6839-4921-8c76-e41208c40ed0)


Resolves #759

Depends on https://github.com/opengisch/QgisModelBakerLibrary/pull/79