### PR TITLE
Topping on create Project

### DIFF
--- a/QgisModelBaker/gui/panel/log_panel.py
+++ b/QgisModelBaker/gui/panel/log_panel.py
@@ -19,7 +19,7 @@
 
 import logging
 
-from PyQt5.QtWidgets import QGridLayout
+from PyQt5.QtWidgets import QGridLayout, QProgressBar
 from qgis.core import Qgis
 from qgis.gui import QgsMessageBar
 from qgis.PyQt.QtCore import QSize, Qt
@@ -40,9 +40,17 @@ class LogPanel(QWidget):
         self.txtStdout.setLayout(QGridLayout())
         self.txtStdout.layout().setContentsMargins(0, 0, 0, 0)
         self.txtStdout.layout().addWidget(self.bar, 0, 0, Qt.AlignTop)
+        self.scrollbar = self.txtStdout.verticalScrollBar()
+
+        self.busy_bar = QProgressBar()
+        self.busy_bar.setRange(0, 0)
+        self.busy_bar.setTextVisible(True)
+        self.busy_bar.setVisible(False)
 
         layout = QGridLayout()
         layout.addWidget(self.txtStdout)
+        layout.addWidget(self.busy_bar)
+
         self.setLayout(layout)
 
     def sizeHint(self):

--- a/QgisModelBaker/gui/workflow_wizard/default_baskets_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/default_baskets_page.py
@@ -52,9 +52,6 @@ class DefaultBasketsPage(QWizardPage, PAGE_UI):
 
     def setComplete(self, complete):
         self.is_complete = complete
-        self.create_default_baskets_button.setDisabled(complete)
-        self.skip_button.setDisabled(complete)
-        self.baskets_panel.setDisabled(complete)
         self.completeChanged.emit()
 
     def nextId(self):
@@ -88,6 +85,9 @@ class DefaultBasketsPage(QWizardPage, PAGE_UI):
             self.progress_bar.setFormat(self.tr("Default baskets created!"))
             self.progress_bar.setValue(100)
             self.setStyleSheet(gui_utils.SUCCESS_STYLE)
+            self.create_default_baskets_button.setDisabled(True)
+            self.skip_button.setDisabled(True)
+            self.baskets_panel.setDisabled(True)
             self.setComplete(True)
         else:
             self.workflow_wizard.log_panel.print_info(message)
@@ -103,4 +103,7 @@ class DefaultBasketsPage(QWizardPage, PAGE_UI):
         self.progress_bar.setFormat(self.tr("SKIPPED"))
         self.progress_bar.setTextVisible(True)
         self.setStyleSheet(gui_utils.INACTIVE_STYLE)
+        self.create_default_baskets_button.setDisabled(True)
+        self.skip_button.setDisabled(True)
+        self.baskets_panel.setDisabled(True)
         self.setComplete(True)

--- a/QgisModelBaker/gui/workflow_wizard/default_baskets_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/default_baskets_page.py
@@ -107,10 +107,3 @@ class DefaultBasketsPage(QWizardPage, PAGE_UI):
         self.skip_button.setDisabled(True)
         self.baskets_panel.setDisabled(True)
         self.setComplete(True)
-
-    def busy(self, busy, text=None):
-        self.setEnabled(not busy)
-        if busy:
-            self.workflow_wizard.start_busy_bar(text)
-        else:
-            self.workflow_wizard.stop_busy_bar()

--- a/QgisModelBaker/gui/workflow_wizard/default_baskets_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/default_baskets_page.py
@@ -107,3 +107,10 @@ class DefaultBasketsPage(QWizardPage, PAGE_UI):
         self.skip_button.setDisabled(True)
         self.baskets_panel.setDisabled(True)
         self.setComplete(True)
+
+    def busy(self, busy, text=None):
+        self.setEnabled(not busy)
+        if busy:
+            self.workflow_wizard.start_busy_bar(text)
+        else:
+            self.workflow_wizard.stop_busy_bar()

--- a/QgisModelBaker/gui/workflow_wizard/execution_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/execution_page.py
@@ -195,3 +195,10 @@ class ExecutionPage(QWizardPage, PAGE_UI):
             message = self.tr("Finished with errors!")
 
         self.workflow_wizard.log_panel.print_info(message, color)
+
+    def busy(self, busy, text=None):
+        self.setEnabled(not busy)
+        if busy:
+            self.workflow_wizard.start_busy_bar(text)
+        else:
+            self.workflow_wizard.stop_busy_bar()

--- a/QgisModelBaker/gui/workflow_wizard/execution_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/execution_page.py
@@ -195,10 +195,3 @@ class ExecutionPage(QWizardPage, PAGE_UI):
             message = self.tr("Finished with errors!")
 
         self.workflow_wizard.log_panel.print_info(message, color)
-
-    def busy(self, busy, text=None):
-        self.setEnabled(not busy)
-        if busy:
-            self.workflow_wizard.start_busy_bar(text)
-        else:
-            self.workflow_wizard.stop_busy_bar()

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -185,6 +185,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self.ilimetaconfigcache.model_refreshed.connect(
             self._update_metaconfig_completer
         )
+        self.busy(True, self.tr("Refresh repository data..."))
         self._refresh_ili_metaconfig_cache()
 
     def _update_ilireferencedatacache(self):
@@ -289,6 +290,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         completer.popup().setItemDelegate(self.metaconfig_delegate)
         self.ili_metaconfig_line_edit.setCompleter(completer)
         self.ili_metaconfig_line_edit.setEnabled(bool(rows))
+        self.busy(False)
 
     def _on_metaconfig_completer_activated(self, text=None):
         self._clean_metaconfig()
@@ -315,8 +317,9 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                     self.ilimetaconfigcache.model.data(model_index, Qt.DisplayRole),
                     metaconfig_id,
                     self.ilimetaconfigcache.model.data(
-                        model_index, int(IliDataItemModel.Roles.SHORT_DESCRIPTION) or ""
-                    ),
+                        model_index, int(IliDataItemModel.Roles.SHORT_DESCRIPTION)
+                    )
+                    or "",
                 )
             )
             self.metaconfig_file_info_label.setStyleSheet("color: #341d5c")
@@ -433,6 +436,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self._crs_changed()
 
     def _load_metaconfig(self):
+        self.busy(True, "Load metaconfiguration...")
         # load ili2db parameters to the GUI
         if "ch.ehi.ili2db" in self.metaconfig.sections():
             self.workflow_wizard.log_panel.print_info(
@@ -570,3 +574,12 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                             LogColor.COLOR_TOPPING,
                         )
             self.workflow_wizard.refresh_import_models()
+
+        self.busy(False)
+
+    def busy(self, busy, text=None):
+        self.setEnabled(not busy)
+        if busy:
+            self.workflow_wizard.start_busy_bar(text)
+        else:
+            self.workflow_wizard.stop_busy_bar()

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -185,7 +185,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self.ilimetaconfigcache.model_refreshed.connect(
             self._update_metaconfig_completer
         )
-        self.busy(True, self.tr("Refresh repository data..."))
+        self.workflow_wizard.busy(self, True, self.tr("Refresh repository data..."))
         self._refresh_ili_metaconfig_cache()
 
     def _update_ilireferencedatacache(self):
@@ -290,7 +290,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         completer.popup().setItemDelegate(self.metaconfig_delegate)
         self.ili_metaconfig_line_edit.setCompleter(completer)
         self.ili_metaconfig_line_edit.setEnabled(bool(rows))
-        self.busy(False)
+        self.workflow_wizard.busy(self, False)
 
     def _on_metaconfig_completer_activated(self, text=None):
         self._clean_metaconfig()
@@ -436,7 +436,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self._crs_changed()
 
     def _load_metaconfig(self):
-        self.busy(True, "Load metaconfiguration...")
+        self.workflow_wizard.busy(self, True, "Load metaconfiguration...")
         # load ili2db parameters to the GUI
         if "ch.ehi.ili2db" in self.metaconfig.sections():
             self.workflow_wizard.log_panel.print_info(
@@ -575,11 +575,4 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                         )
             self.workflow_wizard.refresh_import_models()
 
-        self.busy(False)
-
-    def busy(self, busy, text=None):
-        self.setEnabled(not busy)
-        if busy:
-            self.workflow_wizard.start_busy_bar(text)
-        else:
-            self.workflow_wizard.stop_busy_bar()
+        self.workflow_wizard.busy(self, False)

--- a/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
@@ -113,7 +113,8 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
         self.completeChanged.emit()
 
     def restore_configuration(self, configuration):
-        self.busy(
+        self.workflow_wizard.busy(
+            self,
             True,
             self.tr("Restoring configuration and check existing metaconfigfile..."),
         )
@@ -129,7 +130,7 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
             self.existing_topping_checkbox.setChecked(True)
         else:
             self._use_existing(False)
-        self.busy(False)
+        self.workflow_wizard.busy(self, False)
 
     def _use_existing(self, state):
         # triggered by checked state.
@@ -162,7 +163,7 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
                 self.workflow_wizard.log_panel.show_message
             )
             # wait before activating until end of refreshment
-            self.busy(True, self.tr("Refresh repository data..."))
+            self.workflow_wizard.busy(self, True, self.tr("Refresh repository data..."))
             self.ilitoppingcache.model_refreshed.connect(
                 lambda: self._enable_topping_selection(True)
             )
@@ -190,7 +191,7 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
         self.topping_info.setEnabled(state)
 
         self._enable_optimize_combo(state)
-        self.busy(False)
+        self.workflow_wizard.busy(self, False)
 
     def _enable_optimize_combo(self, state):
         self.optimize_combo.setEnabled(state)
@@ -660,10 +661,3 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
                 ):
                     modelnames.append(name)
         return modelnames
-
-    def busy(self, busy, text=None):
-        self.setEnabled(not busy)
-        if busy:
-            self.workflow_wizard.start_busy_bar(text)
-        else:
-            self.workflow_wizard.stop_busy_bar()

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -694,11 +694,10 @@ class WorkflowWizard(QWizard):
 
     def busy(self, page, busy, text="Busy..."):
         page.setEnabled(not busy)
+        self.log_panel.busy_bar.setVisible(busy)
         if busy:
             self.log_panel.busy_bar.setFormat(text)
-            self.log_panel.busy_bar.setVisible(True)
         else:
-            self.log_panel.busy_bar.setVisible(False)
             self.log_panel.scrollbar.setValue(self.log_panel.scrollbar.maximum())
 
 

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -272,8 +272,10 @@ class WorkflowWizard(QWizard):
                         "Checking for potential referenced data on the repositories (might take a while)..."
                     )
                 )
-                self.schema_configuration_page.busy(
-                    True, self.tr("Checking for potential referenced data...")
+                self.busy(
+                    self.schema_configuration_page,
+                    True,
+                    self.tr("Checking for potential referenced data..."),
                 )
                 self.schema_configuration_page.setComplete(False)
                 if (
@@ -287,7 +289,7 @@ class WorkflowWizard(QWizard):
                         self.tr("Potential referenced data found.")
                     )
                     self.schema_configuration_page.setComplete(True)
-                    self.schema_configuration_page.busy(False)
+                    self.busy(self.schema_configuration_page, False)
                     return PageIds.ImportDataConfiguration
                 else:
                     self.log_panel.print_info(
@@ -296,7 +298,7 @@ class WorkflowWizard(QWizard):
                         )
                     )
                     self.schema_configuration_page.setComplete(True)
-                    self.schema_configuration_page.busy(False)
+                    self.busy(self.schema_configuration_page, False)
 
             if self.current_id == PageIds.ImportSchemaExecution:
                 # if basket handling active, go to the create basket
@@ -313,8 +315,10 @@ class WorkflowWizard(QWizard):
                         "Checking for potential referenced data on the repositories (might take a while)..."
                     )
                 )
-                self.import_schema_execution_page.busy(
-                    True, self.tr("Checking for potential referenced data...")
+                self.busy(
+                    self.import_schema_execution_page,
+                    True,
+                    self.tr("Checking for potential referenced data..."),
                 )
                 self.import_schema_execution_page.setComplete(False)
                 if self.update_referecedata_cache_model(
@@ -325,10 +329,10 @@ class WorkflowWizard(QWizard):
                         self.tr("Potential referenced data found.")
                     )
                     self.import_schema_execution_page.setComplete(True)
-                    self.import_schema_execution_page.busy(False)
+                    self.busy(self.import_schema_execution_page, False)
                     return PageIds.ImportDataConfiguration
                 self.import_schema_execution_page.setComplete(True)
-                self.import_schema_execution_page.busy(False)
+                self.busy(self.import_schema_execution_page, False)
 
                 # otherwise, go to project create
                 return PageIds.ProjectCreation
@@ -345,8 +349,10 @@ class WorkflowWizard(QWizard):
                     )
                 )
                 self.default_baskets_page.setComplete(False)
-                self.default_baskets_page.busy(
-                    True, self.tr("Checking for potential referenced data...")
+                self.busy(
+                    self.default_baskets_page,
+                    True,
+                    self.tr("Checking for potential referenced data..."),
                 )
                 if self.update_referecedata_cache_model(
                     self._db_modelnames(self.import_data_configuration),
@@ -356,10 +362,10 @@ class WorkflowWizard(QWizard):
                         self.tr("Potential referenced data found.")
                     )
                     self.default_baskets_page.setComplete(True)
-                    self.default_baskets_page.busy(False)
+                    self.busy(self.default_baskets_page, False)
                     return PageIds.ImportDataConfiguration
                 self.default_baskets_page.setComplete(True)
-                self.default_baskets_page.busy(False)
+                self.busy(self.default_baskets_page, False)
 
                 # otherwise, go to project create
                 return PageIds.ProjectCreation
@@ -686,13 +692,14 @@ class WorkflowWizard(QWizard):
                 dropped_ini_files[0]
             )
 
-    def start_busy_bar(self, text="Loading..."):
-        self.log_panel.busy_bar.setFormat(text)
-        self.log_panel.busy_bar.setVisible(True)
-
-    def stop_busy_bar(self):
-        self.log_panel.busy_bar.setVisible(False)
-        self.log_panel.scrollbar.setValue(self.log_panel.scrollbar.maximum())
+    def busy(self, page, busy, text="Busy..."):
+        page.setEnabled(not busy)
+        if busy:
+            self.log_panel.busy_bar.setFormat(text)
+            self.log_panel.busy_bar.setVisible(True)
+        else:
+            self.log_panel.busy_bar.setVisible(False)
+            self.log_panel.scrollbar.setValue(self.log_panel.scrollbar.maximum())
 
 
 class WorkflowWizardDialog(QDialog):

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -345,7 +345,7 @@ class WorkflowWizard(QWizard):
                     )
                 )
                 self.default_baskets_page.setComplete(False)
-                self.ddefault_baskets_page.busy(
+                self.default_baskets_page.busy(
                     True, self.tr("Checking for potential referenced data...")
                 )
                 if self.update_referecedata_cache_model(

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -59,6 +59,7 @@ from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
     IliToppingFileCache,
 )
 from QgisModelBaker.libs.modelbaker.utils.globals import DbActionType
+from QgisModelBaker.utils import gui_utils
 from QgisModelBaker.utils.gui_utils import (
     FileDropListView,
     ImportDataModel,
@@ -271,6 +272,9 @@ class WorkflowWizard(QWizard):
                         "Checking for potential referenced data on the repositories (might take a while)..."
                     )
                 )
+                self.schema_configuration_page.busy(
+                    True, self.tr("Checking for potential referenced data...")
+                )
                 self.schema_configuration_page.setComplete(False)
                 if (
                     self.import_data_file_model.rowCount()
@@ -283,6 +287,7 @@ class WorkflowWizard(QWizard):
                         self.tr("Potential referenced data found.")
                     )
                     self.schema_configuration_page.setComplete(True)
+                    self.schema_configuration_page.busy(False)
                     return PageIds.ImportDataConfiguration
                 else:
                     self.log_panel.print_info(
@@ -291,6 +296,7 @@ class WorkflowWizard(QWizard):
                         )
                     )
                     self.schema_configuration_page.setComplete(True)
+                    self.schema_configuration_page.busy(False)
 
             if self.current_id == PageIds.ImportSchemaExecution:
                 # if basket handling active, go to the create basket
@@ -307,6 +313,9 @@ class WorkflowWizard(QWizard):
                         "Checking for potential referenced data on the repositories (might take a while)..."
                     )
                 )
+                self.import_schema_execution_page.busy(
+                    True, self.tr("Checking for potential referenced data...")
+                )
                 self.import_schema_execution_page.setComplete(False)
                 if self.update_referecedata_cache_model(
                     self._db_modelnames(self.import_data_configuration),
@@ -316,8 +325,10 @@ class WorkflowWizard(QWizard):
                         self.tr("Potential referenced data found.")
                     )
                     self.import_schema_execution_page.setComplete(True)
+                    self.import_schema_execution_page.busy(False)
                     return PageIds.ImportDataConfiguration
                 self.import_schema_execution_page.setComplete(True)
+                self.import_schema_execution_page.busy(False)
 
                 # otherwise, go to project create
                 return PageIds.ProjectCreation
@@ -334,6 +345,9 @@ class WorkflowWizard(QWizard):
                     )
                 )
                 self.default_baskets_page.setComplete(False)
+                self.ddefault_baskets_page.busy(
+                    True, self.tr("Checking for potential referenced data...")
+                )
                 if self.update_referecedata_cache_model(
                     self._db_modelnames(self.import_data_configuration),
                     "referenceData",
@@ -342,8 +356,10 @@ class WorkflowWizard(QWizard):
                         self.tr("Potential referenced data found.")
                     )
                     self.default_baskets_page.setComplete(True)
+                    self.default_baskets_page.busy(False)
                     return PageIds.ImportDataConfiguration
                 self.default_baskets_page.setComplete(True)
+                self.default_baskets_page.busy(False)
 
                 # otherwise, go to project create
                 return PageIds.ProjectCreation
@@ -670,10 +686,19 @@ class WorkflowWizard(QWizard):
                 dropped_ini_files[0]
             )
 
+    def start_busy_bar(self, text="Loading..."):
+        self.log_panel.busy_bar.setFormat(text)
+        self.log_panel.busy_bar.setVisible(True)
+
+    def stop_busy_bar(self):
+        self.log_panel.busy_bar.setVisible(False)
+        self.log_panel.scrollbar.setValue(self.log_panel.scrollbar.maximum())
+
 
 class WorkflowWizardDialog(QDialog):
     def __init__(self, iface, base_config, parent):
         QDialog.__init__(self, parent)
+        self.setStyleSheet(gui_utils.DEFAULT_STYLE)
         self.iface = iface
         self.base_config = base_config
 
@@ -683,8 +708,8 @@ class WorkflowWizardDialog(QDialog):
         self.workflow_wizard.setStartId(PageIds.Intro)
         self.workflow_wizard.setWindowFlags(Qt.Widget)
         self.workflow_wizard.show()
-
         self.workflow_wizard.finished.connect(self.done)
+
         layout = QVBoxLayout()
         splitter = QSplitter(Qt.Vertical)
         splitter.addWidget(self.workflow_wizard)

--- a/QgisModelBaker/ui/workflow_wizard/project_creation.ui
+++ b/QgisModelBaker/ui/workflow_wizard/project_creation.ui
@@ -14,61 +14,79 @@
    <string>Select Files</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
-    <spacer name="verticalSpacer">
+   <item row="5" column="0">
+    <spacer name="horizontalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>40</width>
+       <height>20</height>
       </size>
      </property>
     </spacer>
    </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="optimize_combo">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="topping_groupbox">
+     <property name="title">
+      <string/>
      </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Hide unused base class layers:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Base class layers with same named extensions will be &lt;span style=&quot; font-style:italic;&quot;&gt;hidden&lt;/span&gt; and and base class layers with multiple extensions as well. Except if the extension is in the same model, then it's will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;hidden&lt;/span&gt; but &lt;span style=&quot; font-style:italic;&quot;&gt;renamed&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;- Relations of hidden layers will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;created&lt;/span&gt; and with them &lt;span style=&quot; font-style:italic;&quot;&gt;no&lt;/span&gt; widgets&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Group unused base class layers:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Base class layers with same named extensions will be &lt;span style=&quot; font-style:italic;&quot;&gt;collected in a group&lt;/span&gt; and base class layers with multiple extensions as well. Except if the extension is in the same model, then it's will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;grouped&lt;/span&gt; but &lt;span style=&quot; font-style:italic;&quot;&gt;renamed&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;- Relations of grouped layers will be &lt;span style=&quot; font-style:italic;&quot;&gt;created&lt;/span&gt; but the widgets &lt;span style=&quot; font-style:italic;&quot;&gt;not applied&lt;/span&gt; to the form.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     <property name="checkable">
+      <bool>false</bool>
      </property>
-     <item>
-      <property name="text">
-       <string>Hide unused base class layers</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Group unused base class layers</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>No optimization</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you don't get it - nevermind and keep the default. If it's not like expected - try again with 'No optimization'...&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Project optimization strategy concerning inheritances</string>
-     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="0">
+       <widget class="QLabel" name="topping_line_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Project Topping</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="CompletionLineEdit" name="topping_line_edit" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="existing_topping_checkbox">
+        <property name="text">
+         <string>Use existing project topping</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QToolButton" name="topping_file_browse_button">
+        <property name="toolTip">
+         <string>Browse Interlis files</string>
+        </property>
+        <property name="text">
+         <string>…</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QLabel" name="topping_info">
+        <property name="text">
+         <string>TextLabel</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="0" column="0" colspan="2">
@@ -96,26 +114,6 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="6" column="1">
-    <widget class="QCommandLinkButton" name="create_project_button">
-     <property name="text">
-      <string>Generate</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="0" colspan="2">
     <widget class="QProgressBar" name="progress_bar">
      <property name="value">
@@ -123,8 +121,89 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="inheritance_groupbox">
+     <property name="title">
+      <string/>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="optimize_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you don't get it - nevermind and keep the default. If it's not like expected - try again with 'No optimization'...&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Project optimization strategy concerning inheritances</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="optimize_combo">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Hide unused base class layers:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Base class layers with same named extensions will be &lt;span style=&quot; font-style:italic;&quot;&gt;hidden&lt;/span&gt; and and base class layers with multiple extensions as well. Except if the extension is in the same model, then it's will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;hidden&lt;/span&gt; but &lt;span style=&quot; font-style:italic;&quot;&gt;renamed&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;- Relations of hidden layers will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;created&lt;/span&gt; and with them &lt;span style=&quot; font-style:italic;&quot;&gt;no&lt;/span&gt; widgets&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Group unused base class layers:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Base class layers with same named extensions will be &lt;span style=&quot; font-style:italic;&quot;&gt;collected in a group&lt;/span&gt; and base class layers with multiple extensions as well. Except if the extension is in the same model, then it's will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;grouped&lt;/span&gt; but &lt;span style=&quot; font-style:italic;&quot;&gt;renamed&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;- Relations of grouped layers will be &lt;span style=&quot; font-style:italic;&quot;&gt;created&lt;/span&gt; but the widgets &lt;span style=&quot; font-style:italic;&quot;&gt;not applied&lt;/span&gt; to the form.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Hide unused base class layers</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Group unused base class layers</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>No optimization</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCommandLinkButton" name="create_project_button">
+     <property name="text">
+      <string>Generate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CompletionLineEdit</class>
+   <extends></extends>
+   <header>QgisModelBaker.utils.gui_utils</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/QgisModelBaker/ui/workflow_wizard/project_creation.ui
+++ b/QgisModelBaker/ui/workflow_wizard/project_creation.ui
@@ -61,6 +61,9 @@
       </item>
       <item row="0" column="0">
        <widget class="QCheckBox" name="existing_topping_checkbox">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A project topping is already given by the previous metaconfiguration selection or via the metaconfiguration id stored in the database. Uncheck, when you want to choose another project topping file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="text">
          <string>Use existing project topping</string>
         </property>
@@ -113,6 +116,19 @@
       <bool>true</bool>
      </property>
     </widget>
+   </item>
+   <item row="4" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="3" column="0" colspan="2">
     <widget class="QProgressBar" name="progress_bar">
@@ -180,19 +196,6 @@
       <string>Generate</string>
      </property>
     </widget>
-   </item>
-   <item row="4" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
## Topping on Generate
### Get Topping of Metaconfig stored in the DB
Since ili2db 4.11 the id of the metaconfiguration file used to create the physical database is stored in the meta-tables. This means, on **Project Creation** we consider this id and provide the linked **project topping**.

![Screenshot from 2023-12-04 14-41-47](https://github.com/opengisch/QgisModelBaker/assets/28384354/9ddcd4fb-b718-4e01-ab65-aa8f303f5688)

### Get Topping by selection
Still it's possible to **disable it** and choose another **project topping file**.

![image](https://github.com/opengisch/QgisModelBaker/assets/28384354/1f5760c7-0ad4-4556-8088-9f5d7174550c)

You can choose a **project topping file** (identified by model, db-type) from the **UsabILITy Hub** repositories or as well a YAML file from the **local system**.

### Why, *project topping* file
... and not "metaconfiguration* file? 

Because on this step only project topping files are relevant. Metaconfiguration files are only relevant, when the schema is created. We thought about to provide them, to choose the same like on schema import, but this part is already provided by getting the topping from the DB.

### To do
- [x] preferredDataSource
- [x] Finetune GUI
- [x] Synchronize with other open PRs

Resolves #479 and resolves #768

## Busy Bar

Not directly related to this topic but it popped up again. Sometimes the wizard has to load - mostly checking the repos to suggest data / reload the comboboxes. And there users are confused, what's happening. For this reason it does now:
- Disable the Wizard Page (not cancel button)
- Showing a busy bar... 

[Screencast from 04.12.2023 16:24:24.webm](https://github.com/opengisch/QgisModelBaker/assets/28384354/95a0f31c-8d70-4ba5-b728-4c711d862270)

