### PR TITLE
Keep Settings in UsabILIty Exporter on Navigation

### DIFF
--- a/QgisModelBaker/gui/topping_wizard/additives_page.py
+++ b/QgisModelBaker/gui/topping_wizard/additives_page.py
@@ -18,7 +18,6 @@
 """
 
 from qgis.core import QgsProject
-from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QWizardPage
 
 from QgisModelBaker.utils import gui_utils
@@ -26,7 +25,7 @@ from QgisModelBaker.utils.gui_utils import CheckEntriesModel
 
 PAGE_UI = gui_utils.get_ui_class("topping_wizard/additives.ui")
 
-VARIABLE_PREFIX_BLACKLIST = ["default_basket"]
+VARIABLE_PREFIX_BLACKLIST = ["default_basket", "optimize_strategy"]
 
 
 class AdditivesPage(QWizardPage, PAGE_UI):
@@ -55,8 +54,7 @@ class AdditivesPage(QWizardPage, PAGE_UI):
 
     def initializePage(self) -> None:
         maptheme_collection = QgsProject.instance().mapThemeCollection()
-        self.mapthemes_model.setStringList(maptheme_collection.mapThemes())
-        self.mapthemes_model.check_all(Qt.Checked)
+        self.mapthemes_model.refresh_stringlist(maptheme_collection.mapThemes())
         self.mapthemes_view.setVisible(self.mapthemes_model.rowCount())
         self.mapthemes_label.setVisible(self.mapthemes_model.rowCount())
 
@@ -69,15 +67,13 @@ class AdditivesPage(QWizardPage, PAGE_UI):
                 if blacklisted_prefix not in variable_key
             ]
 
-        self.variables_model.setStringList(variables_keys)
-        self.variables_model.check_all(Qt.Checked)
+        self.variables_model.refresh_stringlist(variables_keys)
         self.variables_view.setVisible(self.variables_model.rowCount())
         self.variables_label.setVisible(self.variables_model.rowCount())
 
         layout_manager = QgsProject.instance().layoutManager()
         layout_names = [layout.name() for layout in layout_manager.printLayouts()]
-        self.layouts_model.setStringList(layout_names)
-        self.layouts_model.check_all(Qt.Checked)
+        self.layouts_model.refresh_stringlist(layout_names)
         self.layouts_view.setVisible(self.layouts_model.rowCount())
         self.layouts_label.setVisible(self.layouts_model.rowCount())
         return super().initializePage()

--- a/QgisModelBaker/gui/topping_wizard/ili2dbsettings_page.py
+++ b/QgisModelBaker/gui/topping_wizard/ili2dbsettings_page.py
@@ -257,6 +257,8 @@ class Ili2dbSettingsPage(QWizardPage, PAGE_UI):
         for layer in QgsProject.instance().mapLayers().values():
             if layer.type() == QgsMapLayer.VectorLayer:
                 source_provider = layer.dataProvider()
+                if not source_provider:
+                    continue
                 schema_identificator = (
                     db_utils.get_schema_identificator_from_sourceprovider(
                         source_provider

--- a/QgisModelBaker/gui/topping_wizard/layer_style_categories.py
+++ b/QgisModelBaker/gui/topping_wizard/layer_style_categories.py
@@ -107,10 +107,31 @@ class LayerStyleCategoriesDialog(QDialog, DIALOG_UI):
             self.style_categories_list_view.model().check
         )
 
+        self.select_all_checkbox.stateChanged.connect(self._select_all_items)
+        self.model.dataChanged.connect(lambda: self._set_select_all_checkbox())
+
         self.ok_button.clicked.connect(self.accept)
+
+    def _set_select_all_checkbox(self):
+        self.select_all_checkbox.setCheckState(self._evaluated_check_state(self.model))
+
+    def _evaluated_check_state(self, model):
+        nbr_of_checked = len(model.checked_entries())
+        if nbr_of_checked:
+            if nbr_of_checked == model.rowCount():
+                return Qt.Checked
+            return Qt.PartiallyChecked
+        return Qt.Unchecked
+
+    def _select_all_items(self, state):
+        if state != Qt.PartiallyChecked and state != self._evaluated_check_state(
+            self.model
+        ):
+            self.model.check_all(state)
 
     def set_categories(self, categories: QgsMapLayer.StyleCategories):
         self.style_categories_list_view.model().set_categories(categories)
+        self._set_select_all_checkbox()
 
     @property
     def categories(self):

--- a/QgisModelBaker/gui/topping_wizard/layers_page.py
+++ b/QgisModelBaker/gui/topping_wizard/layers_page.py
@@ -359,6 +359,8 @@ class LayerModel(QgsLayerTreeModel):
         for layer in QgsProject.instance().mapLayers().values():
             if layer.type() == QgsMapLayer.VectorLayer:
                 source_provider = layer.dataProvider()
+                if not source_provider:
+                    continue
                 schema_identificator = (
                     db_utils.get_schema_identificator_from_sourceprovider(
                         source_provider

--- a/QgisModelBaker/gui/topping_wizard/layers_page.py
+++ b/QgisModelBaker/gui/topping_wizard/layers_page.py
@@ -106,7 +106,7 @@ class LayerModel(QgsLayerTreeModel):
         self.use_definition_nodes = {}
         self.ili_schema_identificators = []
 
-        self.reload()
+        self.reload(True)
 
     def columnCount(self, parent=None):
         return len(LayerModel.Columns)
@@ -311,9 +311,10 @@ class LayerModel(QgsLayerTreeModel):
             else:
                 self.setData(index, Qt.CheckStateRole, Qt.Checked)
 
-    def reload(self):
+    def reload(self, load_defaults=False):
         self._load_ili_schema_identificators()
-        self._set_default_values()
+        if load_defaults:
+            self._set_default_values()
 
     def _disable_children(self, parent: QModelIndex):
         for child_row in range(self.rowCount(parent)):
@@ -553,7 +554,7 @@ class LayersPage(QWizardPage, PAGE_UI):
 
         self.categories_dialog = LayerStyleCategoriesDialog()
         self.stylecat_delegate.button_clicked.connect(self.open_categories_dialog)
-        self.reset_button.clicked.connect(self.layermodel.reload)
+        self.reset_button.clicked.connect(lambda: self.layermodel.reload(True))
 
     def open_categories_dialog(self, index):
         layername = index.data(int(Qt.DisplayRole))

--- a/QgisModelBaker/gui/topping_wizard/models_page.py
+++ b/QgisModelBaker/gui/topping_wizard/models_page.py
@@ -87,6 +87,8 @@ class ModelsPage(QWizardPage, PAGE_UI):
         for layer in QgsProject.instance().mapLayers().values():
             if layer.type() == QgsMapLayer.VectorLayer:
                 source_provider = layer.dataProvider()
+                if not source_provider:
+                    continue
                 self._append_possible_sources(sources, source_provider)
                 schema_identificator = (
                     db_utils.get_schema_identificator_from_sourceprovider(

--- a/QgisModelBaker/ui/topping_wizard/layer_style_categories.ui
+++ b/QgisModelBaker/ui/topping_wizard/layer_style_categories.ui
@@ -14,7 +14,10 @@
    <string>Layer Style Categories</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="1">
+   <item row="1" column="0" colspan="2">
+    <widget class="SpaceCheckListView" name="style_categories_list_view" native="true"/>
+   </item>
+   <item row="3" column="1">
     <widget class="QPushButton" name="ok_button">
      <property name="text">
       <string>Ok</string>
@@ -24,7 +27,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -34,12 +37,15 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="SpaceCheckListView" name="style_categories_list_view"/>
+   <item row="0" column="0">
+    <widget class="SemiTristateCheckbox" name="select_all_checkbox">
+     <property name="text">
+      <string>Select all</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
-
  <customwidgets>
   <customwidget>
    <class>SpaceCheckListView</class>
@@ -47,8 +53,12 @@
    <header>QgisModelBaker.utils.gui_utils</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>SemiTristateCheckbox</class>
+   <extends>QWidget</extends>
+   <header>QgisModelBaker.utils.gui_utils</header>
+  </customwidget>
  </customwidgets>
-
  <resources/>
  <connections>
   <connection>

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -902,10 +902,13 @@ class CheckEntriesModel(QStringListModel):
         self.dataChanged.emit(self.index(0, 0), self.index(self.rowCount(), 0))
 
     def checked_entries(self):
+        """
+        Provides the selected entries as list
+        """
         return [
             name
             for name in self.stringList()
-            if self._checked_entries[name] == Qt.Checked
+            if self._checked_entries.get(name, Qt.Unchecked) == Qt.Checked
         ]
 
     def check_entries(self, entries: list = []):
@@ -917,6 +920,25 @@ class CheckEntriesModel(QStringListModel):
                 self._checked_entries[name] == Qt.Checked
             else:
                 self._checked_entries[name] == Qt.Unchecked
+
+    def refresh_stringlist(self, values):
+        """
+        This sets the values to the string list, keeps thes status (checked_entries) when they still exist, and sets the new ones to Checked
+        """
+
+        self.setStringList(values)
+
+        # if there where already entries with a status we take it and otherwise we set checked per default
+        new_checked_entries = {}
+        for value in values:
+            if value in self._checked_entries:
+                new_checked_entries[value] = self._checked_entries[value]
+            else:
+                new_checked_entries[value] = Qt.Checked
+        self._checked_entries = new_checked_entries
+
+        self._emit_data_changed()
+        return self.rowCount()
 
 
 class SchemaModelsModel(CheckEntriesModel):
@@ -980,18 +1002,7 @@ class SchemaModelsModel(CheckEntriesModel):
                             modelnames.append(name)
                             self._parent_models[name] = db_model["parents"]
 
-        self.setStringList(modelnames)
-
-        # if there where already entries with a status we take it and otherwise we set checked per default
-        new_checked_entries = {}
-        for modelname in modelnames:
-            if modelname in self._checked_entries:
-                new_checked_entries[modelname] = self._checked_entries[modelname]
-            else:
-                new_checked_entries[modelname] = Qt.Checked
-        self._checked_entries = new_checked_entries
-
-        return self.rowCount()
+        return self.refresh_stringlist(modelnames)
 
 
 class SchemaDatasetsModel(CheckEntriesModel):

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -982,7 +982,14 @@ class SchemaModelsModel(CheckEntriesModel):
 
         self.setStringList(modelnames)
 
-        self._checked_entries = {modelname: Qt.Checked for modelname in modelnames}
+        # if there where already entries with a status we take it and otherwise we set checked per default
+        new_checked_entries = {}
+        for modelname in modelnames:
+            if modelname in self._checked_entries:
+                new_checked_entries[modelname] = self._checked_entries[modelname]
+            else:
+                new_checked_entries[modelname] = Qt.Checked
+        self._checked_entries = new_checked_entries
 
         return self.rowCount()
 


### PR DESCRIPTION
On going forward and back navigation in the wizard the checked states in...
- model page
- layer tree page
- additive settings (variables, print layouts etc)

... persists.

And a "select all" on categories...

Resolves #746 