### PR TITLE
Wait for model refresh on local repository topping receive

### DIFF
--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -589,7 +589,9 @@ class WorkflowWizard(QWizard):
 
         # we wait for the download or we timeout after 30 seconds and we apply what we have
         loop = QEventLoop()
-        topping_file_cache.download_finished.connect(lambda: loop.quit())
+        topping_file_cache.download_finished_and_model_fresh.connect(
+            lambda: loop.quit()
+        )
         timer = QTimer()
         timer.setSingleShot(True)
         timer.timeout.connect(lambda: loop.quit())
@@ -598,8 +600,8 @@ class WorkflowWizard(QWizard):
         topping_file_cache.refresh()
         self.log_panel.print_info(self.tr("- - Downloading…"), LogColor.COLOR_TOPPING)
 
-        if len(topping_file_cache.downloaded_files) != len(id_list):
-            loop.exec()
+        # we wait for the download_finished_and_model_fresh signal, because even when the files are local, it should only continue when both is ready
+        loop.exec()
 
         if len(topping_file_cache.downloaded_files) == len(id_list):
             self.log_panel.print_info(

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "1.7.0")
+MODELBAKER_LIBRARY=("modelbaker" "1.7.1")
 PACKAGING=("packaging" "21.3")
 
 PACKAGES=(


### PR DESCRIPTION
We had the functionality where we wait in a loop for the topping files to be downloaded. When there is a local repository, we did not wait for download (because the files where already there). But the model (where the mapping from id to file location is done) was sometimes not refreshed yet. That's why we wait for the signal in every case now.

And I renamed the signal in the library to avoid confusion.