### PR TITLE
Smart 1 project optimization

### DIFF
--- a/docs/docs/background_info/extended_models_optimization.md
+++ b/docs/docs/background_info/extended_models_optimization.md
@@ -1,4 +1,4 @@
-If a model or topic contains extended classes, the inclusive base classes are implemented in the physical database. The users only want to see, what is relevant for them and mostly work on the most extended instance of the topics/classes. Model Baker detects the ***irrelevant*** tables and offers optimization strategies to the users on ***smart1intehritance*** implementations.
+If a model or topic contains extended classes, the inclusive base classes are implemented in the physical database. The users only want to see, what is relevant for them and mostly work on the most extended instance of the topics/classes. Model Baker detects the ***irrelevant*** tables and offers optimization strategies.
 
 In the [workflow wizard](../../user_guide/import_workflow/#optimize-qgis-project-if-extended) you can choose the optimization [strategy](../../background_info/extended_models_optimization/#strategies) and receive a nicely prepared layertree and forms.
 
@@ -36,7 +36,7 @@ What to do then? Well, you have always the option for the [NONE-strategy](../../
 
 ## Strategies
 
-Let's check out the following examle model and it's implementation according to the strategies.
+Let's check out the following examle model and it's implementation according to the strategies on a database created with ***smart2intehritance***.
 
 ### Ortsplanung Example
 
@@ -57,6 +57,9 @@ Base class layers with extensions of the same name are **_hidden_** and base cla
 
 Relations of hidden layers are **_not created_** and thus the widgets for them _**neither**_.
 
+!!! Note
+    With ***smart1inheritance***, the extended `Gebaeude` classes would all be summarised in a layer with a `t_type`, which defines what type of extension it is. This strategy hides the irrelevant values for ‘t_type’.
+
 #### Group strategy
 
 Base class layers with extensions of the same name are ***grouped***, base class layers with multiple extensions ***also***. Unless the extension is in the same model, then it's ***not grouped*** but ***renamed***.
@@ -66,6 +69,7 @@ Base class layers with extensions of the same name are ***grouped***, base class
 Relationships of grouped layers are ***created***, but widgets are ***not applied*** to the form.
 
 #### None strategy
+
 Independently from extended models (but pretty much connected to it), we eliminate ambiguous layer naming in general. This means:
 
 - If layername is ambiuous append topic name as suffix.

--- a/docs/docs/background_info/extended_models_optimization.md
+++ b/docs/docs/background_info/extended_models_optimization.md
@@ -36,7 +36,7 @@ What to do then? Well, you have always the option for the [NONE-strategy](../../
 
 ## Strategies
 
-Let's check out the following examle model and it's implementation according to the strategies on a database created with ***smart2intehritance***.
+Let's check out the following example model and it's implementation according to the strategies on a database created with ***smart2intehritance***.
 
 ### Ortsplanung Example
 

--- a/docs/docs/user_guide/import_workflow.md
+++ b/docs/docs/user_guide/import_workflow.md
@@ -187,6 +187,9 @@ Choose your optimization strategy in the checkbox:
 
   Relations of grouped layers will be *created* but the widgets are *not applied* to the form.
 
+!!! Note
+    As well you can optimize projects created with *smart1inheritance*. There it only appends the relevant type-values to the `t_type` dropdown box in the form, when ***Hide unused base class types*** is selected. A "grouping" optimization does not make sense for *smart1inheritance*.
+
 For more information about the optimization of extended models, see the [corresponding chapter](../../background_info/extended_models_optimization).
 
 ## 8. OID Values

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,7 +91,7 @@ plugins:
             Basket and Dataset Handling: Dataset und Basket Handling
             OID Generator: OID Generator
             UsabILIty Hub: UsabILIty Hub
-            Overview: Übersicht
+            Overview: Overview
             Model Baker Integration: Model Baker Integration
             Technical Concept: Technisches Konzept
             Optimized Projects for Extended Models: Optimierte Projekte für erweiterte


### PR DESCRIPTION
Most is done in the backend, but in the strategy selection combobox only HIDE and NONE should be provided (no GROUP).

As well the texts should describe the use case with smart1.

![image](https://github.com/opengisch/QgisModelBaker/assets/28384354/99829658-e1da-496c-b486-5661889b0149)

With this it reads the smart-inheritance mapping that has been chosen for the current schema and updates the combobox accordingly.

Requires https://github.com/opengisch/QgisModelBakerLibrary/pull/93