### PR TITLE
[gui] Remember previous settings when using a PG service

### DIFF
--- a/QgisModelBaker/gui/panel/pg_config_panel.py
+++ b/QgisModelBaker/gui/panel/pg_config_panel.py
@@ -267,21 +267,50 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
                 PgConfigPanel._SERVICE_COMBOBOX_ROLE.SSLMODE,
             )
 
-        self.pg_host_line_edit.setText(configuration.dbhost)
-        self.pg_port_line_edit.setText(configuration.dbport)
-        self.pg_auth_settings.setUsername(configuration.dbusr)
-        self.pg_database_line_edit.setText(configuration.database)
-        self.pg_schema_combo_box.setCurrentText(configuration.dbschema)
-        self.pg_auth_settings.setPassword(configuration.dbpwd)
-        self.pg_auth_settings.setConfigId(configuration.dbauthid)
+            self.pg_host_line_edit.setText(configuration.dbhost)
+            self.pg_port_line_edit.setText(configuration.dbport)
+            self.pg_auth_settings.setUsername(configuration.dbusr)
+            self.pg_database_line_edit.setText(configuration.database)
+            self.pg_schema_combo_box.setCurrentText(configuration.dbschema)
+            self.pg_auth_settings.setPassword(configuration.dbpwd)
+            self.pg_auth_settings.setConfigId(configuration.dbauthid)
 
-        index = self.pg_ssl_mode_combo_box.findData(configuration.sslmode)
-        self.pg_ssl_mode_combo_box.setCurrentIndex(index)
+            index = self.pg_ssl_mode_combo_box.findData(configuration.sslmode)
+            self.pg_ssl_mode_combo_box.setCurrentIndex(index)
 
-        self.pg_use_super_login.setChecked(configuration.db_use_super_login)
+            self.pg_use_super_login.setChecked(configuration.db_use_super_login)
+        else:
+            index = self.pg_service_combo_box.findData(configuration.dbservice)
+            self.pg_service_combo_box.setCurrentIndex(index)
 
-        index = self.pg_service_combo_box.findData(configuration.dbservice)
-        self.pg_service_combo_box.setCurrentIndex(index)
+            # Only apply stored QSettings if the
+            # PG service didn't have a value for them
+            service_config = pgserviceparser.service_config(configuration.dbservice)
+
+            if not service_config.get("host"):
+                self.pg_host_line_edit.setText(configuration.dbhost)
+
+            if not service_config.get("port"):
+                self.pg_port_line_edit.setText(configuration.dbport)
+
+            if not service_config.get("dbname"):
+                self.pg_database_line_edit.setText(configuration.database)
+
+            if not service_config.get("user"):
+                self.pg_auth_settings.setUsername(configuration.dbusr)
+
+            if not service_config.get("password"):
+                self.pg_auth_settings.setPassword(configuration.dbpwd)
+
+            if not service_config.get("sslmode"):
+                index = self.pg_ssl_mode_combo_box.findData(configuration.sslmode)
+                self.pg_ssl_mode_combo_box.setCurrentIndex(index)
+
+            # On the contrary, next settings will never be stored
+            # in PG service, so always take them from QSettings
+            self.pg_schema_combo_box.setCurrentText(configuration.dbschema)
+            self.pg_auth_settings.setConfigId(configuration.dbauthid)
+            self.pg_use_super_login.setChecked(configuration.db_use_super_login)
 
     def is_valid(self):
         result = False
@@ -324,7 +353,7 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
             service_config = pgserviceparser.service_config(service)
 
             # QGIS cannot handle manually set hosts with service
-            # So it needs to has a host defined in service conf or it takes localhost
+            # So it needs to have a host defined in service conf or it takes localhost
             self.pg_host_line_edit.setText(service_config.get("host", "localhost"))
 
             self.pg_port_line_edit.setText(service_config.get("port", ""))


### PR DESCRIPTION
**What is changed**

When opening the dialog, if there is a service stored in QSettings, we set it in the first place (before it was set in the last place), and after that we check for QSettings that complement the PG service settings.

**Other details**

Note the current PG service definition will take precedence over corresponding stored QSettings.

Also note that SSLMode is not being stored in QSettings (see https://github.com/opengisch/QgisModelBakerLibrary/blob/412e60ccf4a0cf96432470c49d3eb725489626de/modelbaker/db_factory/pg_command_config_manager.py#L149-L173). 

[PR #96](https://github.com/opengisch/QgisModelBakerLibrary/pull/96) to the underlying lib fixes that.


-------------

Fix #709 