### PR TITLE
[tests] Test that PG service settings are remembered

### DIFF
--- a/QgisModelBaker/tests/test_pgservice.py
+++ b/QgisModelBaker/tests/test_pgservice.py
@@ -17,15 +17,20 @@
 """
 
 import os
+import shutil
 
 from qgis.testing import start_app, unittest
 
+import QgisModelBaker.libs.modelbaker.libs.pgserviceparser as pgserviceparser
 from QgisModelBaker.gui.panel.pg_config_panel import PgConfigPanel
+from QgisModelBaker.libs.modelbaker.db_factory.pg_command_config_manager import (
+    PgCommandConfigManager,
+)
 from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbconfig import (
     Ili2DbCommandConfiguration,
 )
 from QgisModelBaker.libs.modelbaker.utils.globals import DbActionType
-from QgisModelBaker.tests.utils import testdata_path
+from QgisModelBaker.tests.utils import _testdata_path
 
 start_app()
 
@@ -35,7 +40,7 @@ class TestPgservice(unittest.TestCase):
     def setUpClass(cls):
         """Run before all tests."""
         cls.pgservicefile = os.environ.get("PGSERVICEFILE", None)
-        os.environ["PGSERVICEFILE"] = testdata_path("pgservice/pg_service.conf")
+        os.environ["PGSERVICEFILE"] = _testdata_path("pgservice/pg_service.conf")
 
     def test_pgservice_pg_config_panel(self):
 
@@ -58,8 +63,129 @@ class TestPgservice(unittest.TestCase):
         self.assertEqual(configuration.dbpwd, "secret")
         self.assertEqual(configuration.sslmode, "verify-ca")
 
+    def test_pgservice_settings_remembered(self):
+        pg_config_panel = PgConfigPanel(None, DbActionType.EXPORT)
+        pg_config_panel.show()
+
+        index_postgis_test = pg_config_panel.pg_service_combo_box.findData(
+            "postgis_test", PgConfigPanel._SERVICE_COMBOBOX_ROLE.DBSERVICE
+        )
+        self.assertIsNot(index_postgis_test, -1)
+
+        # Select the pg service and check additional fields' default values
+        # e.g., schema
+        pg_config_panel.pg_service_combo_box.setCurrentIndex(index_postgis_test)
+        self.assertEqual(pg_config_panel.pg_schema_combo_box.currentText(), "")
+
+        # Save to QSettings
+        configuration = Ili2DbCommandConfiguration()
+        pg_config_panel.get_fields(configuration)
+        config_manager = PgCommandConfigManager(configuration)
+        config_manager.save_config_in_qsettings()
+
+        # Restart panel and restore QSettings
+        pg_config_panel.close()
+
+        pg_config_panel = PgConfigPanel(None, DbActionType.EXPORT)
+        pg_config_panel.show()
+
+        configuration = Ili2DbCommandConfiguration()  # New config object
+        config_manager = PgCommandConfigManager(configuration)
+        config_manager.load_config_from_qsettings()
+        pg_config_panel.set_fields(configuration)
+
+        # Check PG service settings and additional QSettings
+        self.assertEqual(
+            pg_config_panel.pg_service_combo_box.currentData(), "postgis_test"
+        )
+        self.assertEqual(pg_config_panel.pg_host_line_edit.text(), "db.test.com")
+        self.assertEqual(pg_config_panel.pg_port_line_edit.text(), "5433")
+        self.assertEqual(pg_config_panel.pg_database_line_edit.text(), "postgres")
+
+        self.assertEqual(pg_config_panel.pg_schema_combo_box.currentText(), "")
+        self.assertEqual(
+            pg_config_panel.pg_ssl_mode_combo_box.currentText(), "verify-ca"
+        )
+        self.assertEqual(pg_config_panel.pg_auth_settings.password(), "secret")
+        self.assertEqual(pg_config_panel.pg_auth_settings.username(), "postgres")
+
+    def test_pgservice_modified_settings_remembered(self):
+        # Switch to a copy pg_service.conf
+        shutil.copy(
+            _testdata_path("pgservice/pg_service.conf"),
+            _testdata_path("pgservice/pg_service_mod.conf"),
+        )
+        os.environ["PGSERVICEFILE"] = _testdata_path("pgservice/pg_service_mod.conf")
+
+        # Remove password setting from the copied pg_service.conf
+        config = pgserviceparser.full_config()
+        config.remove_option("postgis_test", "password")
+        with open(pgserviceparser.conf_path(), "w") as configfile:
+            config.write(configfile, space_around_delimiters=False)
+
+        pg_config_panel = PgConfigPanel(None, DbActionType.EXPORT)
+        pg_config_panel.show()
+
+        index_postgis_test = pg_config_panel.pg_service_combo_box.findData(
+            "postgis_test", PgConfigPanel._SERVICE_COMBOBOX_ROLE.DBSERVICE
+        )
+        self.assertIsNot(index_postgis_test, -1)
+
+        # Select the pg service and check additional fields' default values
+        # e.g., schema
+        pg_config_panel.pg_service_combo_box.setCurrentIndex(index_postgis_test)
+        self.assertEqual(pg_config_panel.pg_schema_combo_box.currentText(), "")
+
+        # This time, set a schema, ssl-mode and password by hand.
+        # We'll check that:
+        # 1. schema is remembered,
+        # 2. ssl-mode will be obtained from the PG service and not from QSettings.
+        # 3. password will be obtained from QSettings.
+        pg_config_panel.pg_schema_combo_box.setCurrentText("my_schema")
+        index = pg_config_panel.pg_ssl_mode_combo_box.findData("require")
+        pg_config_panel.pg_ssl_mode_combo_box.setCurrentIndex(index)
+        self.assertEqual(pg_config_panel.pg_ssl_mode_combo_box.currentData(), "require")
+        pg_config_panel.pg_auth_settings.setPassword("new_secret")
+
+        # Save to QSettings
+        configuration = Ili2DbCommandConfiguration()
+        pg_config_panel.get_fields(configuration)
+        config_manager = PgCommandConfigManager(configuration)
+        config_manager.save_config_in_qsettings()
+
+        # Restart panel and restore QSettings
+        pg_config_panel.close()
+
+        pg_config_panel = PgConfigPanel(None, DbActionType.EXPORT)
+        pg_config_panel.show()
+
+        configuration = Ili2DbCommandConfiguration()  # New config object
+        config_manager = PgCommandConfigManager(configuration)
+        config_manager.load_config_from_qsettings()
+        pg_config_panel.set_fields(configuration)
+
+        # Check PG service settings and additional QSettings
+        self.assertEqual(
+            pg_config_panel.pg_service_combo_box.currentData(), "postgis_test"
+        )
+        self.assertEqual(pg_config_panel.pg_host_line_edit.text(), "db.test.com")
+        self.assertEqual(pg_config_panel.pg_port_line_edit.text(), "5433")
+        self.assertEqual(pg_config_panel.pg_database_line_edit.text(), "postgres")
+
+        self.assertEqual(pg_config_panel.pg_schema_combo_box.currentText(), "my_schema")
+        self.assertEqual(
+            pg_config_panel.pg_ssl_mode_combo_box.currentText(), "verify-ca"
+        )
+        self.assertEqual(pg_config_panel.pg_auth_settings.password(), "new_secret")
+        self.assertEqual(pg_config_panel.pg_auth_settings.username(), "postgres")
+
+        os.environ["PGSERVICEFILE"] = _testdata_path("pgservice/pg_service.conf")
+
     @classmethod
     def tearDownClass(cls):
         """Run after all tests."""
         if cls.pgservicefile:
             os.environ["PGSERVICEFILE"] = cls.pgservicefile
+
+        if os.path.exists(_testdata_path("pgservice/pg_service_mod.conf")):
+            os.remove(_testdata_path("pgservice/pg_service_mod.conf"))

--- a/QgisModelBaker/tests/test_pgservice.py
+++ b/QgisModelBaker/tests/test_pgservice.py
@@ -30,7 +30,7 @@ from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbconfig import (
     Ili2DbCommandConfiguration,
 )
 from QgisModelBaker.libs.modelbaker.utils.globals import DbActionType
-from QgisModelBaker.tests.utils import _testdata_path
+from QgisModelBaker.tests.utils import path_testdata
 
 start_app()
 
@@ -40,7 +40,7 @@ class TestPgservice(unittest.TestCase):
     def setUpClass(cls):
         """Run before all tests."""
         cls.pgservicefile = os.environ.get("PGSERVICEFILE", None)
-        os.environ["PGSERVICEFILE"] = _testdata_path("pgservice/pg_service.conf")
+        os.environ["PGSERVICEFILE"] = path_testdata("pgservice/pg_service.conf")
 
     def test_pgservice_pg_config_panel(self):
 
@@ -112,10 +112,10 @@ class TestPgservice(unittest.TestCase):
     def test_pgservice_modified_settings_remembered(self):
         # Switch to a copy pg_service.conf
         shutil.copy(
-            _testdata_path("pgservice/pg_service.conf"),
-            _testdata_path("pgservice/pg_service_mod.conf"),
+            path_testdata("pgservice/pg_service.conf"),
+            path_testdata("pgservice/pg_service_mod.conf"),
         )
-        os.environ["PGSERVICEFILE"] = _testdata_path("pgservice/pg_service_mod.conf")
+        os.environ["PGSERVICEFILE"] = path_testdata("pgservice/pg_service_mod.conf")
 
         # Remove password setting from the copied pg_service.conf
         config = pgserviceparser.full_config()
@@ -179,7 +179,7 @@ class TestPgservice(unittest.TestCase):
         self.assertEqual(pg_config_panel.pg_auth_settings.password(), "new_secret")
         self.assertEqual(pg_config_panel.pg_auth_settings.username(), "postgres")
 
-        os.environ["PGSERVICEFILE"] = _testdata_path("pgservice/pg_service.conf")
+        os.environ["PGSERVICEFILE"] = path_testdata("pgservice/pg_service.conf")
 
     @classmethod
     def tearDownClass(cls):
@@ -187,5 +187,5 @@ class TestPgservice(unittest.TestCase):
         if cls.pgservicefile:
             os.environ["PGSERVICEFILE"] = cls.pgservicefile
 
-        if os.path.exists(_testdata_path("pgservice/pg_service_mod.conf")):
-            os.remove(_testdata_path("pgservice/pg_service_mod.conf"))
+        if os.path.exists(path_testdata("pgservice/pg_service_mod.conf")):
+            os.remove(path_testdata("pgservice/pg_service_mod.conf"))

--- a/QgisModelBaker/tests/utils.py
+++ b/QgisModelBaker/tests/utils.py
@@ -4,6 +4,6 @@ import pytest
 
 
 @pytest.mark.skip("This is a utility function, not a test function")
-def _testdata_path(path):
+def path_testdata(path):
     basepath = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(basepath, "testdata", path)

--- a/QgisModelBaker/tests/utils.py
+++ b/QgisModelBaker/tests/utils.py
@@ -4,6 +4,6 @@ import pytest
 
 
 @pytest.mark.skip("This is a utility function, not a test function")
-def testdata_path(path):
+def _testdata_path(path):
     basepath = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(basepath, "testdata", path)


### PR DESCRIPTION
As well as additional settings given by users like schema, ssl-mode and auth config.

Note:
Added a prefix on a test utility function to avoid the `SKIPPED (This is a utility function, not a test function)` notice when running tests.

Follow-up #918 