### PR TITLE
Consequent use of database settings in Export / Dataset Manager

### DIFF
--- a/QgisModelBaker/gui/dataset_manager.py
+++ b/QgisModelBaker/gui/dataset_manager.py
@@ -17,21 +17,25 @@
 """
 
 from qgis.core import QgsApplication, QgsMapLayer, QgsProject
-from qgis.PyQt.QtCore import QSettings, Qt, QTimer
-from qgis.PyQt.QtWidgets import QDialog, QHeaderView, QMessageBox, QTableView
+from qgis.gui import QgsMessageBar
+from qgis.PyQt.QtCore import QSettings, Qt
+from qgis.PyQt.QtWidgets import (
+    QDialog,
+    QHeaderView,
+    QMessageBox,
+    QSizePolicy,
+    QTableView,
+)
 
 import QgisModelBaker.libs.modelbaker.utils.db_utils as db_utils
 from QgisModelBaker.gui.basket_manager import BasketManagerDialog
 from QgisModelBaker.gui.edit_dataset_name import EditDatasetDialog
-from QgisModelBaker.gui.panel import db_panel_utils
 from QgisModelBaker.libs.modelbaker.db_factory.db_simple_factory import DbSimpleFactory
 from QgisModelBaker.libs.modelbaker.iliwrapper.globals import DbIliMode
 from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbconfig import (
     Ili2DbCommandConfiguration,
 )
-from QgisModelBaker.libs.modelbaker.utils.globals import DbActionType
 from QgisModelBaker.utils import gui_utils
-from QgisModelBaker.utils.globals import displayDbIliMode
 from QgisModelBaker.utils.gui_utils import DatasetModel
 
 DIALOG_UI = gui_utils.get_ui_class("dataset_manager.ui")
@@ -42,28 +46,17 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
 
         QDialog.__init__(self, parent)
         self.iface = iface
+        self.embedded = wizard_embedded
         self._close_editing()
 
         self.setupUi(self)
         self.buttonBox.accepted.connect(self._accepted)
         self.buttonBox.rejected.connect(self._rejected)
+        self.bar = QgsMessageBar()
+        self.bar.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Expanding)
+        self.info_layout.addWidget(self.bar, 0, Qt.AlignTop)
 
-        self.type_combo_box.clear()
-        self._lst_panel = dict()
         self.db_simple_factory = DbSimpleFactory()
-
-        for db_id in self.db_simple_factory.get_db_list(False):
-            self.type_combo_box.addItem(displayDbIliMode[db_id], db_id)
-            item_panel = db_panel_utils.get_config_panel(
-                db_id, self, DbActionType.EXPORT
-            )
-            self._lst_panel[db_id] = item_panel
-            self.db_layout.addWidget(item_panel)
-
-        self.type_combo_box.currentIndexChanged.connect(self._type_changed)
-
-        # when opened by the wizard it uses the current db connection settings and should not be changeable
-        self.db_frame.setHidden(wizard_embedded)
 
         self.dataset_model = DatasetModel()
         self.dataset_tableview.horizontalHeader().setSectionResizeMode(
@@ -74,27 +67,13 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
         self.dataset_tableview.setSelectionMode(QTableView.SingleSelection)
         self.dataset_tableview.setModel(self.dataset_model)
 
-        self._restore_configuration()
-
-        # refresh the models on changing values but avoid massive db connects by timer
-        self.refreshTimer = QTimer()
-        self.refreshTimer.setSingleShot(True)
-        self.refreshTimer.timeout.connect(
-            lambda: self._refresh_datasets(self._updated_configuration())
-        )
-
-        for key, value in self._lst_panel.items():
-            value.notify_fields_modified.connect(self._request_for_refresh_datasets)
-
-        self._refresh_datasets(self._updated_configuration())
-
         self.add_button.clicked.connect(self._add_dataset)
         self.edit_button.clicked.connect(self._edit_dataset)
         self.dataset_tableview.selectionModel().selectionChanged.connect(
             lambda: self._enable_dataset_handling(True)
         )
 
-        if wizard_embedded:
+        if self.embedded:
             # While performing an Import Data operation,
             # baskets should not be shown, since the operation
             # will create a new basket for the chosen dataset.
@@ -104,6 +83,9 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
 
         self.add_button.setIcon(QgsApplication.getThemeIcon("/symbologyAdd.svg"))
         self.edit_button.setIcon(QgsApplication.getThemeIcon("/symbologyEdit.svg"))
+
+        self.configuration = self._evaluated_configuration()
+        self._refresh_datasets()
 
     def _close_editing(self):
         editable_layers = []
@@ -137,45 +119,33 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
         self.edit_button.setEnabled(self._valid_selection())
         self.basket_manager_button.setEnabled(self._valid_selection())
 
-    def _type_changed(self):
-        ili_mode = self.type_combo_box.currentData()
-        db_id = ili_mode & ~DbIliMode.ili
-
-        self.db_wrapper_group_box.setTitle(displayDbIliMode[db_id])
-
-        # Refresh panels
-        for key, value in self._lst_panel.items():
-            is_current_panel_selected = db_id == key
-            value.setVisible(is_current_panel_selected)
-            if is_current_panel_selected:
-                value._show_panel()
-        self._refresh_datasets(self._updated_configuration())
-
-    def _request_for_refresh_datasets(self):
-        # hold refresh back
-        self.refreshTimer.start(500)
-
-    def _refresh_datasets(self, configuration):
-        db_connector = db_utils.get_db_connector(configuration)
-        if db_connector and db_connector.get_basket_handling:
+    def _refresh_datasets(self):
+        db_connector = db_utils.get_db_connector(self.configuration)
+        if db_connector and db_connector.get_basket_handling():
             self._enable_dataset_handling(True)
             return self.dataset_model.refresh_model(db_connector)
         else:
             self._enable_dataset_handling(False)
+            self.bar.pushWarning(
+                self.tr("Warning"),
+                self.tr(
+                    "This source does not support datasets and baskets (recreate it with basket columns)."
+                ),
+            )
             return self.dataset_model.clear()
 
     def _add_dataset(self):
-        db_connector = db_utils.get_db_connector(self._updated_configuration())
-        if db_connector and db_connector.get_basket_handling:
+        db_connector = db_utils.get_db_connector(self.configuration)
+        if db_connector and db_connector.get_basket_handling():
             edit_dataset_dialog = EditDatasetDialog(self, db_connector)
             edit_dataset_dialog.exec_()
-            self._refresh_datasets(self._updated_configuration())
+            self._refresh_datasets()
             self._jump_to_entry(edit_dataset_dialog.dataset_line_edit.text())
 
     def _edit_dataset(self):
         if self._valid_selection():
-            db_connector = db_utils.get_db_connector(self._updated_configuration())
-            if db_connector and db_connector.get_basket_handling:
+            db_connector = db_utils.get_db_connector(self.configuration)
+            if db_connector and db_connector.get_basket_handling():
                 dataset = (
                     self.dataset_tableview.selectedIndexes()[0].data(
                         int(DatasetModel.Roles.TID)
@@ -186,13 +156,13 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
                 )
                 edit_dataset_dialog = EditDatasetDialog(self, db_connector, dataset)
                 edit_dataset_dialog.exec_()
-                self._refresh_datasets(self._updated_configuration())
+                self._refresh_datasets()
                 self._jump_to_entry(edit_dataset_dialog.dataset_line_edit.text())
 
     def _open_basket_manager(self):
         if self._valid_selection():
-            db_connector = db_utils.get_db_connector(self._updated_configuration())
-            if db_connector and db_connector.get_basket_handling:
+            db_connector = db_utils.get_db_connector(self.configuration)
+            if db_connector and db_connector.get_basket_handling():
                 datasetname = self.dataset_tableview.selectedIndexes()[0].data(
                     int(DatasetModel.Roles.DATASETNAME)
                 )
@@ -213,45 +183,94 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
             self.dataset_tableview.setCurrentIndex(matches[0])
             self.dataset_tableview.scrollTo(matches[0])
 
-    def _restore_configuration(self):
-        settings = QSettings()
+    def _evaluated_configuration(self):
+        configuration = Ili2DbCommandConfiguration()
 
+        if self.embedded:
+            # when embedded, just use the current configuration
+            configuration = self._restored_configuration()
+        else:
+            valid = False
+            mode = None
+
+            layer = self._relevant_layer()
+            if layer:
+                source_provider = layer.dataProvider()
+                valid, mode = db_utils.get_configuration_from_sourceprovider(
+                    source_provider, configuration
+                )
+                configuration.tool = mode
+                source_info_text = self.tr(
+                    "<body><p>It's the datasource of the current project, evaluated by layer <b>{}</b>.</p>"
+                ).format(layer.name())
+
+            # when no valid configuration has been read from layer(s), take the last stored
+            if not valid or not mode:
+                configuration = self._restored_configuration()
+                source_info_text = self.tr(
+                    "<p>It's the last time used datasource, since no valid layer in the current project (probably empty project).</p>"
+                )
+
+            if configuration.tool == DbIliMode.gpkg:
+                self.info_label.setText(
+                    self.tr(
+                        """<html><head/><body><p><b>Modify datasets and baskets in the GeoPackage databasefile <span style=" font-family:'monospace'; color:'#9BCADE';">{}</span></b></p>{}</body></html>"""
+                    ).format(configuration.dbfile, source_info_text)
+                )
+            elif (
+                configuration.tool == DbIliMode.pg
+                or configuration.tool == DbIliMode.mssql
+            ):
+                self.info_label.setText(
+                    self.tr(
+                        """<html><head/><body><p><b>Modify datasets and baskets in the schema <span style=" font-family:'monospace'; color:'#9BCADE';">{}</span> at the PostgreSQL database <span style=" font-family:'monospace'; color:'#9BCADE';">{}</span></b></p>{}</body></html>"""
+                    ).format(
+                        configuration.dbschema, configuration.database, source_info_text
+                    )
+                )
+            else:
+                self.info_label.setText(
+                    self.tr(
+                        """<html><head/><body><p><b>No valid datasource found. Open or create an INTERLIS based QGIS project first.</b></p></body></html>"""
+                    )
+                )
+
+        return configuration
+
+    def _relevant_layer(self):
+        layer = None
+
+        for layer in [self.iface.activeLayer()] + list(
+            QgsProject.instance().mapLayers().values()
+        ):
+            if layer and layer.dataProvider() and layer.dataProvider().isValid():
+                return layer
+
+    def _restored_configuration(self):
+        settings = QSettings()
+        configuration = Ili2DbCommandConfiguration()
         for db_id in self.db_simple_factory.get_db_list(False):
-            configuration = Ili2DbCommandConfiguration()
             db_factory = self.db_simple_factory.create_factory(db_id)
             config_manager = db_factory.get_db_command_config_manager(configuration)
             config_manager.load_config_from_qsettings()
-            self._lst_panel[db_id].set_fields(configuration)
 
         mode = settings.value("QgisModelBaker/importtype")
         mode = DbIliMode[mode] if mode else self.db_simple_factory.default_database
         mode = mode & ~DbIliMode.ili
-
-        self.type_combo_box.setCurrentIndex(self.type_combo_box.findData(mode))
-        self._type_changed()
-
-    def _updated_configuration(self):
-        configuration = Ili2DbCommandConfiguration()
-
-        mode = self.type_combo_box.currentData()
-        self._lst_panel[mode].get_fields(configuration)
-
         configuration.tool = mode
-        configuration.db_ili_version = db_utils.db_ili_version(configuration)
+        print(configuration.dbschema)
         return configuration
 
     def _save_configuration(self, configuration):
         settings = QSettings()
-        settings.setValue(
-            "QgisModelBaker/importtype", self.type_combo_box.currentData().name
-        )
-        mode = self.type_combo_box.currentData()
+        settings.setValue("QgisModelBaker/importtype", configuration.tool.name)
+        mode = configuration.tool
         db_factory = self.db_simple_factory.create_factory(mode)
         config_manager = db_factory.get_db_command_config_manager(configuration)
         config_manager.save_config_in_qsettings()
 
     def _accepted(self):
-        self._save_configuration(self._updated_configuration())
+        self._save_configuration(self.configuration)
         self.close()
 
     def _rejected(self):

--- a/QgisModelBaker/gui/dataset_manager.py
+++ b/QgisModelBaker/gui/dataset_manager.py
@@ -95,12 +95,12 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
         )
 
         if wizard_embedded:
-            self.basket_manager_button.clicked.connect(self._open_basket_manager)
-        else:
             # While performing an Import Data operation,
             # baskets should not be shown, since the operation
             # will create a new basket for the chosen dataset.
             self.basket_manager_button.setVisible(False)
+        else:
+            self.basket_manager_button.clicked.connect(self._open_basket_manager)
 
         self.add_button.setIcon(QgsApplication.getThemeIcon("/symbologyAdd.svg"))
         self.edit_button.setIcon(QgsApplication.getThemeIcon("/symbologyEdit.svg"))

--- a/QgisModelBaker/gui/dataset_manager.py
+++ b/QgisModelBaker/gui/dataset_manager.py
@@ -258,7 +258,6 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
         mode = DbIliMode[mode] if mode else self.db_simple_factory.default_database
         mode = mode & ~DbIliMode.ili
         configuration.tool = mode
-        print(configuration.dbschema)
         return configuration
 
     def _save_configuration(self, configuration):

--- a/QgisModelBaker/gui/topping_wizard/referencedata_page.py
+++ b/QgisModelBaker/gui/topping_wizard/referencedata_page.py
@@ -30,11 +30,7 @@ from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
     IliDataFileCompleterDelegate,
     IliDataItemModel,
 )
-from QgisModelBaker.libs.modelbaker.utils.qt_utils import (
-    FileValidator,
-    QValidator,
-    make_file_selector,
-)
+from QgisModelBaker.libs.modelbaker.utils.qt_utils import make_file_selector
 from QgisModelBaker.utils import gui_utils
 from QgisModelBaker.utils.gui_utils import SourceModel
 
@@ -64,7 +60,7 @@ class ReferencedataPage(QWizardPage, PAGE_UI):
             )
         )
 
-        self.fileValidator = FileValidator(
+        self.fileValidator = gui_utils.FileValidator(
             pattern=["*." + ext for ext in self.ValidExtensions], allow_empty=False
         )
 
@@ -197,7 +193,7 @@ class ReferencedataPage(QWizardPage, PAGE_UI):
         return (
             len(match_contains) == 1
             or self.fileValidator.validate(self.input_line_edit.text(), 0)[0]
-            == QValidator.Acceptable
+            == gui_utils.QValidator.Acceptable
         )
 
     def _valid_selection(self):

--- a/QgisModelBaker/gui/workflow_wizard/database_selection_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/database_selection_page.py
@@ -17,12 +17,16 @@
  ***************************************************************************/
 """
 
+from qgis.core import QgsProject
 from qgis.PyQt.QtCore import QSettings
 from qgis.PyQt.QtWidgets import QWizardPage
 
 from QgisModelBaker.gui.panel import db_panel_utils
 from QgisModelBaker.libs.modelbaker.db_factory.db_simple_factory import DbSimpleFactory
 from QgisModelBaker.libs.modelbaker.iliwrapper.globals import DbIliMode
+from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbconfig import (
+    Ili2DbCommandConfiguration,
+)
 from QgisModelBaker.libs.modelbaker.utils import db_utils
 from QgisModelBaker.libs.modelbaker.utils.globals import DbActionType
 from QgisModelBaker.utils import gui_utils
@@ -83,21 +87,38 @@ class DatabaseSelectionPage(QWizardPage, PAGE_UI):
             if is_current_panel_selected:
                 value._show_panel()
 
-    def restore_configuration(self, configuration):
-        # takes settings from QSettings and provides it to the gui (not the configuration)
-        # it needs the configuration - this is the same for Schema or Data Config
-        settings = QSettings()
+    def restore_configuration(self, configuration, get_config_from_project=False):
+        configuration = Ili2DbCommandConfiguration()
+        valid = False
+        mode = None
 
-        for db_id in self.db_simple_factory.get_db_list(False):
-            db_factory = self.db_simple_factory.create_factory(db_id)
-            config_manager = db_factory.get_db_command_config_manager(configuration)
-            config_manager.load_config_from_qsettings()
-            self._lst_panel[db_id].set_fields(configuration)
+        if get_config_from_project:
+            # tries to take settings from the project
+            layer = self._relevant_layer()
+            if layer:
+                source_provider = layer.dataProvider()
+                valid, mode = db_utils.get_configuration_from_sourceprovider(
+                    source_provider, configuration
+                )
 
-        mode = settings.value("QgisModelBaker/importtype")
-        mode = DbIliMode[mode] if mode else self.db_simple_factory.default_database
-        mode = mode & ~DbIliMode.ili
+        if valid and mode:
+            # uses the settings from the project and provides it to the gui
+            configuration.tool = mode
+        else:
+            # takes settings from QSettings and provides it to the gui
+            settings = QSettings()
 
+            for db_id in self.db_simple_factory.get_db_list(False):
+                db_factory = self.db_simple_factory.create_factory(db_id)
+                config_manager = db_factory.get_db_command_config_manager(configuration)
+                config_manager.load_config_from_qsettings()
+
+            mode = settings.value("QgisModelBaker/importtype")
+            mode = DbIliMode[mode] if mode else self.db_simple_factory.default_database
+            mode = mode & ~DbIliMode.ili
+            configuration.tool = mode
+
+        self._lst_panel[mode].set_fields(configuration)
         self.type_combo_box.setCurrentIndex(self.type_combo_box.findData(mode))
         self._type_changed()
 
@@ -118,6 +139,15 @@ class DatabaseSelectionPage(QWizardPage, PAGE_UI):
         db_factory = self.db_simple_factory.create_factory(mode)
         config_manager = db_factory.get_db_command_config_manager(updated_configuration)
         config_manager.save_config_in_qsettings()
+
+    def _relevant_layer(self):
+        layer = None
+
+        for layer in [self.workflow_wizard.iface.activeLayer()] + list(
+            QgsProject.instance().mapLayers().values()
+        ):
+            if layer and layer.dataProvider() and layer.dataProvider().isValid():
+                return layer
 
     def is_valid(self):
         db_id = self.type_combo_box.currentData()

--- a/QgisModelBaker/gui/workflow_wizard/import_source_selection_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_source_selection_page.py
@@ -20,6 +20,7 @@
 
 from qgis.core import QgsApplication
 from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QValidator
 from qgis.PyQt.QtWidgets import (
     QApplication,
     QCompleter,

--- a/QgisModelBaker/gui/workflow_wizard/import_source_selection_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_source_selection_page.py
@@ -35,9 +35,7 @@ from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
     ModelCompleterDelegate,
 )
 from QgisModelBaker.libs.modelbaker.utils.qt_utils import (
-    FileValidator,
     OverrideCursor,
-    QValidator,
     make_file_selector,
 )
 from QgisModelBaker.utils import gui_utils
@@ -67,7 +65,7 @@ class ImportSourceSelectionPage(QWizardPage, PAGE_UI):
             )
         )
 
-        self.fileValidator = FileValidator(
+        self.fileValidator = gui_utils.FileValidator(
             pattern=["*." + ext for ext in self.ValidExtensions], allow_empty=False
         )
 

--- a/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
@@ -39,10 +39,7 @@ from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
     IliToppingFileItemModel,
 )
 from QgisModelBaker.libs.modelbaker.utils.globals import OptimizeStrategy
-from QgisModelBaker.libs.modelbaker.utils.qt_utils import (
-    FileValidator,
-    make_file_selector,
-)
+from QgisModelBaker.libs.modelbaker.utils.qt_utils import make_file_selector
 from QgisModelBaker.utils import gui_utils
 from QgisModelBaker.utils.globals import CATALOGUE_DATASETNAME
 from QgisModelBaker.utils.gui_utils import TRANSFERFILE_MODELS_BLACKLIST, LogLevel
@@ -93,7 +90,7 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
                 file_filter=self.tr("Project Topping File (*.yaml *.YAML)"),
             )
         )
-        self.fileValidator = FileValidator(
+        self.fileValidator = gui_utils.FileValidator(
             pattern=["*." + ext for ext in self.ValidExtensions], allow_empty=False
         )
 

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -412,12 +412,12 @@ class WorkflowWizard(QWizard):
         if self.current_id == PageIds.ImportDatabaseSelection:
             # use schema config to restore
             self.import_database_selection_page.restore_configuration(
-                self.import_schema_configuration
+                self.import_schema_configuration, True
             )
 
         if self.current_id == PageIds.GenerateDatabaseSelection:
             self.generate_database_selection_page.restore_configuration(
-                self.import_schema_configuration
+                self.import_schema_configuration, True
             )
 
         if self.current_id == PageIds.ExportDatabaseSelection:

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -422,7 +422,7 @@ class WorkflowWizard(QWizard):
 
         if self.current_id == PageIds.ExportDatabaseSelection:
             self.export_database_selection_page.restore_configuration(
-                self.export_data_configuration
+                self.export_data_configuration, True
             )
 
         if self.current_id == PageIds.ImportSchemaConfiguration:

--- a/QgisModelBaker/ui/dataset_manager.ui
+++ b/QgisModelBaker/ui/dataset_manager.ui
@@ -6,46 +6,50 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>376</height>
+    <width>855</width>
+    <height>504</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dataset Manager</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <layout class="QGridLayout" name="gridLayout_3">
-     <item row="0" column="0">
-      <widget class="QTableView" name="dataset_tableview"/>
-     </item>
-     <item row="1" column="0">
-      <layout class="QGridLayout" name="gridLayout_4">
-       <item row="0" column="0">
-        <widget class="QToolButton" name="add_button">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QVBoxLayout" name="info_layout">
+       <item>
+        <widget class="QLabel" name="info_label">
          <property name="text">
-          <string>Create Dataset</string>
+          <string/>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
+      </layout>
+     </item>
+     <item>
+      <widget class="QTableView" name="dataset_tableview"/>
+     </item>
+     <item>
+      <layout class="QGridLayout" name="button_layout">
+       <item row="1" column="1">
         <widget class="QToolButton" name="edit_button">
          <property name="text">
           <string>Rename Dataset</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="2">
-        <widget class="QToolButton" name="basket_manager_button">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To create a &lt;span style=&quot; font-weight:600;&quot;&gt;basket&lt;/span&gt; per &lt;span style=&quot; font-weight:600;&quot;&gt;topic&lt;/span&gt; and &lt;span style=&quot; font-weight:600;&quot;&gt;dataset &lt;/span&gt;in the &lt;span style=&quot; font-style:italic;&quot;&gt;t_ili2db_basket&lt;/span&gt; table or not.&lt;/p&gt;&lt;p&gt;While a dataset is just an entry in the &lt;span style=&quot; font-style:italic;&quot;&gt;t_ili2db_dataset&lt;/span&gt; table, there must be baskets for each entry that can be selected. Usually there exists only one basket per topic and dataset.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
+       <item row="1" column="0">
+        <widget class="QToolButton" name="add_button">
          <property name="text">
-          <string>Manage baskets of selected dataset</string>
+          <string>Create Dataset</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="3">
+       <item row="1" column="3">
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -58,74 +62,21 @@
          </property>
         </spacer>
        </item>
+       <item row="1" column="2">
+        <widget class="QToolButton" name="basket_manager_button">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To create a &lt;span style=&quot; font-weight:600;&quot;&gt;basket&lt;/span&gt; per &lt;span style=&quot; font-weight:600;&quot;&gt;topic&lt;/span&gt; and &lt;span style=&quot; font-weight:600;&quot;&gt;dataset &lt;/span&gt;in the &lt;span style=&quot; font-style:italic;&quot;&gt;t_ili2db_basket&lt;/span&gt; table or not.&lt;/p&gt;&lt;p&gt;While a dataset is just an entry in the &lt;span style=&quot; font-style:italic;&quot;&gt;t_ili2db_dataset&lt;/span&gt; table, there must be baskets for each entry that can be selected. Usually there exists only one basket per topic and dataset.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Manage baskets of selected dataset</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>
    </item>
    <item row="1" column="0">
-    <widget class="QFrame" name="db_frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="1">
-       <widget class="QComboBox" name="type_combo_box">
-        <item>
-         <property name="text">
-          <string>Interlis (PostGIS)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Interlis (GeoPackage)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>PostGIS</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>GeoPackage</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QGroupBox" name="db_wrapper_group_box">
-        <property name="title">
-         <string/>
-        </property>
-        <layout class="QVBoxLayout" name="db_layout"/>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_10">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>88</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Source</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>

--- a/QgisModelBaker/ui/dataset_manager.ui
+++ b/QgisModelBaker/ui/dataset_manager.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>855</width>
-    <height>504</height>
+    <height>288</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
## Dataset Manager

Because you barely want to edit datasets on another datasource than the one you are currently using, Model Baker detects now automatically the source of your project (according to the selected layer). You cannot edit the datasource in the Dataset Manager anymore. We removed it because it leaded to confusion.

And what if my current layer is not a valid layer (e.g. a group or a WMS)?
> Then it goes through all the layers and takes the first valid one.

And what if I have no project opened at all? 
> Then it takes the last used connection (used anywhere - not only in Dataset Manager)

![Screenshot from 2024-06-21 13-04-34](https://github.com/opengisch/QgisModelBaker/assets/28384354/2082d175-a943-49e8-bf55-69dde402a06f)

### Without an opened project

![Screenshot from 2024-06-21 13-05-16](https://github.com/opengisch/QgisModelBaker/assets/28384354/c069f108-e8b1-4767-9376-1c60b3864d77)

### Embedded in the Wizard (takes the setting from the import)

![Screenshot from 2024-06-21 12-59-45](https://github.com/opengisch/QgisModelBaker/assets/28384354/9d9649a1-7624-4b15-93d7-22ff82780a18)

### Detecting a data source but without basket handling
![Screenshot from 2024-06-21 13-07-25](https://github.com/opengisch/QgisModelBaker/assets/28384354/7bf2cdd8-a22d-4da4-b4e7-ee3389ae2234)

### Some thoughts I made here

I like that with Model Baker the QGIS Window is still responsive. But we had to decide, what functions in Model Baker Window (Wizard or Dataset Manager) should be triggered on interactions in the QGIS Window. In Validaton it's clear, there you change the db-settings by changing the layer. For the Dataset Manager we get now the db-settings from the current layer as well, but I avoided that it triggers a layer change (because this could lead to faults and confusions). In case you opened with a wrongly activated layer, you have to change the db-settings by selecting the correct one and close and open the Dataset Manager again.

## Export

On export it does the same. It checks for layers in the current project and takes their data source. If no project or valid layer present, it takes the last used connection.

## And on import / generate

After some thoughts I decided to adapt the behavior here. Although on schema import you usually create a new schema / gpkg at the moment it just takes the last used connection, what is not better than take the one from the active project. And additionally I assume, that mostly the other parameters (like the db / host etc. or on GeoPackage the directory) are the same like the one of the opened project.

[Screencast from 21.06.2024 14:44:33.webm](https://github.com/opengisch/QgisModelBaker/assets/28384354/3bd09f36-0c73-4f99-aa09-e4879d0714b4)

And on Generate you have no project opened usually. But better have it everywhere in the same way...

Resolves #847