### PR TITLE
OID Manager settings for not-null and unique constraint

### DIFF
--- a/QgisModelBaker/gui/panel/layer_tids_panel.py
+++ b/QgisModelBaker/gui/panel/layer_tids_panel.py
@@ -251,7 +251,6 @@ class FieldExpressionDelegate(QStyledItemDelegate):
 
     def setModelData(self, editor, model, index):
         value = editor.expression()
-        print(f"new exp{value}")
         model.setData(index, value, int(Qt.EditRole))
 
     def updateEditorGeometry(self, editor, option, index):

--- a/QgisModelBaker/gui/panel/layer_tids_panel.py
+++ b/QgisModelBaker/gui/panel/layer_tids_panel.py
@@ -289,6 +289,12 @@ class LayerTIDsPanel(QWidget, WIDGET_UI):
         self.layer_tids_view.horizontalHeader().setSectionResizeMode(
             TIDModel.Columns.IN_FORM, QHeaderView.ResizeToContents
         )
+        self.layer_tids_view.horizontalHeader().setSectionResizeMode(
+            TIDModel.Columns.NOTNULL, QHeaderView.ResizeToContents
+        )
+        self.layer_tids_view.horizontalHeader().setSectionResizeMode(
+            TIDModel.Columns.UNIQUE, QHeaderView.ResizeToContents
+        )
 
         self.layer_tids_view.setItemDelegateForColumn(
             TIDModel.Columns.DEFAULT_VALUE,

--- a/QgisModelBaker/ui/basket_panel.ui
+++ b/QgisModelBaker/ui/basket_panel.ui
@@ -27,7 +27,11 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="QTableView" name="basket_view"/>
+    <widget class="QTableView" name="basket_view">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/QgisModelBaker/ui/layer_tids_panel.ui
+++ b/QgisModelBaker/ui/layer_tids_panel.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
+    <width>1127</width>
     <height>600</height>
    </rect>
   </property>
@@ -28,9 +28,15 @@
    </property>
    <item row="1" column="0">
     <widget class="QTableView" name="layer_tids_view">
-     <property name="sortingEnabled">
-      <bool>true</bool>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
      </property>
+     <property name="sortingEnabled">
+      <bool>false</bool>
+     </property>
+     <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+      <bool>false</bool>
+     </attribute>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
The settings for unique and not-null constraint are now provided by the OID Manger.

![image](https://github.com/opengisch/QgisModelBaker/assets/28384354/01dff661-46b1-4df7-8904-7c1d6bfd503b)

This requires this https://github.com/opengisch/QgisModelBakerLibrary/pull/103 where it sets the constraints when an OID is defined in the model and it does not set it when no OID is defined.