### PR TITLE
Remove override decorator 

### DIFF
--- a/QgisModelBaker/gui/panel/gpkg_config_panel.py
+++ b/QgisModelBaker/gui/panel/gpkg_config_panel.py
@@ -19,9 +19,6 @@ import logging
 
 from qgis.PyQt.QtGui import QValidator
 
-# Available in typing module from v3.12 on
-from typing_extensions import override
-
 from QgisModelBaker.libs.modelbaker.utils.globals import DbActionType
 from QgisModelBaker.libs.modelbaker.utils.qt_utils import (
     make_file_selector,
@@ -63,7 +60,6 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
 
         self.gpkg_file_line_edit.textChanged.connect(self.notify_fields_modified)
 
-    @override
     def _show_panel(self):
         if (
             self._db_action_type == DbActionType.GENERATE
@@ -98,16 +94,13 @@ class GpkgConfigPanel(DbConfigPanel, WIDGET_UI):
         self.gpkg_file_line_edit.textChanged.emit(self.gpkg_file_line_edit.text())
         self.gpkg_file_browse_button.clicked.connect(file_selector)
 
-    @override
     def get_fields(self, configuration):
         configuration.dbfile = self.gpkg_file_line_edit.text().strip()
         configuration.dbschema = None
 
-    @override
     def set_fields(self, configuration):
         self.gpkg_file_line_edit.setText(configuration.dbfile)
 
-    @override
     def is_valid(self):
         result = False
         message = ""

--- a/QgisModelBaker/gui/panel/mssql_config_panel.py
+++ b/QgisModelBaker/gui/panel/mssql_config_panel.py
@@ -17,9 +17,6 @@
 """
 import logging
 
-# Available in typing module from v3.12 on
-from typing_extensions import override
-
 from QgisModelBaker.libs.modelbaker.utils.globals import DbActionType
 from QgisModelBaker.utils import gui_utils
 from QgisModelBaker.utils.mssql_utils import get_odbc_drivers
@@ -68,7 +65,6 @@ class MssqlConfigPanel(DbConfigPanel, WIDGET_UI):
         self.mssql_user_line_edit.textChanged.connect(self.notify_fields_modified)
         self.mssql_password_line_edit.textChanged.connect(self.notify_fields_modified)
 
-    @override
     def _show_panel(self):
         if self._db_action_type == DbActionType.GENERATE:
             self.mssql_schema_line_edit.setPlaceholderText(
@@ -85,7 +81,6 @@ class MssqlConfigPanel(DbConfigPanel, WIDGET_UI):
         else:
             logging.error(f"Unknown action type: {self._db_action_type}")
 
-    @override
     def get_fields(self, configuration):
         configuration.dbhost = self.mssql_host_line_edit.text().strip()
         configuration.dbinstance = self.mssql_instance_line_edit.text().strip()
@@ -96,7 +91,6 @@ class MssqlConfigPanel(DbConfigPanel, WIDGET_UI):
         configuration.dbpwd = self.mssql_password_line_edit.text()
         configuration.db_odbc_driver = self.mssql_odbc_driver.currentText()
 
-    @override
     def set_fields(self, configuration):
         self.mssql_host_line_edit.setText(configuration.dbhost)
         self.mssql_instance_line_edit.setText(configuration.dbinstance)
@@ -110,7 +104,6 @@ class MssqlConfigPanel(DbConfigPanel, WIDGET_UI):
         if index != -1:
             self.mssql_odbc_driver.setCurrentIndex(index)
 
-    @override
     def is_valid(self):
         result = False
         message = ""

--- a/QgisModelBaker/gui/panel/pg_config_panel.py
+++ b/QgisModelBaker/gui/panel/pg_config_panel.py
@@ -21,9 +21,6 @@ from enum import IntEnum
 
 from qgis.PyQt.QtCore import Qt, QThread, QTimer
 
-# Available in typing module from v3.12 on
-from typing_extensions import override
-
 import QgisModelBaker.libs.modelbaker.utils.db_utils as db_utils
 from QgisModelBaker.libs.modelbaker.iliwrapper.globals import DbIliMode
 from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbconfig import (
@@ -185,7 +182,6 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
         except RuntimeError:
             pass
 
-    @override
     def _show_panel(self):
 
         self._fill_schema_combo_box()
@@ -204,7 +200,6 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
         else:
             logging.error(f"Unknown action type: {self._db_action_type}")
 
-    @override
     def get_fields(self, configuration):
 
         configuration.dbservice = self.pg_service_combo_box.currentData()
@@ -220,7 +215,6 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
 
         configuration.db_use_super_login = self.pg_use_super_login.isChecked()
 
-    @override
     def set_fields(self, configuration):
 
         service_config, error = db_utils.get_service_config(configuration.dbservice)
@@ -317,7 +311,6 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
             self.pg_auth_settings.setConfigId(configuration.dbauthid)
             self.pg_use_super_login.setChecked(configuration.db_use_super_login)
 
-    @override
     def is_valid(self):
         result = False
         message = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 psycopg2>=2.7.4
-typing-extensions>=4.4.0
 pytest
 pyodbc
 pyyaml


### PR DESCRIPTION
Apparently this leaded to issues. Not sure why. Seems older QGIS had the problem.

Fixes #945 and fixes #947