### PR TITLE
Concern multiple geometries per GeoPackage Table Frontend

### DIFF
--- a/QgisModelBaker/gui/ili2db_options.py
+++ b/QgisModelBaker/gui/ili2db_options.py
@@ -142,17 +142,12 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         # on gdal versions that dont support multiple geometries per table it's disabled
         if int(gdal.VersionInfo("VERSION_NUM")) < 3080000:
             self.create_gpkg_multigeom_groupbox.setHidden(True)
-            self.create_gpkg_multigeom_checkbox.setChecked(False)
         else:
             self.create_gpkg_multigeom_groupbox.setHidden(False)
-            self.create_gpkg_multigeom_checkbox.setChecked(
-                False
-            )  # maybe in future this could be true...
             self.create_gpkg_multigeom_checkbox.setToolTip(
                 """<html><head/><body>
             <p>If the INTERLIS model has classes that contain <span style=" font-weight:600;">multiple geometries</span>, tables with multiple geometry columns can be created in <span style=" font-weight:600;">GeoPackage</span>.</p>
-            <p><br/></p
-            ><p>This function is not standardized and requires <span style=" font-weight:600;">GDAL version &gt;= 3.8</span> to run in QGIS (your current QGIS version is <span style=" font-weight:600;">{qgis_version}</span> with GDAL <span style=" font-weight:600;">{gdal_version},</span> but note that others with lower 3.8 versions <span style=" font-weight:600;">will not be able </span>to read this GeoPackage or create a QGIS project from it.</p>
+            <p>This function is not standardized and such tables with multiple geometries require <span style=" font-weight:600;">GDAL version &gt;= 3.8</span> to run in QGIS (your current QGIS version is <span style=" font-weight:600;">{qgis_version}</span> with GDAL <span style=" font-weight:600;">{gdal_version},</span> but note that others with lower 3.8 versions <span style=" font-weight:600;">will not be able </span>to read such tables in the created QGIS project.</p>
             </body></html>""".format(
                     qgis_version=Qgis.QGIS_VERSION,
                     gdal_version=gdal.VersionInfo("RELEASE_NAME"),
@@ -259,7 +254,9 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
             "QgisModelBaker/ili2db/create_import_tid", defaultValue=True, type=bool
         )
         create_gpkg_multigeom = settings.value(
-            "QgisModelBaker/ili2db/create_gpkg_multigeom", defaultValue=True, type=bool
+            "QgisModelBaker/ili2db/create_gpkg_multigeom",
+            defaultValue=True,
+            type=bool,
         )
         stroke_arcs = settings.value(
             "QgisModelBaker/ili2db/stroke_arcs", defaultValue=True, type=bool
@@ -267,7 +264,10 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
 
         self.create_basket_col_checkbox.setChecked(create_basket_col)
         self.create_import_tid_checkbox.setChecked(create_import_tid)
-        self.create_gpkg_multigeom_checkbox.setChecked(create_gpkg_multigeom)
+        if int(gdal.VersionInfo("VERSION_NUM")) >= 3080000:
+            self.create_gpkg_multigeom_checkbox.setChecked(create_gpkg_multigeom)
+        else:
+            self.create_gpkg_multigeom_checkbox.setChecked(False)
         self.stroke_arcs_checkbox.setChecked(stroke_arcs)
         self.toml_file_line_edit.setText(settings.value(self.toml_file_key))
 

--- a/QgisModelBaker/gui/ili2db_options.py
+++ b/QgisModelBaker/gui/ili2db_options.py
@@ -147,7 +147,7 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
             self.create_gpkg_multigeom_checkbox.setToolTip(
                 """<html><head/><body>
             <p>If the INTERLIS model has classes that contain <span style=" font-weight:600;">multiple geometries</span>, tables with multiple geometry columns can be created in <span style=" font-weight:600;">GeoPackage</span>.</p>
-            <p>This function is not standardized and such tables with multiple geometries require <span style=" font-weight:600;">GDAL version &gt;= 3.8</span> to run in QGIS (your current QGIS version is <span style=" font-weight:600;">{qgis_version}</span> with GDAL <span style=" font-weight:600;">{gdal_version}</span>, but note that others with lower 3.8 versions <span style=" font-weight:600;">will not be able </span>to read such tables in the created QGIS project.</p>
+            <p>This function is not standardized and such tables with multiple geometries require <span style=" font-weight:600;">GDAL version &gt;= 3.8</span> to run in QGIS (yours is <span style=" font-weight:600;">{gdal_version}</span>, but note that others with lower 3.8 versions <span style=" font-weight:600;">will not be able </span>to read such tables in the created QGIS project.)</p>
             </body></html>""".format(
                     qgis_version=Qgis.QGIS_VERSION,
                     gdal_version=gdal.VersionInfo("RELEASE_NAME"),

--- a/QgisModelBaker/gui/ili2db_options.py
+++ b/QgisModelBaker/gui/ili2db_options.py
@@ -147,7 +147,7 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
             self.create_gpkg_multigeom_checkbox.setToolTip(
                 """<html><head/><body>
             <p>If the INTERLIS model has classes that contain <span style=" font-weight:600;">multiple geometries</span>, tables with multiple geometry columns can be created in <span style=" font-weight:600;">GeoPackage</span>.</p>
-            <p>This function is not standardized and such tables with multiple geometries require <span style=" font-weight:600;">GDAL version &gt;= 3.8</span> to run in QGIS (your current QGIS version is <span style=" font-weight:600;">{qgis_version}</span> with GDAL <span style=" font-weight:600;">{gdal_version},</span> but note that others with lower 3.8 versions <span style=" font-weight:600;">will not be able </span>to read such tables in the created QGIS project.</p>
+            <p>This function is not standardized and such tables with multiple geometries require <span style=" font-weight:600;">GDAL version &gt;= 3.8</span> to run in QGIS (your current QGIS version is <span style=" font-weight:600;">{qgis_version}</span> with GDAL <span style=" font-weight:600;">{gdal_version}</span>, but note that others with lower 3.8 versions <span style=" font-weight:600;">will not be able </span>to read such tables in the created QGIS project.</p>
             </body></html>""".format(
                     qgis_version=Qgis.QGIS_VERSION,
                     gdal_version=gdal.VersionInfo("RELEASE_NAME"),

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -136,6 +136,9 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         configuration.inheritance = self.ili2db_options.inheritance_type()
         configuration.create_basket_col = self.ili2db_options.create_basket_col()
         configuration.create_import_tid = self.ili2db_options.create_import_tid()
+        configuration.create_gpkg_multigeom = (
+            self.ili2db_options.create_gpkg_multigeom()
+        )
         configuration.stroke_arcs = self.ili2db_options.stroke_arcs()
         configuration.pre_script = self.ili2db_options.pre_script()
         configuration.post_script = self.ili2db_options.post_script()

--- a/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
@@ -22,7 +22,6 @@ import os
 import re
 
 import yaml
-
 from osgeo import gdal
 from qgis.core import Qgis, QgsApplication, QgsProject
 from qgis.PyQt.QtCore import Qt

--- a/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
@@ -754,7 +754,7 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
                 """
                 <html><head/><body style="background-color:powderblue;">
                      <p><b>This GeoPackage contains at least one table with multiple geometries</b></p>
-                    <p>These tables require <span style=" font-weight:600;">GDAL version &gt;= 3.8</span> to run in QGIS.<br/>Your current QGIS version is <span style=" font-weight:600;">{qgis_version}</span> with GDAL <span style=" font-weight:600;">{gdal_version}</span>.</p>
+                    <p>These tables require <span style=" font-weight:600;">GDAL version &gt;= 3.8</span> to run in QGIS, yours is <span style=" font-weight:600;">{gdal_version}</span>.</p>
                     <p>Means this won't work.</p>
                 </body></html>
                 """.format(
@@ -768,8 +768,8 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
                 """
                 <html><head/><body style="background-color:powderblue;">
                     <p><b>This GeoPackage contains at least one table with multiple geometries</b></p>
-                    <p>These tables require <span style=" font-weight:600;">GDAL version &gt;= 3.8</span> to run in QGIS.<br/>Your current QGIS version is <span style=" font-weight:600;">{qgis_version}</span> with GDAL <span style=" font-weight:600;">{gdal_version}</span>.</p>
-                    <p>But note that others with lower 3.8 version <span style=" font-weight:600;">will not be able </span>to read such tables in the created QGIS project.</p>
+                    <p>These tables require <span style=" font-weight:600;">GDAL version &gt;= 3.8</span> to run in QGIS, yours is <span style=" font-weight:600;">{gdal_version}</span>.</p>
+                    <p>But note that others with lower 3.8 version <span style=" font-weight:600;">will not be able</span> to read such tables in the created QGIS project.</p>
                 </body></html>
                 """.format(
                     qgis_version=Qgis.QGIS_VERSION,
@@ -777,12 +777,6 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
                 )
             )
         return True
-
-    def _multiple_geometry_gpkg_table(self):
-        if self.db_connector.multiple_geometry_tables() > 0:
-            return True
-
-        return false
 
     def help_text(self):
         logline = self.tr(

--- a/QgisModelBaker/ui/ili2db_options.ui
+++ b/QgisModelBaker/ui/ili2db_options.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>552</width>
-    <height>557</height>
+    <height>622</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,62 +17,58 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Stroke arcs</string>
+   <item row="7" column="0">
+    <widget class="QLabel" name="metaconfig_info_label">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:large; color:#341d5c;&quot;&gt;▪ &lt;/span&gt;&lt;span style=&quot; color:#341d5c;&quot;&gt;corresponds to the metaconfig &lt;/span&gt;&lt;span style=&quot; font-size:large; color:#c64600;&quot;&gt;▪ &lt;/span&gt;&lt;span style=&quot; color:#c64600;&quot;&gt;deviates from the metaconfig&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="stroke_arcs_checkbox">
-        <property name="toolTip">
-         <string>If this option is activated, circular arcs are stroked when importing the data</string>
-        </property>
-        <property name="text">
-         <string>Stroke Arcs</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="inheritance_group_box">
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="create_import_tid_groupbox">
      <property name="title">
-      <string>Inheritance type</string>
+      <string>Create Import Tid</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QRadioButton" name="smart1_radio_button">
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="create_import_tid_checkbox">
         <property name="toolTip">
-         <string>Form the inheritance hierarchy with a dynamic strategy. The NewClass strategy is used for classes that are
-referenced and whose base classes are not mapped using a NewClass strategy. Abstract classes are mapped
-using a SubClass strategy. Concrete classes, without a base class or their direct base classes with a SubClass
-strategy are mapped using a NewClass strategy. All other classes are mapped using a SuperClass strategy.</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Creates a new column t_ili_tid in all classes, which is mandatory and should be unique, not only for across the current database, but across the whole system.&lt;/p&gt;&lt;p&gt;Normally you should not enable this option directly, but rely on the INTERLIS model and ili2db. The former should have a line enabling OIDs (preferably with UUIDs) and the latter will make sure the database updates the new column every time a new record is created.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
-         <string>smart1Inheritance</string>
+         <string>Create Import Tid</string>
         </property>
         <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QRadioButton" name="smart2_radio_button">
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Create Basket Column</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="create_basket_col_checkbox">
         <property name="toolTip">
-         <string>Form the inheritance hierarchy with a dymamic strategy. Abstract classes are mapped using a SubClass
-strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Creates a new column t_basket in class tables which references entries in the additional table t_ili2db_basket.&lt;/p&gt;&lt;p&gt;The T_basket column needs to be filled with the basket to which an object belongs.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Warning&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If this option is enabled, it is required to make sure that this column is filled by the database, by default values on QGIS side or manually from the user.&lt;/p&gt;&lt;p&gt;If&lt;span style=&quot; font-style:italic;&quot;&gt; BASKET OID&lt;/span&gt; is defined in the model, it's required to use the basket handling in QGIS. This is currently not automatically detected by the Model Baker and needs to be assured by the user.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
-         <string>smart2Inheritance</string>
+         <string>Create Basket Column</string>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
       <string>SQL scripts</string>
@@ -141,7 +137,36 @@ strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
      </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="8" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Stroke arcs</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="stroke_arcs_checkbox">
+        <property name="toolTip">
+         <string>If this option is activated, circular arcs are stroked when importing the data</string>
+        </property>
+        <property name="text">
+         <string>Stroke Arcs</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
     <widget class="QFrame" name="frame">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
@@ -180,65 +205,59 @@ strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="inheritance_group_box">
      <property name="title">
-      <string>Create Basket Column</string>
+      <string>Inheritance type</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="create_basket_col_checkbox">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QRadioButton" name="smart1_radio_button">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Creates a new column t_basket in class tables which references entries in the additional table t_ili2db_basket.&lt;/p&gt;&lt;p&gt;The T_basket column needs to be filled with the basket to which an object belongs.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Warning&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If this option is enabled, it is required to make sure that this column is filled by the database, by default values on QGIS side or manually from the user.&lt;/p&gt;&lt;p&gt;If&lt;span style=&quot; font-style:italic;&quot;&gt; BASKET OID&lt;/span&gt; is defined in the model, it's required to use the basket handling in QGIS. This is currently not automatically detected by the Model Baker and needs to be assured by the user.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>Form the inheritance hierarchy with a dynamic strategy. The NewClass strategy is used for classes that are
+referenced and whose base classes are not mapped using a NewClass strategy. Abstract classes are mapped
+using a SubClass strategy. Concrete classes, without a base class or their direct base classes with a SubClass
+strategy are mapped using a NewClass strategy. All other classes are mapped using a SuperClass strategy.</string>
         </property>
         <property name="text">
-         <string>Create Basket Column</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="create_import_tid_groupbox">
-     <property name="title">
-      <string>Create Import Tid</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="create_import_tid_checkbox">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Creates a new column t_ili_tid in all classes, which is mandatory and should be unique, not only for across the current database, but across the whole system.&lt;/p&gt;&lt;p&gt;Normally you should not enable this option directly, but rely on the INTERLIS model and ili2db. The former should have a line enabling OIDs (preferably with UUIDs) and the latter will make sure the database updates the new column every time a new record is created.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Create Import Tid</string>
+         <string>smart1Inheritance</string>
         </property>
         <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QRadioButton" name="smart2_radio_button">
+        <property name="toolTip">
+         <string>Form the inheritance hierarchy with a dymamic strategy. Abstract classes are mapped using a SubClass
+strategy. Concrete classes are mapped using a NewAndSubClass strategy.</string>
+        </property>
+        <property name="text">
+         <string>smart2Inheritance</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="metaconfig_info_label">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:large; color:#341d5c;&quot;&gt;▪ &lt;/span&gt;&lt;span style=&quot; color:#341d5c;&quot;&gt;corresponds to the metaconfig &lt;/span&gt;&lt;span style=&quot; font-size:large; color:#c64600;&quot;&gt;▪ &lt;/span&gt;&lt;span style=&quot; color:#c64600;&quot;&gt;deviates from the metaconfig&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="create_gpkg_multigeom_groupbox">
+     <property name="title">
+      <string>Multiple Geometries per Table in GeoPackage</string>
      </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
+     <layout class="QGridLayout" name="gridLayout_7">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="create_gpkg_multigeom_checkbox">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the INTERLIS model has classes that contain &lt;span style=&quot; font-weight:600;&quot;&gt;multiple geometries&lt;/span&gt;, tables with multiple geometry columns can be created in &lt;span style=&quot; font-weight:600;&quot;&gt;GeoPackage&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Create Multiple Geometry Columns per Table</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/QgisModelBaker/ui/workflow_wizard/project_creation.ui
+++ b/QgisModelBaker/ui/workflow_wizard/project_creation.ui
@@ -6,132 +6,37 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>979</width>
+    <height>847</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Select Files</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="description">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
+   <item row="5" column="0" colspan="2">
+    <widget class="QFrame" name="gpkg_multigeometry_frame">
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(255, 200, 0);</string>
      </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
-     <property name="text">
-      <string>Generate a QGIS Project from an existing database.</string>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QCommandLinkButton" name="create_project_button">
-     <property name="text">
-      <string>Generate</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="description">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Generate a QGIS Project from an existing database.</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QGroupBox" name="inheritance_groupbox">
-     <property name="title">
-      <string/>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
+     <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
-       <widget class="QLabel" name="optimize_label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you don't get it - nevermind and keep the default. If it's not like expected - try again with 'No optimization'...&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       <widget class="QLabel" name="gpkg_multigeometry_label">
+        <property name="styleSheet">
+         <string notr="true">color: rgb(36, 31, 49);</string>
         </property>
         <property name="text">
-         <string>Project optimization strategy concerning inheritances</string>
+         <string>GPKG info</string>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="optimize_combo">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Hide unused base class layers:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Base class layers with same named extensions will be &lt;span style=&quot; font-style:italic;&quot;&gt;hidden&lt;/span&gt; and and base class layers with multiple extensions as well. Except if the extension is in the same model, then it's will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;hidden&lt;/span&gt; but &lt;span style=&quot; font-style:italic;&quot;&gt;renamed&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;- Relations of hidden layers will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;created&lt;/span&gt; and with them &lt;span style=&quot; font-style:italic;&quot;&gt;no&lt;/span&gt; widgets&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Group unused base class layers:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Base class layers with same named extensions will be &lt;span style=&quot; font-style:italic;&quot;&gt;collected in a group&lt;/span&gt; and base class layers with multiple extensions as well. Except if the extension is in the same model, then it's will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;grouped&lt;/span&gt; but &lt;span style=&quot; font-style:italic;&quot;&gt;renamed&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;- Relations of grouped layers will be &lt;span style=&quot; font-style:italic;&quot;&gt;created&lt;/span&gt; but the widgets &lt;span style=&quot; font-style:italic;&quot;&gt;not applied&lt;/span&gt; to the form.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Hide unused base class layers</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Group unused base class layers</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>No optimization</string>
-         </property>
-        </item>
        </widget>
       </item>
      </layout>
@@ -202,7 +107,46 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="6" column="0" colspan="2">
+    <widget class="QProgressBar" name="progress_bar">
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QCommandLinkButton" name="create_project_button">
+     <property name="text">
+      <string>Generate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="description">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Generate a QGIS Project from an existing database.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -215,8 +159,112 @@
      </property>
     </spacer>
    </item>
+   <item row="8" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="description">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Generate a QGIS Project from an existing database.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="2" column="0" colspan="2">
     <widget class="QGroupBox" name="inheritance_groupbox">
+     <property name="title">
+      <string/>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="optimize_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If you don't get it - nevermind and keep the default. If it's not like expected - try again with 'No optimization'...&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Project optimization strategy concerning inheritances</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="optimize_combo">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Hide unused base class layers:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Base class layers with same named extensions will be &lt;span style=&quot; font-style:italic;&quot;&gt;hidden&lt;/span&gt; and and base class layers with multiple extensions as well. Except if the extension is in the same model, then it's will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;hidden&lt;/span&gt; but &lt;span style=&quot; font-style:italic;&quot;&gt;renamed&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;- Relations of hidden layers will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;created&lt;/span&gt; and with them &lt;span style=&quot; font-style:italic;&quot;&gt;no&lt;/span&gt; widgets&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Group unused base class layers:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;- Base class layers with same named extensions will be &lt;span style=&quot; font-style:italic;&quot;&gt;collected in a group&lt;/span&gt; and base class layers with multiple extensions as well. Except if the extension is in the same model, then it's will &lt;span style=&quot; font-style:italic;&quot;&gt;not&lt;/span&gt; be &lt;span style=&quot; font-style:italic;&quot;&gt;grouped&lt;/span&gt; but &lt;span style=&quot; font-style:italic;&quot;&gt;renamed&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;- Relations of grouped layers will be &lt;span style=&quot; font-style:italic;&quot;&gt;created&lt;/span&gt; but the widgets &lt;span style=&quot; font-style:italic;&quot;&gt;not applied&lt;/span&gt; to the form.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Hide unused base class layers</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Group unused base class layers</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>No optimization</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QGroupBox" name="translation_groupbox">
      <property name="title">
       <string/>
      </property>
@@ -263,54 +311,6 @@ Select the language in which the QGIS project is to be set up.</string>
           <string>Italian</string>
          </property>
         </item>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QProgressBar" name="progress_bar">
-     <property name="value">
-      <number>0</number>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QFrame" name="gpkg_multigeometry_frame">
-     <property name="styleSheet">
-      <string notr="true">background-color: rgb(255, 200, 0);</string>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QLabel" name="gpkg_multigeometry_label">
-        <property name="styleSheet">
-         <string notr="true">color: rgb(36, 31, 49);</string>
-        </property>
-        <property name="text">
-         <string>GPKG info</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
        </widget>
       </item>
      </layout>

--- a/QgisModelBaker/ui/workflow_wizard/project_creation.ui
+++ b/QgisModelBaker/ui/workflow_wizard/project_creation.ui
@@ -14,18 +14,12 @@
    <string>Select Files</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="6" column="0">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="7" column="1">
+    <widget class="QCommandLinkButton" name="create_project_button">
+     <property name="text">
+      <string>Generate</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
+    </widget>
    </item>
    <item row="5" column="1">
     <spacer name="verticalSpacer">
@@ -183,22 +177,59 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QProgressBar" name="progress_bar">
-     <property name="value">
-      <number>0</number>
+   <item row="7" column="0">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="description">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Generate a QGIS Project from an existing database.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
    <item row="6" column="1">
-    <widget class="QCommandLinkButton" name="create_project_button">
-     <property name="text">
-      <string>Generate</string>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-    </widget>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QGroupBox" name="translation_groupbox">
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="inheritance_groupbox">
      <property name="title">
       <string/>
      </property>
@@ -248,6 +279,20 @@ Select the language in which the QGIS project is to be set up.</string>
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QProgressBar" name="progress_bar">
+     <property name="value">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="gpkg_multigeometry_info">
+     <property name="text">
+      <string>GPKG info</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/QgisModelBaker/ui/workflow_wizard/project_creation.ui
+++ b/QgisModelBaker/ui/workflow_wizard/project_creation.ui
@@ -303,7 +303,7 @@ Select the language in which the QGIS project is to be set up.</string>
       <item row="0" column="0">
        <widget class="QLabel" name="gpkg_multigeometry_label">
         <property name="styleSheet">
-         <string notr="true"/>
+         <string notr="true">color: rgb(36, 31, 49);</string>
         </property>
         <property name="text">
          <string>GPKG info</string>

--- a/QgisModelBaker/ui/workflow_wizard/project_creation.ui
+++ b/QgisModelBaker/ui/workflow_wizard/project_creation.ui
@@ -14,6 +14,31 @@
    <string>Select Files</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="description">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Generate a QGIS Project from an existing database.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="7" column="1">
     <widget class="QCommandLinkButton" name="create_project_button">
      <property name="text">
@@ -190,44 +215,6 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="description">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Generate a QGIS Project from an existing database.</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="2" column="0" colspan="2">
     <widget class="QGroupBox" name="inheritance_groupbox">
      <property name="title">
@@ -288,11 +275,45 @@ Select the language in which the QGIS project is to be set up.</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="gpkg_multigeometry_info">
-     <property name="text">
-      <string>GPKG info</string>
+   <item row="6" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QFrame" name="gpkg_multigeometry_frame">
+     <property name="styleSheet">
+      <string notr="true">background-color: rgb(255, 200, 0);</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QLabel" name="gpkg_multigeometry_label">
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <property name="text">
+         <string>GPKG info</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
## The setting for `gpkgMultiGeomPerTable` on Schema Import

![Screenshot from 2024-10-30 22-06-22](https://github.com/user-attachments/assets/b9293977-aae4-4512-88fe-17fb370f650b)

Otherwise the setting is invisible and the parameter is `false`

This does only work with a sufficient GDAL version \* Otherwise it's invisible and false.

## Generating QGIS Project

Reading such a project does only work with a sufficient GDAL version \* If the schema has been created with the `gpkgMultiGeomPerTable` *and* it contains tables with multiple geometry columns, but the current **GDAL version is not sufficient**, we block the creation of a QGIS Project.

![Screenshot from 2024-10-30 22-08-58](https://github.com/user-attachments/assets/2796c259-038e-4509-98f0-0c9edb1d69ce)

When we have a **sufficient** GDAL version \* we can create a QGIS project, but need to warn, that others reading this project might have trouble.

![image](https://github.com/user-attachments/assets/80255461-67fd-4fba-a2b7-92d541d93556)

## GDAL Version 3.8

This functionality is not standardized and does only work with GDAL Version >= 3.8

Windows Builds have it since 3.36 but Ubuntu from the current repositories not yet.

When a schema is created with this parameter  `gpkgMultiGeomPerTable`  and the Model contains multiple geometries per table,  it can neither create a project on QGIS with GDAL<3.8 nor read a project that has been created on a QGIS with GDAL >= 3.8. 

If no multiple geometries per table, it still can create a project from it by GDAL<3.8 or open such a project.

## Night mode:

![image](https://github.com/user-attachments/assets/15727d79-be4e-44e9-8cf4-29a53dfcd961)


Requires https://github.com/opengisch/QgisModelBakerLibrary/pull/108

Resolves https://github.com/opengisch/QgisModelBaker/issues/531