### PR TITLE
If no user name (or auth config) is chosen, we fill up the user name …

### DIFF
--- a/QgisModelBaker/gui/dataset_manager.py
+++ b/QgisModelBaker/gui/dataset_manager.py
@@ -199,7 +199,6 @@ class DatasetManagerDialog(QDialog, DIALOG_UI):
                 valid, mode = db_utils.get_configuration_from_sourceprovider(
                     source_provider, configuration
                 )
-                configuration.tool = mode
                 source_info_text = self.tr(
                     "<body><p>It's the datasource of the current project, evaluated by layer <b>{}</b>.</p>"
                 ).format(layer.name())

--- a/QgisModelBaker/gui/panel/dataset_selector.py
+++ b/QgisModelBaker/gui/panel/dataset_selector.py
@@ -26,6 +26,7 @@ from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbconfig import (
 )
 from QgisModelBaker.libs.modelbaker.utils.db_utils import (
     get_configuration_from_sourceprovider,
+    get_db_connector,
     get_schema_identificator_from_sourceprovider,
 )
 from QgisModelBaker.libs.modelbaker.utils.qt_utils import slugify
@@ -82,12 +83,8 @@ class DatasetSelector(QComboBox):
                 source_provider, configuration
             )
             if valid and mode:
-                db_factory = self.db_simple_factory.create_factory(mode)
-                config_manager = db_factory.get_db_command_config_manager(configuration)
                 try:
-                    db_connector = db_factory.get_db_connector(
-                        config_manager.get_uri(), configuration.dbschema
-                    )
+                    db_connector = get_db_connector(configuration)
                     if db_connector.get_basket_handling():
                         self.basket_model.reload_schema_baskets(
                             db_connector,

--- a/QgisModelBaker/gui/panel/pg_config_panel.py
+++ b/QgisModelBaker/gui/panel/pg_config_panel.py
@@ -328,15 +328,6 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
             message = self.tr("Please set a database before creating the project.")
             self.pg_database_line_edit.setFocus()
         elif (
-            not self.pg_auth_settings.username()
-            and not self.pg_auth_settings.configId()
-        ):
-            message = self.tr(
-                "Please set a username or select an authentication configuration before creating the "
-                "project."
-            )
-            self.pg_auth_settings.setFocus()
-        elif (
             self.pg_auth_settings.configId()
             and not self.pg_use_super_login.isChecked()
             and self._db_action_type

--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -19,6 +19,7 @@
 
 import os
 
+from qgis.core import QgsApplication
 from qgis.PyQt.QtCore import Qt, pyqtSignal
 from qgis.PyQt.QtWidgets import QAction, QApplication, QMessageBox, QWidget
 
@@ -34,7 +35,7 @@ from QgisModelBaker.libs.modelbaker.iliwrapper import (
 from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbutils import JavaNotFoundError
 from QgisModelBaker.libs.modelbaker.utils.globals import DbActionType
 from QgisModelBaker.libs.modelbaker.utils.qt_utils import OverrideCursor
-from QgisModelBaker.utils.globals import DEFAULT_DATASETNAME
+from QgisModelBaker.utils.globals import DEFAULT_DATASETNAME, DbIliMode
 from QgisModelBaker.utils.gui_utils import LogLevel
 
 WIDGET_UI = gui_utils.get_ui_class("workflow_wizard/session_panel.ui")
@@ -108,6 +109,13 @@ class SessionPanel(QWidget, WIDGET_UI):
 
         # set up the values
         self.configuration = general_configuration
+        if self.configuration.tool & DbIliMode.pg:
+            # on pg we should consider the user account name as fallback
+            if (
+                not self.configuration.db_use_super_login
+                and not self.configuration.dbusr
+            ):
+                self.configuration.dbusr = QgsApplication.userLoginName()
         if self.db_action_type == DbActionType.GENERATE:
             self.configuration.ilifile = ""
             if os.path.isfile(self.file):

--- a/QgisModelBaker/gui/panel/tid_configurator_panel.py
+++ b/QgisModelBaker/gui/panel/tid_configurator_panel.py
@@ -66,8 +66,9 @@ class TIDConfiguratorPanel(QWidget, WIDGET_UI):
                     valid, mode = db_utils.get_configuration_from_sourceprovider(
                         source_provider, self.configuration
                     )
-                    if valid:
-                        self.configuration.tool = mode
+                    if not valid:
+                        # invalidate tool
+                        self.configuration.tool = ""
 
         if self.configuration and self.configuration.tool:
             self._reset_tid_configuration()

--- a/QgisModelBaker/gui/topping_wizard/ili2dbsettings_page.py
+++ b/QgisModelBaker/gui/topping_wizard/ili2dbsettings_page.py
@@ -271,7 +271,6 @@ class Ili2dbSettingsPage(QWizardPage, PAGE_UI):
                     source_provider, configuration
                 )
                 if valid and mode:
-                    configuration.tool = mode
                     db_connector = db_utils.get_db_connector(configuration)
                     # only load it when it exists and metadata there (contains interlis data)
                     if (

--- a/QgisModelBaker/gui/topping_wizard/layers_page.py
+++ b/QgisModelBaker/gui/topping_wizard/layers_page.py
@@ -389,7 +389,6 @@ class LayerModel(QgsLayerTreeModel):
                     source_provider, configuration
                 )
                 if valid and mode:
-                    configuration.tool = mode
                     db_connector = db_utils.get_db_connector(configuration)
 
                     if (

--- a/QgisModelBaker/gui/topping_wizard/models_page.py
+++ b/QgisModelBaker/gui/topping_wizard/models_page.py
@@ -104,7 +104,6 @@ class ModelsPage(QWizardPage, PAGE_UI):
                         source_provider, current_configuration
                     )
                     if valid and mode:
-                        current_configuration.tool = mode
                         db_connector = db_utils.get_db_connector(current_configuration)
                         if db_connector:
                             db_connectors.append(db_connector)

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -248,7 +248,6 @@ class ValidateDock(QDockWidget, DIALOG_UI):
                 QStandardPaths.writableLocation(QStandardPaths.TempLocation),
                 f"dataexport_{output_file_name}",
             )
-            self.current_configuration.tool = mode
             if mode == DbIliMode.gpkg:
                 self.info_label.setText(
                     self.tr(

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -349,6 +349,13 @@ class ValidateDock(QDockWidget, DIALOG_UI):
 
         validator.tool = self.current_configuration.tool
         validator.configuration = self.current_configuration
+        if validator.configuration.tool & DbIliMode.pg:
+            # on pg we should consider the user account name as fallback
+            if (
+                not validator.configuration.db_use_super_login
+                and not validator.configuration.dbusr
+            ):
+                validator.configuration.dbusr = QgsApplication.userLoginName()
 
         validator.configuration.ilimodels = ""
         validator.configuration.dataset = ""

--- a/QgisModelBaker/gui/workflow_wizard/database_selection_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/database_selection_page.py
@@ -104,7 +104,6 @@ class DatabaseSelectionPage(QWizardPage, PAGE_UI):
         if valid and mode:
             # uses the settings from the project and provides it to the gui
             configuration = layer_configuration
-            configuration.tool = mode
             self._lst_panel[mode].set_fields(configuration)
         else:
             # takes settings from QSettings and provides it to the gui

--- a/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
@@ -22,7 +22,7 @@ import os
 import re
 
 import yaml
-from qgis.core import Qgis, QgsProject
+from qgis.core import Qgis, QgsApplication, QgsProject
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtWidgets import QCompleter, QWizardPage
 

--- a/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
@@ -332,7 +332,10 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
                 self.configuration
             )
             uri = config_manager.get_uri(qgis=True)
-            mgmt_uri = config_manager.get_uri(self.configuration.db_use_super_login)
+            mgmt_uri = config_manager.get_uri(
+                su=self.configuration.db_use_super_login,
+                fallback_user=QgsApplication.userLoginName(),
+            )
             generator = Generator(
                 self.configuration.tool,
                 uri,
@@ -375,7 +378,9 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
             self.progress_bar.setValue(0)
             return
 
-        res, message = db_factory.post_generate_project_validations(self.configuration)
+        res, message = db_factory.post_generate_project_validations(
+            self.configuration, QgsApplication.userLoginName()
+        )
 
         if not res:
             self.workflow_wizard.log_panel.txtStdout.setText(message)


### PR DESCRIPTION
But not always. The layer should not be created with it (and have instead no user name). Such functionalities are provided by the PG Kerberos integration.

Backend here https://github.com/opengisch/QgisModelBakerLibrary/pull/114

We need to pass it:

- in ili2db commands (import, validation etc.)
- in generate project (but don't save it in layer sources)
- on direct connections (basket manager, oid manager)

### ili2db commands
If no user name available just set the account user name.

### generate project
Pass the account user name (the account name) to the library when it needs to connect the db, but not on creating the layers (means only on mgmt_uri)

### direct connections
Provided over the `db_utils.get_db_connector`