### PR TITLE
Pass blacklisted models to find available language because they are irrelevant

### DIFF
--- a/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
@@ -43,7 +43,7 @@ from QgisModelBaker.libs.modelbaker.utils.globals import OptimizeStrategy
 from QgisModelBaker.libs.modelbaker.utils.qt_utils import make_file_selector
 from QgisModelBaker.utils import gui_utils
 from QgisModelBaker.utils.globals import CATALOGUE_DATASETNAME, displayLanguages
-from QgisModelBaker.utils.gui_utils import TRANSFERFILE_MODELS_BLACKLIST, LogLevel
+from QgisModelBaker.utils.gui_utils import MODELS_BLACKLIST, LogLevel
 
 PAGE_UI = gui_utils.get_ui_class("workflow_wizard/project_creation.ui")
 
@@ -244,8 +244,17 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
         self.translation_combo.clear()
 
         if self.db_connector:
-            for lang in self.db_connector.get_available_languages():
-                self.translation_combo.addItem(displayLanguages.get(lang, lang), lang)
+            available_languages = self.db_connector.get_available_languages(
+                MODELS_BLACKLIST
+            )
+            if len(available_languages) > 1:
+                for lang in available_languages:
+                    self.translation_combo.addItem(
+                        displayLanguages.get(lang, lang), lang
+                    )
+                self.translation_combo.setEnabled(True)
+            else:
+                self.translation_combo.setEnabled(False)
 
         self.translation_combo.addItem(self.tr("Original model language"), "__")
 
@@ -725,11 +734,7 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
         for db_model in db_models:
             for modelname in regex.split(db_model["modelname"]):
                 name = modelname.strip()
-                if (
-                    name
-                    and name not in TRANSFERFILE_MODELS_BLACKLIST
-                    and name not in modelnames
-                ):
+                if name and name not in MODELS_BLACKLIST and name not in modelnames:
                     modelnames.append(name)
         return modelnames
 

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -65,7 +65,7 @@ TransferExtensions = [
     "XLSX",
 ]
 
-TRANSFERFILE_MODELS_BLACKLIST = [
+MODELS_BLACKLIST = [
     "CHBaseEx_MapCatalogue_V1",
     "CHBaseEx_WaterNet_V1",
     "CHBaseEx_Sewage_V1",
@@ -112,6 +112,7 @@ TRANSFERFILE_MODELS_BLACKLIST = [
     "StandardSymbology",
     "Time",
     "Units",
+    "",
 ]
 
 # style
@@ -714,8 +715,7 @@ class ImportModelsModel(SourceModel):
                     for sub_element in element:
                         if (
                             "NAME" in sub_element.attrib
-                            and sub_element.attrib["NAME"]
-                            not in TRANSFERFILE_MODELS_BLACKLIST
+                            and sub_element.attrib["NAME"] not in MODELS_BLACKLIST
                         ):
                             model = {}
                             model["name"] = sub_element.attrib["NAME"]
@@ -1049,7 +1049,7 @@ class SchemaModelsModel(CheckEntriesModel):
                         name = modelname.strip()
                         if (
                             name
-                            and name not in TRANSFERFILE_MODELS_BLACKLIST
+                            and name not in MODELS_BLACKLIST
                             and name not in modelnames
                         ):
                             modelnames.append(name)

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "1.9.0")
+MODELBAKER_LIBRARY=("modelbaker" "1.9.1")
 PACKAGING=("packaging" "21.3")
 
 PACKAGES=(


### PR DESCRIPTION
In the language combobox. Because it should not find English from Units etc.

And if only one language is found it's disabled anyway and only provides the "original" language.


Requires https://github.com/opengisch/QgisModelBakerLibrary/pull/117