### PR TITLE
Export ValidationConfig File as Topping

### DIFF
--- a/QgisModelBaker/gui/topping_wizard/additives_page.py
+++ b/QgisModelBaker/gui/topping_wizard/additives_page.py
@@ -27,6 +27,8 @@ PAGE_UI = gui_utils.get_ui_class("topping_wizard/additives.ui")
 
 VARIABLE_PREFIX_BLACKLIST = ["default_basket", "optimize_strategy"]
 
+VALIDATION_VARIABLE = "validator_config"
+
 
 class AdditivesPage(QWizardPage, PAGE_UI):
     def __init__(self, parent, title):
@@ -70,6 +72,13 @@ class AdditivesPage(QWizardPage, PAGE_UI):
         self.variables_model.refresh_stringlist(variables_keys)
         self.variables_view.setVisible(self.variables_model.rowCount())
         self.variables_label.setVisible(self.variables_model.rowCount())
+
+        if VALIDATION_VARIABLE in self.variables_model.stringList():
+            self.validatortopping_checkbox.setVisible(True)
+            self.validatortopping_checkbox.setChecked(True)
+        else:
+            self.validatortopping_checkbox.setVisible(False)
+            self.validatortopping_checkbox.setChecked(False)
 
         layout_manager = QgsProject.instance().layoutManager()
         layout_names = [layout.name() for layout in layout_manager.printLayouts()]

--- a/QgisModelBaker/gui/topping_wizard/additives_page.py
+++ b/QgisModelBaker/gui/topping_wizard/additives_page.py
@@ -107,4 +107,8 @@ class AdditivesPage(QWizardPage, PAGE_UI):
         self.topping_wizard.topping.export_settings.layouts = (
             self.layouts_model.checked_entries()
         )
+        if self.validatortopping_checkbox.isChecked():
+            self.topping_wizard.topping.export_settings.path_variables = [
+                VALIDATION_VARIABLE
+            ]
         return super().validatePage()

--- a/QgisModelBaker/gui/topping_wizard/additives_page.py
+++ b/QgisModelBaker/gui/topping_wizard/additives_page.py
@@ -76,6 +76,16 @@ class AdditivesPage(QWizardPage, PAGE_UI):
         self.layouts_model.refresh_stringlist(layout_names)
         self.layouts_view.setVisible(self.layouts_model.rowCount())
         self.layouts_label.setVisible(self.layouts_model.rowCount())
+
+        if not (
+            self.mapthemes_model.rowCount()
+            or self.variables_model.rowCount()
+            or self.layouts_model.rowCount()
+        ):
+            self.topping_wizard.log_panel.print_info(
+                self.tr("No additive settings - go on...")
+            )
+            self.topping_wizard.next()
         return super().initializePage()
 
     def validatePage(self) -> bool:

--- a/QgisModelBaker/ui/topping_wizard/additives.ui
+++ b/QgisModelBaker/ui/topping_wizard/additives.ui
@@ -14,6 +14,40 @@
    <string>Select Files</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="variables_label">
+     <property name="text">
+      <string>Custom Project Variables</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="SpaceCheckListView" name="variables_view" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="SpaceCheckListView" name="layouts_view" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="layouts_label">
+     <property name="text">
+      <string>Print Layouts (exported as templates)</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="description">
      <property name="minimumSize">
@@ -39,6 +73,13 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="mapthemes_label">
+     <property name="text">
+      <string>Map Themes</string>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0" colspan="2">
     <widget class="SpaceCheckListView" name="mapthemes_view" native="true">
      <property name="sizePolicy">
@@ -49,44 +90,10 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLabel" name="variables_label">
+   <item row="5" column="0" colspan="2">
+    <widget class="QCheckBox" name="validatortopping_checkbox">
      <property name="text">
-      <string>Custom Project Variables</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="SpaceCheckListView" name="layouts_view" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="SpaceCheckListView" name="variables_view" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="layouts_label">
-     <property name="text">
-      <string>Print Layouts (exported as templates)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="mapthemes_label">
-     <property name="text">
-      <string>Map Themes</string>
+      <string>Convert validation configuration file to topping file</string>
      </property>
     </widget>
    </item>

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "1.9.5")
+MODELBAKER_LIBRARY=("modelbaker" "1.9.6")
 PACKAGING=("packaging" "21.3")
 
 PACKAGES=(


### PR DESCRIPTION
Since quite some time we are able to store the path to the validation configuration file as project variable, so we have it always in the validator:

![image](https://github.com/user-attachments/assets/1df31c2a-8752-4821-901d-c7904f6430e8)

This variable could be exported so far to the project topping **but** if the file is not stored on a accessible drive the project using this topping could not access to it.

## Topping Export

That's why with this PR you have the option in the **Topping Exporter** to *create* a topping file from the variable with the name "validator_config" that is stored at the topping files.

![image](https://github.com/user-attachments/assets/9981559b-4cfb-4903-bea2-89c653ef4d12)

Means we have now the validation-config.ini file in the toppings and link over the variable to the `ilidata:` key.

## Topping Import
But what happens on project create with this topping?

Nothing :-) It keeps the `ilidata:` key in the variable. This means in the Validator we see the `ilidata:` key as well. And this can be used then on validation (passing this key as `--validConfig` to ili2db).

![image](https://github.com/user-attachments/assets/b603f2a1-7566-479c-89a1-f78ec6a3ba7a)

## Why the file is not downloaded
This because we are not able to download and store the file, since we do not know where to store it. Next to the project? Maybe, but on generating a project there will not be a project stored. So it needs to be an interaction with the user.
### Future idea
If it is required to get the file again locally, then an implementation might be done in the validator, to download the file and store it next to the project and replace the variable with the relative path

![image](https://github.com/user-attachments/assets/0131b452-19d3-47eb-ae37-4e324d549cf6)
(mockup)

Resolves https://github.com/opengisch/QgisModelBaker/issues/829
Requires https://github.com/opengisch/toppingmaker/pull/14 and with this a new library