### PR TITLE
 Support parsing of models from xtf 2.4. 

### DIFF
--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -418,8 +418,9 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                 )
 
         for linked_model in linked_models:
+            model_name = linked_model.split(":")[0]
             if self.workflow_wizard.source_model.add_source(
-                linked_model,
+                model_name,
                 "model",
                 None,
                 self.tr("Linked model referenced over ilidata repository."),


### PR DESCRIPTION
Use interparse to not need to parse the whole (large) XTF file instead of own made solution.

This fixes #1014
