### PR TITLE
Add --dbparams dialog in PG settings

### DIFF
--- a/QgisModelBaker/gui/panel/pg_config_panel.py
+++ b/QgisModelBaker/gui/panel/pg_config_panel.py
@@ -639,13 +639,15 @@ class DbParamsDialog(QDialog, DIALOG_UI):
         """
         key_item = self.mappingtable.item(row, 0)
         value_item = self.mappingtable.item(row, 1)
+        # if we did something the second last row and it's empty (means we cleared it), we remove the empty row at the end.
         if row == self.mappingtable.rowCount() - 2 and not (
             key_item
             and len(str(key_item.data(Qt.DisplayRole))) > 0
             or value_item
             and len(str(value_item.data(Qt.DisplayRole))) > 0
         ):
-            self.mappingtable.setRowCount(row + 1)
+            self.mappingtable.removeRow(row + 1)
+        # if we did something in the last row, and it's not empty, we add a fresh empty row at the end.
         elif row == self.mappingtable.rowCount() - 1 and (
             key_item
             and len(str(key_item.data(Qt.DisplayRole))) > 0

--- a/QgisModelBaker/gui/panel/pg_config_panel.py
+++ b/QgisModelBaker/gui/panel/pg_config_panel.py
@@ -228,7 +228,7 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
         configuration.sslmode = self.pg_ssl_mode_combo_box.currentData()
 
         configuration.db_use_super_login = self.pg_use_super_login.isChecked()
-        configuration.param_map = self.pg_param_map
+        configuration.dbparam_map = self.pg_param_map
 
     def set_fields(self, configuration):
 
@@ -326,7 +326,7 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
             self.pg_auth_settings.setConfigId(configuration.dbauthid)
             self.pg_use_super_login.setChecked(configuration.db_use_super_login)
 
-        self.pg_param_map = configuration.param_map
+        self.pg_param_map = configuration.dbparam_map
 
     def is_valid(self):
         result = False
@@ -596,7 +596,6 @@ class DbParamsDialog(QDialog, DIALOG_UI):
 
         self.param_map = param_map
 
-        self.mappingtable.insertRow(0)
         self.mappingtable.horizontalHeader().setSectionsClickable(True)
         self.mappingtable.setSortingEnabled(True)
 
@@ -605,6 +604,9 @@ class DbParamsDialog(QDialog, DIALOG_UI):
         self.mappingtable.cellChanged.connect(self._cell_changed)
 
     def init(self):
+        """
+        Reads content from param_map
+        """
         for key in self.param_map.keys():
             row = self.mappingtable.rowCount()
             self.mappingtable.insertRow(row)
@@ -614,9 +616,12 @@ class DbParamsDialog(QDialog, DIALOG_UI):
             value_item.setData(Qt.DisplayRole, self.param_map[key])
             self.mappingtable.setItem(row, 0, key_item)
             self.mappingtable.setItem(row, 1, value_item)
-            print(f"insert{key_item} and {value_item}")
+        self.mappingtable.insertRow(self.mappingtable.rowCount())
 
     def accepted(self):
+        """
+        Stores content to param_map
+        """
         self.param_map = {}
         for row in range(self.mappingtable.rowCount()):
             key_item = self.mappingtable.item(row, 0)
@@ -641,5 +646,10 @@ class DbParamsDialog(QDialog, DIALOG_UI):
             and len(str(value_item.data(Qt.DisplayRole))) > 0
         ):
             self.mappingtable.setRowCount(row + 1)
-        elif row == self.mappingtable.rowCount() - 1:
+        elif row == self.mappingtable.rowCount() - 1 and (
+            key_item
+            and len(str(key_item.data(Qt.DisplayRole))) > 0
+            or value_item
+            and len(str(value_item.data(Qt.DisplayRole))) > 0
+        ):
             self.mappingtable.insertRow(row + 1)

--- a/QgisModelBaker/gui/panel/pg_config_panel.py
+++ b/QgisModelBaker/gui/panel/pg_config_panel.py
@@ -20,6 +20,7 @@ import logging
 from enum import IntEnum
 
 from qgis.PyQt.QtCore import QSettings, Qt, QThread, QTimer
+from qgis.PyQt.QtWidgets import QDialog, QTableWidgetItem
 
 import QgisModelBaker.libs.modelbaker.utils.db_utils as db_utils
 from QgisModelBaker.libs.modelbaker.iliwrapper.globals import DbIliMode
@@ -178,6 +179,9 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
             Qt.ToolTipRole,
         )
 
+        self.pg_param_map = {}
+        self.pg_dbparam_button.clicked.connect(self._dbparams_open)
+
         self._show_panel()
 
     def __del__(self):
@@ -224,6 +228,7 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
         configuration.sslmode = self.pg_ssl_mode_combo_box.currentData()
 
         configuration.db_use_super_login = self.pg_use_super_login.isChecked()
+        configuration.param_map = self.pg_param_map
 
     def set_fields(self, configuration):
 
@@ -320,6 +325,8 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
             self.pg_schema_combo_box.setCurrentText(configuration.dbschema)
             self.pg_auth_settings.setConfigId(configuration.dbauthid)
             self.pg_use_super_login.setChecked(configuration.db_use_super_login)
+
+        self.pg_param_map = configuration.param_map
 
     def is_valid(self):
         result = False
@@ -546,6 +553,11 @@ class PgConfigPanel(DbConfigPanel, WIDGET_UI):
         if currentTextIndex > -1:
             self.pg_schema_combo_box.setCurrentIndex(currentTextIndex)
 
+    def _dbparams_open(self):
+        db_params_dialog = DbParamsDialog(self, self.pg_param_map)
+        if db_params_dialog.exec_() == QDialog.Accepted:
+            self.pg_param_map = db_params_dialog.param_map
+
 
 class ReadPgSchemasTask(QThread):
     def __init__(self, parent):
@@ -572,3 +584,62 @@ class ReadPgSchemasTask(QThread):
         except Exception as exception:
             logging.warning(f"Refresh schema list error: {exception}")
             self.schemas = []
+
+
+DIALOG_UI = gui_utils.get_ui_class("dbparam_map.ui")
+
+
+class DbParamsDialog(QDialog, DIALOG_UI):
+    def __init__(self, parent=None, param_map={}):
+        QDialog.__init__(self, parent)
+        self.setupUi(self)
+
+        self.param_map = param_map
+
+        self.mappingtable.insertRow(0)
+        self.mappingtable.horizontalHeader().setSectionsClickable(True)
+        self.mappingtable.setSortingEnabled(True)
+
+        self.init()
+        self.buttonBox.accepted.connect(self.accepted)
+        self.mappingtable.cellChanged.connect(self._cell_changed)
+
+    def init(self):
+        for key in self.param_map.keys():
+            row = self.mappingtable.rowCount()
+            self.mappingtable.insertRow(row)
+            key_item = QTableWidgetItem()
+            key_item.setData(Qt.DisplayRole, key)
+            value_item = QTableWidgetItem()
+            value_item.setData(Qt.DisplayRole, self.param_map[key])
+            self.mappingtable.setItem(row, 0, key_item)
+            self.mappingtable.setItem(row, 1, value_item)
+            print(f"insert{key_item} and {value_item}")
+
+    def accepted(self):
+        self.param_map = {}
+        for row in range(self.mappingtable.rowCount()):
+            key_item = self.mappingtable.item(row, 0)
+            if key_item and len(str(key_item.data(Qt.DisplayRole))) > 0:
+                value_item = self.mappingtable.item(row, 1)
+                if value_item and len(str(value_item.data(Qt.DisplayRole))) > 0:
+                    self.param_map[str(key_item.data(Qt.DisplayRole))] = str(
+                        value_item.data(Qt.DisplayRole)
+                    )
+
+    def _cell_changed(self, row, column):
+        """
+        If one of the cells in this row has content and is the last row, add an additional row.
+        If none of the cells in this row has context and it's the second last row, remove the last row.
+        """
+        key_item = self.mappingtable.item(row, 0)
+        value_item = self.mappingtable.item(row, 1)
+        if row == self.mappingtable.rowCount() - 2 and not (
+            key_item
+            and len(str(key_item.data(Qt.DisplayRole))) > 0
+            or value_item
+            and len(str(value_item.data(Qt.DisplayRole))) > 0
+        ):
+            self.mappingtable.setRowCount(row + 1)
+        elif row == self.mappingtable.rowCount() - 1:
+            self.mappingtable.insertRow(row + 1)

--- a/QgisModelBaker/gui/workflow_wizard/database_selection_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/database_selection_page.py
@@ -100,23 +100,23 @@ class DatabaseSelectionPage(QWizardPage, PAGE_UI):
                     source_provider, layer_configuration
                 )
 
+        # takes settings from QSettings and provides it to the gui
+        settings = QSettings()
+
+        for db_id in self.db_simple_factory.get_db_list(False):
+            db_factory = self.db_simple_factory.create_factory(db_id)
+            config_manager = db_factory.get_db_command_config_manager(configuration)
+            config_manager.load_config_from_qsettings()
+            self._lst_panel[db_id].set_fields(configuration)
+
+        mode = settings.value("QgisModelBaker/importtype")
+        mode = DbIliMode[mode] if mode else self.db_simple_factory.default_database
+        mode = mode & ~DbIliMode.ili
+
         if valid and mode:
-            # uses the settings from the project and provides it to the gui
+            # ... and overrides the settings with the settings from the project (this because there are more settings available in the settings than the project (e.g. dbparams))
             configuration = layer_configuration
             self._lst_panel[mode].set_fields(configuration)
-        else:
-            # takes settings from QSettings and provides it to the gui
-            settings = QSettings()
-
-            for db_id in self.db_simple_factory.get_db_list(False):
-                db_factory = self.db_simple_factory.create_factory(db_id)
-                config_manager = db_factory.get_db_command_config_manager(configuration)
-                config_manager.load_config_from_qsettings()
-                self._lst_panel[db_id].set_fields(configuration)
-
-            mode = settings.value("QgisModelBaker/importtype")
-            mode = DbIliMode[mode] if mode else self.db_simple_factory.default_database
-            mode = mode & ~DbIliMode.ili
 
         self.type_combo_box.setCurrentIndex(self.type_combo_box.findData(mode))
         self._type_changed()

--- a/QgisModelBaker/ui/dbparam_map.ui
+++ b/QgisModelBaker/ui/dbparam_map.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>477</width>
+    <width>478</width>
     <height>355</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Custom Parameters</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
@@ -81,7 +81,7 @@
    <item row="2" column="0">
     <widget class="QLabel" name="boolean_note_label">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Boolean values should be &lt;span style=&quot; font-style:italic;&quot;&gt;true&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;false&lt;/span&gt; (lowercase)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;p&gt;Boolean values should be &lt;span style=&quot; font-style:italic;&quot;&gt;true&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;false&lt;/span&gt; (lowercase).&lt;/p&gt;&lt;p&gt;The possible parameters are described in the respective &lt;a href=&quot;https://jdbc.postgresql.org/documentation/use/#connection-parameters&quot;&gt;JDBC driver&lt;/a&gt;.&lt;/p&gt;</string>
      </property>
     </widget>
    </item>

--- a/QgisModelBaker/ui/dbparam_map.ui
+++ b/QgisModelBaker/ui/dbparam_map.ui
@@ -44,6 +44,9 @@
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>
      </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
      <attribute name="verticalHeaderMinimumSectionSize">
       <number>50</number>
      </attribute>

--- a/QgisModelBaker/ui/dbparam_map.ui
+++ b/QgisModelBaker/ui/dbparam_map.ui
@@ -17,10 +17,20 @@
    <item row="0" column="0">
     <widget class="QLabel" name="description_label">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter your custom parameters passed to ili2db via temporary file by &lt;span style=&quot; font-family:'monospace';&quot;&gt;--dbparams&lt;/span&gt;. Be aware that those settings are not used in the QGIS Project.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter your parameters passed to ili2db via a temporary file to &lt;span style=&quot; font-family:'monospace';&quot;&gt;--dbparams&lt;/span&gt;. These settings are used to create or update a database. They are not considered in the QGIS project.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -69,12 +79,9 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+    <widget class="QLabel" name="boolean_note_label">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Boolean values should be &lt;span style=&quot; font-style:italic;&quot;&gt;true&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;false&lt;/span&gt; (lowercase)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>

--- a/QgisModelBaker/ui/dbparam_map.ui
+++ b/QgisModelBaker/ui/dbparam_map.ui
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>477</width>
+    <height>355</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="description_label">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter your custom parameters passed to ili2db via temporary file by &lt;span style=&quot; font-family:'monospace';&quot;&gt;--dbparams&lt;/span&gt;. Be aware that those settings are not used in the QGIS Project.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QTableWidget" name="mappingtable">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="rowCount">
+      <number>0</number>
+     </property>
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <attribute name="horizontalHeaderMinimumSectionSize">
+      <number>50</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderMinimumSectionSize">
+      <number>50</number>
+     </attribute>
+     <attribute name="verticalHeaderDefaultSectionSize">
+      <number>50</number>
+     </attribute>
+     <attribute name="verticalHeaderStretchLastSection">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Key</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Value</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/QgisModelBaker/ui/pg_settings_panel.ui
+++ b/QgisModelBaker/ui/pg_settings_panel.ui
@@ -14,11 +14,28 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="6" column="0" colspan="2">
-    <widget class="QgsAuthSettingsWidget" name="pg_auth_settings" native="true"/>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="pg_port_line_edit">
+     <property name="placeholderText">
+      <string>[Leave empty to use standard port 5432]</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="pg_schema_combo_box"/>
    </item>
    <item row="0" column="1">
     <widget class="QComboBox" name="pg_service_combo_box"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="pg_port_label">
+     <property name="text">
+      <string>Port</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QgsAuthSettingsWidget" name="pg_auth_settings" native="true"/>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
@@ -27,31 +44,10 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="pg_schema_label">
-     <property name="text">
-      <string>Schema</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QCheckBox" name="pg_use_super_login">
-     <property name="text">
-      <string>Use logins from settings (superuser) for schema generation</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="pg_host_label">
-     <property name="text">
-      <string>Host</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="pg_port_label">
-     <property name="text">
-      <string>Port</string>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="pg_database_line_edit">
+     <property name="placeholderText">
+      <string>Database Name</string>
      </property>
     </widget>
    </item>
@@ -62,27 +58,10 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="pg_port_line_edit">
-     <property name="placeholderText">
-      <string>[Leave empty to use standard port 5432]</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="pg_host_line_edit">
-     <property name="text">
-      <string>localhost</string>
-     </property>
-     <property name="placeholderText">
-      <string>Database Hostname</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="pg_database_line_edit">
-     <property name="placeholderText">
-      <string>Database Name</string>
+   <item row="5" column="1">
+    <widget class="QComboBox" name="pg_ssl_mode_combo_box">
+     <property name="toolTip">
+      <string>This option determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.</string>
      </property>
     </widget>
    </item>
@@ -96,15 +75,49 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QComboBox" name="pg_ssl_mode_combo_box">
-     <property name="toolTip">
-      <string>This option determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.</string>
+   <item row="8" column="0" colspan="2">
+    <widget class="QCheckBox" name="pg_use_super_login">
+     <property name="text">
+      <string>Use logins from settings (superuser) for schema generation</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="pg_schema_combo_box"/>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="pg_host_line_edit">
+     <property name="text">
+      <string>localhost</string>
+     </property>
+     <property name="placeholderText">
+      <string>Database Hostname</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="pg_host_label">
+     <property name="text">
+      <string>Host</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="pg_schema_label">
+     <property name="text">
+      <string>Schema</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QToolButton" name="pg_dbparam_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Specific custom parameters</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/QgisModelBaker/ui/pg_settings_panel.ui
+++ b/QgisModelBaker/ui/pg_settings_panel.ui
@@ -114,6 +114,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specific user defined parameters are passed to ili2db via a temporary file to &lt;span style=&quot; font-family:'monospace';&quot;&gt;--dbparams&lt;/span&gt;. These settings are used to create or update a database. They are not considered in the QGIS project.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
       <string>Specific custom parameters</string>
      </property>

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "1.11.0")
+MODELBAKER_LIBRARY=("modelbaker" "2.0.0")
 PACKAGING=("packaging" "21.3")
 
 PACKAGES=(


### PR DESCRIPTION
Specific user defined parameters are passed to ili2db via a temporary file to` --dbparams`. These settings are used to create or update a database. They are not considered in the QGIS project.

The possible parameters are described in the respective JDBC driver - I linked it to the description in the GUI: https://jdbc.postgresql.org/documentation/use/#connection-parameters

The dialog can be opened by the button "Specific custom parameters".

![image](https://github.com/user-attachments/assets/3b34e7e7-ffe7-4a8d-bf07-e1148a9032b8)

This is the dialog to set the parameters.

![image](https://github.com/user-attachments/assets/e6261570-5295-4156-9176-f53d5de8405e)

These parameters are stored in the configuration. Then on calling ili2pg they are written to a temporary file (like the sslmode).

This depends on https://github.com/opengisch/QgisModelBakerLibrary/pull/145

- [x] Tests in modelbaker lib
- [x] ~Help Button~ (more description instead)

Resolves #1023