### PR TITLE
quick viewer uses skipReferenceErrors to be able to display data with…

### DIFF
--- a/QgisModelBaker/utils/tools.py
+++ b/QgisModelBaker/utils/tools.py
@@ -202,6 +202,7 @@ class QuickVisualizer(QObject):
         # parameters to import the data "dirty" (without validation and constraints)
         configuration.inheritance = "smart2"
         configuration.disable_validation = True
+        configuration.skip_reference_errors = True
         configuration.with_schemaimport = True
 
         importer.configuration = configuration


### PR DESCRIPTION
… missing catalogues. Fixes #1050

and it requires https://github.com/opengisch/QgisModelBakerLibrary/pull/149