### PR TITLE
Validator crossed and grayed out when error is marked as fixed

### DIFF
--- a/docs/docs/user_guide/validation.md
+++ b/docs/docs/user_guide/validation.md
@@ -51,7 +51,7 @@ With *right click* on the error a menu is opened with the following options:
 - Zoom to coordinates (if coordinates are provided) with an extend of 10 map units
 - Open in Feature Form (if a stable t_ili_tid is available)
 - Select in Attribute Table (if a stable t_ili_tid is available)
-- Set to fixed (marking the entry mark green to have organize the fixing process)
+- Mark as fixed (marking the entry mark green and crossed over to have organize the fixing process)
 - Copy (to copy the message text)
 
 Automatic pan, zoom and highlight features or coordinates are performed by clicking on the result tables entry.


### PR DESCRIPTION
While evaluating this #1045 I noted again that the "fixed" entries in the list with this green button are hard to see. Maybe it's because of my color-blindness but even then, it's better to have it clearer.

<img width="784" height="183" alt="Screenshot from 2025-08-26 09-42-46" src="https://github.com/user-attachments/assets/14e5bb71-fba9-40f7-a240-87549cfbf46e" />

And name it "mark as fixed" and not "set to fixed" to avoid that the user believes they really *fix* the error.