### PR TITLE
Remove confusing "Set configuration" from OID Generation page

### DIFF
--- a/QgisModelBaker/gui/panel/set_sequence_panel.py
+++ b/QgisModelBaker/gui/panel/set_sequence_panel.py
@@ -36,6 +36,9 @@ class SetSequencePanel(QWidget, WIDGET_UI):
         self.last_loaded_sequence_value = None
         self.sequence_value_edit.setSpecialValueText("-")
 
+    def is_checked(self):
+        return self.sequence_group.isChecked()
+
     def set_configuration(self, configuration):
         self.configuration = configuration
         self.pg_use_super_login.setVisible(self.configuration.tool & DbIliMode.pg)

--- a/QgisModelBaker/gui/panel/tid_configurator_panel.py
+++ b/QgisModelBaker/gui/panel/tid_configurator_panel.py
@@ -85,9 +85,11 @@ class TIDConfiguratorPanel(QWidget, WIDGET_UI):
         return result, message
 
     def set_tid_configuration(self):
-        result, message = self.set_sequence_panel.save_sequence()
-        # only set the project settings when the sequence part succeeds (or is not performed)
+        result = True
+        if self.sequence_panel.is_checked():
+            result, message = self.set_sequence_panel.save_sequence()
+        # only set the project settings when the sequence part succeeds (or is not performed) or is not required
         if result:
             self.layer_tids_panel.save_tid_config(self.qgis_project)
-            return True, message
-        return False, message
+            message = self.tr("Set OID configurations successfully")
+        return result, message

--- a/QgisModelBaker/gui/panel/tid_configurator_panel.py
+++ b/QgisModelBaker/gui/panel/tid_configurator_panel.py
@@ -86,7 +86,7 @@ class TIDConfiguratorPanel(QWidget, WIDGET_UI):
 
     def set_tid_configuration(self):
         result = True
-        if self.sequence_panel.is_checked():
+        if self.set_sequence_panel.is_checked():
             result, message = self.set_sequence_panel.save_sequence()
         # only set the project settings when the sequence part succeeds (or is not performed) or is not required
         if result:

--- a/QgisModelBaker/gui/workflow_wizard/tid_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/tid_configuration_page.py
@@ -42,32 +42,33 @@ class TIDConfigurationPage(QWizardPage, PAGE_UI):
         self.tid_configurator_panel = TIDConfiguratorPanel(self.workflow_wizard)
         self.tid_configurator_layout.addWidget(self.tid_configurator_panel)
 
-        self.set_layer_tids_and_sequence_button.clicked.connect(
-            self._set_tid_configuration
-        )
-
         self.configuration = None
 
     def set_configuration(self, configuration):
         self.tid_configurator_panel.setup_dialog(QgsProject.instance(), configuration)
 
     def _set_tid_configuration(self):
-        self.progress_bar.setValue(0)
+        self.workflow_wizard.busy(
+            self,
+            True,
+            self.tr("Storing OID configurations"),
+        )
         # we store the settings to project and db
         result, message = self.tid_configurator_panel.set_tid_configuration()
         if result:
             self.workflow_wizard.log_panel.print_info(
-                self.tr("Stored OID configurations to current project")
+                self.tr("Stored OID configurations successfully.")
             )
-            self.workflow_wizard.log_panel.print_info(
-                self.tr("Stored the sequence value to current database")
-            )
-            self.progress_bar.setValue(100)
-            self.setStyleSheet(gui_utils.SUCCESS_STYLE)
+            self.workflow_wizard.busy(self, False)
+            return True
         else:
-            self.workflow_wizard.log_panel.print_info(message, LogLevel.WARNING)
-            self.progress_bar.setValue(100)
-            self.setStyleSheet(gui_utils.ERROR_STYLE)
+            self.workflow_wizard.log_panel.print_info(message, LogLevel.FAIL)
+            self.workflow_wizard.busy(self, False)
+        return False
+
+    def validatePage(self) -> bool:
+        return self._set_tid_configuration()
+        return super().validatePage()
 
     def help_text(self):
         logline = self.tr(

--- a/QgisModelBaker/ui/workflow_wizard/tid_configuration.ui
+++ b/QgisModelBaker/ui/workflow_wizard/tid_configuration.ui
@@ -39,39 +39,12 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QProgressBar" name="progress_bar">
-     <property name="value">
-      <number>0</number>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0" colspan="2">
     <layout class="QVBoxLayout" name="tid_configurator_layout">
      <property name="sizeConstraint">
       <enum>QLayout::SetMaximumSize</enum>
      </property>
     </layout>
-   </item>
-   <item row="3" column="0">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="1">
-    <widget class="QCommandLinkButton" name="set_layer_tids_and_sequence_button">
-     <property name="text">
-      <string>Set configuration</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Remove "Set configuration" and progress bar. On "Finish" it performs the action. If there is an issue, it does not close the dialog and prints a message. On success, it closes the wizard. Mostly an issue encounters when something with the sequence happens.

<img width="858" height="756" alt="image" src="https://github.com/user-attachments/assets/d6c0e6cd-1036-4b8e-a2af-58c1c2df9c5b" />

Including fix, that it does not perform the sequence modification when the checkbox is not checked.