### PR TITLE
Fix weird behavior on failed ili2db sessions

### DIFF
--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -318,6 +318,7 @@ class SessionPanel(QWidget, WIDGET_UI):
             self.run(edited_command)
 
     def run(self, edited_command=None):
+        self.is_skipped_or_done = False
         if self.is_running:
             # means this is called by "cancel" option
             self.print_info.emit(self.tr("Cancel session..."), LogLevel.INFO)

--- a/QgisModelBaker/gui/workflow_wizard/execution_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/execution_page.py
@@ -19,7 +19,7 @@
 
 import copy
 
-from qgis.PyQt.QtCore import QCoreApplication, QEventLoop
+from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import (
     QSizePolicy,
     QSpacerItem,
@@ -171,12 +171,11 @@ class ExecutionPage(QWizardPage, PAGE_UI):
         self.setComplete(not self.pending_sessions)
 
     def _run(self):
-        loop = QEventLoop()
         for session_widget in self.session_widget_list:
-            session_widget.on_done_or_skipped.connect(lambda: loop.quit())
-            # fall in a loop on fail untill the user skipped it or it has been successful
+            if session_widget.is_skipped_or_done:
+                continue
             if not session_widget.run():
-                loop.exec()
+                return
 
     def _on_process_started(self, command):
         self.workflow_wizard.log_panel.print_info(command, LogLevel.INFO)


### PR DESCRIPTION
When a session is skipped the loop to excecute all sessions is interupted.

On pressing 'run all commands' again only the one that are not done or skipped are started.

[Screencast from 29.08.2025 13:29:57.webm](https://github.com/user-attachments/assets/29bf5a6d-9390-450f-bbe7-8aa482863611)

This fixes #1021
