### PR TITLE
Do not expose baskets without t_ili_tid (BID)

### DIFF
--- a/QgisModelBaker/gui/panel/filter_data_panel.py
+++ b/QgisModelBaker/gui/panel/filter_data_panel.py
@@ -65,9 +65,10 @@ class FilterDataPanel(QWidget, WIDGET_UI):
             self.filter_combobox.addItem(
                 self.tr("Datasets"), gui_utils.SchemaDataFilterMode.DATASET
             )
-            self.filter_combobox.addItem(
-                self.tr("Baskets"), gui_utils.SchemaDataFilterMode.BASKET
-            )
+            if self.parent.current_baskets_model.rowCount() > 0:
+                self.filter_combobox.addItem(
+                    self.tr("Baskets"), gui_utils.SchemaDataFilterMode.BASKET
+                )
         if self.filter_combobox.itemData(stored_index):
             self.filter_combobox.setCurrentIndex(stored_index)
             if (

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -1214,6 +1214,8 @@ class SchemaBasketsModel(CheckEntriesModel):
         ):
             baskets_info = db_connector.get_baskets_info()
             for record in baskets_info:
+                if not record["basket_t_ili_tid"]:
+                    continue
                 basketname = f"{record['datasetname']}-{record['topic']} ({record['basket_t_ili_tid']}) {record['attachmentkey']}"
                 basketnames.append(basketname)
                 self._basket_ids[basketname] = record["basket_t_ili_tid"]


### PR DESCRIPTION
if baskets do not have a t_ili_tid, they cannot be validated or exported.

so, we do not expose baskets without t_ili_tid to the gui. and if there is no basket, they are neither listed in the filter-combo. This resolves #957