### PR TITLE
Pass jar-location + 'plugins' as plugin dir on validation

### DIFF
--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -49,7 +49,10 @@ from QgisModelBaker.libs.modelbaker.db_factory.db_simple_factory import DbSimple
 from QgisModelBaker.libs.modelbaker.iliwrapper import ilivalidator
 from QgisModelBaker.libs.modelbaker.iliwrapper.globals import DbIliMode
 from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbconfig import ValidateConfiguration
-from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbutils import JavaNotFoundError, get_ili2db_bin
+from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbutils import (
+    JavaNotFoundError,
+    get_ili2db_bin,
+)
 from QgisModelBaker.libs.modelbaker.iliwrapper.ilivalidator import ValidationResultModel
 from QgisModelBaker.libs.modelbaker.utils.qt_utils import OverrideCursor
 from QgisModelBaker.utils import gui_utils
@@ -385,7 +388,17 @@ class ValidateDock(QDockWidget, DIALOG_UI):
                 validator.configuration.dbusr = QgsApplication.userLoginName()
 
         # if exists, we add a plugin dir located next to the jar-file - this might be configurable in future
-        plugins_dir = os.path.join(os.path.dirname(get_ili2db_bin(validator.tool, validator._get_ili2db_version(),self._validator_stdout,self._validator_stderr)), "plugins")
+        plugins_dir = os.path.join(
+            os.path.dirname(
+                get_ili2db_bin(
+                    validator.tool,
+                    validator._get_ili2db_version(),
+                    self._validator_stdout,
+                    self._validator_stderr,
+                )
+            ),
+            "plugins",
+        )
         if os.path.exists(plugins_dir) and os.path.isdir(plugins_dir):
             validator.configuration.plugins_dir = plugins_dir
         validator.configuration.ilimodels = ""


### PR DESCRIPTION
if there is a plugins folder alongside the jar file, we pass it as --plugins

this folder is the default folder in ilivaidator

there are still discussions about the general concept of the plugins like if ili2db should download the plugins itself and so on. Maybe we might need a setting for a custom path or whatever, but until then, we keep it static.

depends on https://github.com/opengisch/QgisModelBakerLibrary/pull/159