### PR TITLE
New option on creating the schema: Run without not null

### DIFF
--- a/QgisModelBaker/gui/panel/session_panel.py
+++ b/QgisModelBaker/gui/panel/session_panel.py
@@ -89,6 +89,14 @@ class SessionPanel(QWidget, WIDGET_UI):
         self.set_button_to_create_without_constraints_action.triggered.connect(
             self.set_button_to_create_without_constraints
         )
+
+        self.set_button_to_create_without_not_null_action = QAction(
+            self.tr("Run without not null"), None
+        )
+        self.set_button_to_create_without_not_null_action.triggered.connect(
+            self.set_button_to_create_without_not_null
+        )
+
         self.edit_command_action = QAction(self.tr("Edit ili2db command"), None)
         self.edit_command_action.triggered.connect(self.edit_command)
 
@@ -98,6 +106,10 @@ class SessionPanel(QWidget, WIDGET_UI):
         self.create_tool_button.addAction(
             self.set_button_to_create_without_constraints_action
         )
+        if self.db_action_type == DbActionType.SCHEMA_IMPORT:
+            self.create_tool_button.addAction(
+                self.set_button_to_create_without_not_null_action
+            )
         self.create_tool_button.addAction(self.edit_command_action)
         self.create_tool_button.addAction(self.skip_action)
 
@@ -218,12 +230,23 @@ class SessionPanel(QWidget, WIDGET_UI):
         The buttons actions are changed to be able to switch the with-validation mode.
         """
         self.configuration.disable_validation = False
+        self.configuration.disable_mandatory = False
         self.create_tool_button.removeAction(self.set_button_to_create_action)
+        self.create_tool_button.removeAction(
+            self.set_button_to_create_without_constraints_action
+        )
+        self.create_tool_button.removeAction(
+            self.set_button_to_create_without_not_null_action
+        )
         self.create_tool_button.removeAction(self.edit_command_action)
         self.create_tool_button.removeAction(self.skip_action)
         self.create_tool_button.addAction(
             self.set_button_to_create_without_constraints_action
         )
+        if self.db_action_type == DbActionType.SCHEMA_IMPORT:
+            self.create_tool_button.addAction(
+                self.set_button_to_create_without_not_null_action
+            )
         self.create_tool_button.addAction(self.edit_command_action)
         self.create_tool_button.addAction(self.skip_action)
         self.create_tool_button.setText(self.create_text)
@@ -231,19 +254,54 @@ class SessionPanel(QWidget, WIDGET_UI):
     def set_button_to_create_without_constraints(self):
         """
         Changes the text of the button to create without validation and sets the validate_data to false.
-        So on clicking the button the creation will start without validation.
+        So on clicking the button the creation will start without setting constraints or without validating data.
         The buttons actions are changed to be able to switch the with-validation mode.
         """
         self.configuration.disable_validation = True
+        self.configuration.disable_mandatory = False
         self.create_tool_button.removeAction(
             self.set_button_to_create_without_constraints_action
         )
+        self.create_tool_button.removeAction(
+            self.set_button_to_create_without_not_null_action
+        )
+        self.create_tool_button.removeAction(self.set_button_to_create_action)
         self.create_tool_button.removeAction(self.edit_command_action)
         self.create_tool_button.removeAction(self.skip_action)
         self.create_tool_button.addAction(self.set_button_to_create_action)
+        if self.db_action_type == DbActionType.SCHEMA_IMPORT:
+            self.create_tool_button.addAction(
+                self.set_button_to_create_without_not_null_action
+            )
         self.create_tool_button.addAction(self.edit_command_action)
         self.create_tool_button.addAction(self.skip_action)
         self.create_tool_button.setText(self.create_without_constraints_text)
+
+    def set_button_to_create_without_not_null(self):
+        """
+        Changes the text of the button to create without not null constraints and sets the disable_mandatory to true.
+        So on clicking the button the creation will start without setting not null constraints.
+        The buttons actions are changed to be able to switch the with-not-null-constraints mode.
+        """
+        self.configuration.disable_validation = False
+        self.configuration.disable_mandatory = True
+
+        self.create_tool_button.removeAction(
+            self.set_button_to_create_without_not_null_action
+        )
+        self.create_tool_button.removeAction(
+            self.set_button_to_create_without_not_null_action
+        )
+        self.create_tool_button.removeAction(self.set_button_to_create_action)
+        self.create_tool_button.removeAction(self.edit_command_action)
+        self.create_tool_button.removeAction(self.skip_action)
+        self.create_tool_button.addAction(self.set_button_to_create_action)
+        self.create_tool_button.addAction(
+            self.set_button_to_create_without_constraints_action
+        )
+        self.create_tool_button.addAction(self.edit_command_action)
+        self.create_tool_button.addAction(self.skip_action)
+        self.create_tool_button.setText(self.tr("Run without not null"))
 
     def set_button_to_last_create_state(self):
         if self.configuration.disable_validation:

--- a/docs/docs/user_guide/export_workflow.md
+++ b/docs/docs/user_guide/export_workflow.md
@@ -45,6 +45,6 @@ With the ![run arrow_button](../assets/arrow_button.png) button next to *Run* th
 
 ### Data Validation
 
-If you did not choose *Run without constraints* on your export session, then the data are validated against their INTERLIS models. If this validation did not succeed, then the export will fail.
+If you did not choose *Run without validation* on your export session, then the data are validated against their INTERLIS models. If this validation did not succeed, then the export will fail.
 
 To check your data in advance against the INTERLIS model, use the [Model Baker Validator](../validation/).

--- a/docs/docs/user_guide/import_workflow.md
+++ b/docs/docs/user_guide/import_workflow.md
@@ -128,7 +128,10 @@ In the next step you can run all the sessions to create your physical model. In 
 
 ![wizard schema import sessions](../assets/workflow_wizard_schema_session.png)
 
-With the ![run arrow_button](../assets/arrow_button.png) button next to *Run* the options are provided to run the command without checking constraints or to edit the command manually before running it.
+With the ![run arrow_button](../assets/arrow_button.png) button next to *Run* the options are provided to run the command without creating constraints or not null constraints or to edit the command manually before running it.
+
+!!! Note
+    When "Run without constraints" is selected, the parameters `--sqlEnableNull` and `--sqlColsAsText` are additionally passed to ili2db, while the parameters `--createNumChecks`, `--createUnique` and `--createFk` are removed. This results in a super-tolerant database that allows for lots of data inputs when fixing invalid data or performing a migration. When "Run without not null" is selected, only the additional parameter `--sqlEnableNull` is passed, and all other constraints and column types are still considered.
 
 ## 5. Create Baskets
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -92,16 +92,15 @@ plugins:
             Model and Data Import Workflow: Modell und Daten Import Workflow
             Export Data Workflow: Daten Export Workflow
             Validate Data: Daten Validierung
-            Topping Exporter: Topping Exporter
+            Toppings: Toppings
             Quick Visualizer: Quick Visualizer
             Plugin Configuration: Plugin Konfiguration
             Tipps & Tricks: Tipps & Tricks
             Repositories: Repositories
             Basket and Dataset Handling: Dataset und Basket Handling
             OID Generator: OID Generator
-            Toppings: Toppings
-            Overview: Übersicht
-            Model Baker Integration: Model Baker Integration
+            Toppingfiles: Toppingfiles
+            Create your own Toppings: Create your own Toppings
             Technical Concept: Technisches Konzept
             Optimized Projects for Extended Models: Optimierte Projekte für
               erweiterte Modelle
@@ -138,7 +137,7 @@ plugins:
               modèles et de données
             Export Data Workflow: Flux de travail d'exportation de données
             Validate Data: Validation des données
-            Topping Exporter: Exportateur de Topping
+            Toppings: Toppings
             Quick Visualizer: Quick Visualizer
             Plugin Configuration: Configuration du plugin
             Tipps & Tricks: Trucs et astuces
@@ -146,9 +145,8 @@ plugins:
             Basket and Dataset Handling: Gestion des paniers (baskets) et des
               ensembles (datasets)
             OID Generator: Générateur OID
-            Toppings: Toppings
-            Overview: Vue d'ensemble
-            Model Baker Integration: Intégration de Model Baker
+            Toppingfiles: Toppingfiles
+            Create your own Toppings: Create your own Toppings
             Technical Concept: Concept technique
             Optimized Projects for Extended Models: Projets optimisés pour les
               modèles étendus

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "2.4.3")
+MODELBAKER_LIBRARY=("modelbaker" "2.5.0")
 PACKAGING=("packaging" "21.3")
 
 PACKAGES=(


### PR DESCRIPTION
Avoiding to create mandatory not null constraints on the field. This sets disable_mandatory on the configuration and will lead to the parameter sqlEnableNull on ili2db command.

<img width="1059" height="352" alt="Screenshot From 2026-02-25 20-15-51" src="https://github.com/user-attachments/assets/55a69289-5a06-41a0-98a1-e1349f6e0c5d" />

See in Doku:
> When "Run without constraints" is selected, the parameters `--sqlEnableNull` and `--sqlColsAsText` are additionally passed to ili2db, while the parameters `--createNumChecks`, `--createUnique` and `--createFk` are removed. This results in a super-tolerant database that allows for lots of data inputs when fixing invalid data or performing a migration. When "Run without not null" is selected, only the additional parameter `--sqlEnableNull` is passed, and all other constraints and column types are still considered.

Requires https://github.com/opengisch/QgisModelBakerLibrary/pull/165