### PR TITLE
Placeholder in the list view to drag files to it

### DIFF
--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -14,6 +14,7 @@ from qgis.PyQt.QtCore import (
     QModelIndex,
     QObject,
     QRect,
+    QRectF,
     QSortFilterProxyModel,
     QStringListModel,
     Qt,
@@ -22,9 +23,11 @@ from qgis.PyQt.QtCore import (
 from qgis.PyQt.QtGui import (
     QColor,
     QIcon,
+    QPainter,
     QPalette,
     QStandardItem,
     QStandardItemModel,
+    QTextOption,
     QValidator,
 )
 from qgis.PyQt.QtWidgets import (
@@ -305,6 +308,25 @@ class FileDropListView(QListView):
                 dropped_ini_files.append(local_file)
 
         return dropped_interlis_files, dropped_xml_files, dropped_ini_files
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+
+        if not self.model() or self.model().rowCount() == 0:
+            painter = QPainter(self.viewport())
+            # valid gray for all the themes
+            painter.setPen(Qt.GlobalColor.gray)
+
+            text_option = QTextOption(Qt.AlignmentFlag.AlignCenter)
+            text_option.setWrapMode(QTextOption.WrapMode.WordWrap)
+
+            painter.drawText(
+                QRectF(self.viewport().rect()),
+                self.tr(
+                    "Drag a file into this zone (.ili, .xtf, .itf, .xml, .ini, .toml)"
+                ),
+                text_option,
+            )
 
 
 class SourceModel(QStandardItemModel):


### PR DESCRIPTION
<img width="676" height="513" alt="image" src="https://github.com/user-attachments/assets/0d1d879a-11f4-4cf2-b21f-4bbcec6084d9" />
<img width="698" height="566" alt="image" src="https://github.com/user-attachments/assets/e880d609-2691-411f-adfb-a07ec215951a" />


I decided to keep the info **as short as possible** and against something like "Drag the desired file into this field or select one or a model from the repository in the selector above and add it with + (.ili, .xtf, . itf, .xml, .ini, .toml)" because people prefer to read literature instead of GUI instructions...

See #931

### Financed 
by the QGIS Model Baker Group