### PR TITLE
Text in the validate button

### DIFF
--- a/QgisModelBaker/ui/validator.ui
+++ b/QgisModelBaker/ui/validator.ui
@@ -65,7 +65,7 @@
          <item>
           <widget class="QToolButton" name="run_button">
            <property name="text">
-            <string>✔</string>
+            <string>Validate ✔</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
<img width="579" height="36" alt="image" src="https://github.com/user-attachments/assets/9e7417e4-4162-44aa-96df-ee1f9b1e343e" />

<img width="519" height="40" alt="image" src="https://github.com/user-attachments/assets/7cf005d3-d5ea-456a-ab49-b83dec4f4dd3" />

Before it was only a checkmark in the button.

This fixes #1085 what was a user request to have a text "validate" there. I keep the checkmark though.


### Financed 
by the QGIS Model Baker Group

