### PR TITLE
SettingsProphet integration

### DIFF
--- a/QgisModelBaker/__init__.py
+++ b/QgisModelBaker/__init__.py
@@ -16,6 +16,15 @@
  *                                                                         *
  ***************************************************************************/
 """
+import os
+import sys
+
+# add libs path to be able to use libraries with absolute paths in the modelbaker package
+_libs_dir = os.path.join(os.path.dirname(__file__), "libs")
+_modelbaker_libs_dir = os.path.join(_libs_dir, "modelbaker", "libs")
+for _path in (_modelbaker_libs_dir, _libs_dir):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
 
 
 def classFactory(iface):

--- a/QgisModelBaker/gui/ili2db_options.py
+++ b/QgisModelBaker/gui/ili2db_options.py
@@ -398,6 +398,42 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
             self.save_configuration()
         self._restyle_concerning_metaconfig()
 
+    def load_prophethy_settings(self, settings_prophet):
+        # basket column
+        if settings_prophet.needs_basket_column():
+            self.create_basket_col_checkbox.setChecked(True)
+            self.create_basket_groupbox.setVisible(False)
+        else:
+            self.create_basket_groupbox.setVisible(True)
+        # multiple geometries per table
+        if settings_prophet.contains_multiple_geometry_columns():
+            self.create_gpkg_multigeom_groupbox.setVisible(True)
+        else:
+            self.create_gpkg_multigeom_groupbox.setVisible(False)
+        # stroke arcs
+        if settings_prophet.contains_arcs():
+            self.stroke_arcs_groupbox.setVisible(True)
+        else:
+            self.stroke_arcs_groupbox.setVisible(False)
+        # enum
+        if settings_prophet.contains_enumerations():
+            self.enumeration_groupbox.setVisible(True)
+        else:
+            self.enumeration_groupbox.setVisible(False)
+        # language - here we have an original language option, so we don't need the preferred language
+        is_translation, languages, _ = settings_prophet.language_infos()
+        if is_translation:
+            self.translation_groupbox.setVisible(True)
+        else:
+            self.translation_groupbox.setVisible(False)
+        self._update_translation_combo(languages)
+
+    def _update_translation_combo(self, languages):
+        self.namelang_combo.clear()
+        for key in languages:
+            self.namelang_combo.addItem(displayLanguages.get(key, key), key)
+        self.namelang_combo.addItem(self.tr("Original model language"), "")
+
     def load_toml_file_path(self, key_postfix, toml_file_path):
         self.current_metaconfig_toml_file_path = toml_file_path
         self.set_toml_file_key(key_postfix)

--- a/QgisModelBaker/gui/ili2db_options.py
+++ b/QgisModelBaker/gui/ili2db_options.py
@@ -409,7 +409,7 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
             self.save_configuration()
         self._restyle_concerning_metaconfig()
 
-    def load_prophethy_settings(self, settings_prophet):
+    def load_prophecy_settings(self, settings_prophet):
         # basket column
         if settings_prophet.needs_basket_column():
             self.create_basket_col_checkbox.setChecked(True)

--- a/QgisModelBaker/gui/ili2db_options.py
+++ b/QgisModelBaker/gui/ili2db_options.py
@@ -26,7 +26,10 @@ from qgis.PyQt.QtWidgets import QDialog, QSizePolicy
 from QgisModelBaker.libs.modelbaker.utils.globals import LogLevel
 from QgisModelBaker.libs.modelbaker.utils.qt_utils import make_file_selector
 from QgisModelBaker.utils import gui_utils
-from QgisModelBaker.utils.globals import displayLanguages
+from QgisModelBaker.utils.globals import (
+    ORIGINAL_MODEL_LANGUAGE,
+    displayLanguages,
+)
 from QgisModelBaker.utils.gui_utils import get_text_color
 
 DIALOG_UI = gui_utils.get_ui_class("ili2db_options.ui")
@@ -100,7 +103,7 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         self.namelang_combo.clear()
         for key in displayLanguages.keys():
             self.namelang_combo.addItem(displayLanguages.get(key, key), key)
-        self.namelang_combo.addItem(self.tr("Original model language"), "")
+        self.namelang_combo.addItem(ORIGINAL_MODEL_LANGUAGE, "")
 
         self.restore_configuration()
 
@@ -157,7 +160,6 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         self.namelang_combo.currentIndexChanged.connect(
             lambda: self._restyle_concerning_metaconfig()
         )
-
         self.metaconfig_info_label.setVisible(False)
 
         self.create_import_tid_groupbox.setHidden(remove_create_tid_group)
@@ -176,6 +178,15 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
                     gdal_version=gdal.VersionInfo("RELEASE_NAME"),
                 )
             )
+
+        # current status set by the prophet, if the prophet is not used, this will be false
+        self.model_contains_extended_enumerations = False
+        self.smart1_radio_button.toggled.connect(
+            lambda: self._update_enums_according_to_inheritance()
+        )
+        self.smart2_radio_button.toggled.connect(
+            lambda: self._update_enums_according_to_inheritance()
+        )
 
         self.bar = QgsMessageBar()
         self.bar.setSizePolicy(
@@ -333,7 +344,7 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
             self.create_gpkg_multigeom_checkbox.setChecked(False)
         self.stroke_arcs_checkbox.setChecked(stroke_arcs)
         self.namelang_combo.setCurrentText(
-            displayLanguages.get(name_lang, "Original model language")
+            displayLanguages.get(name_lang, ORIGINAL_MODEL_LANGUAGE)
         )
         self.toml_file_line_edit.setText(settings.value(self.toml_file_key))
 
@@ -392,7 +403,7 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
                 self.namelang_combo.setCurrentText(
                     displayLanguages.get(
                         self.current_metaconfig_ili2db.get("nameLang", ""),
-                        "Original model language",
+                        ORIGINAL_MODEL_LANGUAGE,
                     )
                 )
             self.save_configuration()
@@ -418,6 +429,9 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         # enum
         if settings_prophet.contains_enumerations():
             self.enumeration_groupbox.setVisible(True)
+            if settings_prophet.contains_extended_enumerations():
+                self.model_contains_extended_enumerations = True
+                self._update_enums_according_to_inheritance()
         else:
             self.enumeration_groupbox.setVisible(False)
         # language - here we have an original language option, so we don't need the preferred language
@@ -427,12 +441,33 @@ class Ili2dbOptionsDialog(QDialog, DIALOG_UI):
         else:
             self.translation_groupbox.setVisible(False)
         self._update_translation_combo(languages)
+        self.save_configuration()
+        self._restyle_concerning_metaconfig()
 
     def _update_translation_combo(self, languages):
+        current_lang = self.namelang_combo.currentData()
         self.namelang_combo.clear()
         for key in languages:
             self.namelang_combo.addItem(displayLanguages.get(key, key), key)
-        self.namelang_combo.addItem(self.tr("Original model language"), "")
+        self.namelang_combo.addItem(ORIGINAL_MODEL_LANGUAGE, "")
+        # if the current language is still in the list, keep it selected, otherwise select the original model language
+        if current_lang in languages:
+            self.namelang_combo.setCurrentText(
+                displayLanguages.get(current_lang, ORIGINAL_MODEL_LANGUAGE)
+            )
+        else:
+            self.namelang_combo.setCurrentText(ORIGINAL_MODEL_LANGUAGE)
+
+    def _update_enums_according_to_inheritance(self):
+        if (
+            self.model_contains_extended_enumerations
+            and self.smart1_radio_button.isChecked()
+        ):
+            if self.enum_tabs_radio_button.isChecked():
+                self.enum_singletab_radio_button.setChecked(True)
+            self.enum_tabs_radio_button.setVisible(False)
+        else:
+            self.enum_tabs_radio_button.setVisible(True)
 
     def load_toml_file_path(self, key_postfix, toml_file_path):
         self.current_metaconfig_toml_file_path = toml_file_path

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -27,13 +27,19 @@ from qgis.PyQt.QtCore import QSettings, Qt
 from qgis.PyQt.QtWidgets import QCompleter, QWizardPage
 
 from QgisModelBaker.gui.ili2db_options import Ili2dbOptionsDialog
+from QgisModelBaker.libs.modelbaker.ili2pytools.prophets import SettingsProphet
+from QgisModelBaker.libs.modelbaker.ili2pytools.pythonizer import BakerPyIndex
 from QgisModelBaker.libs.modelbaker.iliwrapper.globals import DbIliMode
 from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
     IliDataCache,
     IliDataFileCompleterDelegate,
     IliDataItemModel,
 )
-from QgisModelBaker.libs.modelbaker.utils.globals import LogLevel
+from QgisModelBaker.libs.modelbaker.utils.globals import (
+    MODELS_BLACKLIST,
+    LogLevel,
+)
+from QgisModelBaker.libs.modelbaker.utils.ili2db_utils import Ili2DbUtils
 from QgisModelBaker.utils import gui_utils
 from QgisModelBaker.utils.globals import CRS_PATTERNS
 from QgisModelBaker.utils.gui_utils import (
@@ -186,6 +192,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                 break
         self._update_ilimetaconfigcache()
         self._update_ilireferencedatacache()
+        self._update_prophety_settings()
 
     def _update_ilimetaconfigcache(self):
         self.ilimetaconfigcache = IliDataCache(
@@ -436,6 +443,8 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self.setComplete(True)
 
     def _update_linked_models(self):
+        self.workflow_wizard.busy(self, True, "Update linked models...")
+
         linked_models = []
 
         for r in range(
@@ -463,7 +472,139 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                 None,
                 self.tr("Linked model referenced over ilidata repository"),
             ):
-                self.workflow_wizard.refresh_import_models()
+                self._refresh_model_data()
+
+        self.workflow_wizard.busy(self, False)
+
+    def _refresh_model_data(self):
+        self.workflow_wizard.refresh_import_models()
+
+    def _update_prophety_settings(self):
+        checked_models = (
+            self.workflow_wizard.import_models_model.checked_models_with_source()
+        )
+
+        self.workflow_wizard.log_panel.print_info(
+            self.tr("Prophety the settings according the models: {}").format(
+                ", ".join(checked_models.keys())
+            ),
+            LogLevel.INFO,
+        )
+        # multiple iteration through the (not many) models to keep the workflow structured
+        model_files = {}
+        for model in checked_models.keys():
+            if "ili" == checked_models[model]["type"]:
+                # local model file, get the local path
+                model_files[model] = checked_models[model]["source"]
+                self.workflow_wizard.log_panel.print_info(
+                    self.tr("- Model {} in local file {}.").format(
+                        model, model_files[model]
+                    ),
+                    LogLevel.INFO,
+                )
+            else:
+                self.workflow_wizard.log_panel.print_info(
+                    self.tr(
+                        "- Model {} in repository requires download..."
+                    ).format(model),
+                    LogLevel.INFO,
+                )
+                repo, file = self.workflow_wizard.get_filepath_from_ilicache(
+                    model
+                )
+                if file:
+                    (
+                        local_file,
+                        message,
+                    ) = self.workflow_wizard.download_ilifile(repo, file)
+                    if local_file:
+                        self.workflow_wizard.log_panel.print_info(
+                            message,
+                            LogLevel.INFO,
+                        )
+                        model_files[model] = local_file
+                    else:
+                        self.workflow_wizard.log_panel.print_info(
+                            message,
+                            LogLevel.WARNING,
+                        )
+                else:
+                    self.workflow_wizard.log_panel.print_info(
+                        self.tr(
+                            "  ...failed to receive file url from ilicache."
+                        ),
+                        LogLevel.WARNING,
+                    )
+
+        if not model_files:
+            self.workflow_wizard.log_panel.print_info(
+                self.tr("No model files found to prophety the settings..."),
+                LogLevel.INFO,
+            )
+            return
+
+        imd_files = {}
+        for model in model_files.keys():
+            imd_file = str(
+                pathlib.Path(model_files[model]).with_suffix(".imd")
+            )
+            if os.path.exists(imd_file):
+                self.workflow_wizard.log_panel.print_info(
+                    self.tr("- Metamodel for Model {} found in cache.").format(
+                        model
+                    ),
+                    LogLevel.INFO,
+                )
+                imd_files[model] = imd_file
+                continue
+            self.workflow_wizard.log_panel.print_info(
+                self.tr(
+                    "- Metamodel for Model {} needs to be compiled..."
+                ).format(model),
+                LogLevel.INFO,
+            )
+            result, imd_file, message = Ili2DbUtils().compile(
+                model_files[model], None, imd_file
+            )
+            if not result:
+                self.workflow_wizard.log_panel.print_error(
+                    self.tr("  ...failed to compile model file {}: {}").format(
+                        model, message
+                    ),
+                    LogLevel.WARNING,
+                )
+            else:
+                self.workflow_wizard.log_panel.print_info(
+                    self.tr(
+                        "  ...metamodel for Model {} successfully compiled."
+                    ).format(model),
+                    LogLevel.INFO,
+                )
+                imd_files[model] = imd_file
+        if not imd_files:
+            self.workflow_wizard.log_panel.print_info(
+                self.tr("No imds found to prophety the settings..."),
+                LogLevel.INFO,
+            )
+            return
+
+        model_indexes = {}
+        for model in imd_files.keys():
+            model_indexes[model] = BakerPyIndex.from_imd(imd_files[model])
+        if not model_indexes:
+            self.workflow_wizard.log_panel.print_info(
+                self.tr("No indexes found to prophety the settings..."),
+                LogLevel.INFO,
+            )
+            return
+
+        settings_prophet = SettingsProphet(model_indexes, MODELS_BLACKLIST)
+        if settings_prophet is not None:
+            self.ili2db_options.load_prophethy_settings(settings_prophet)
+        self.workflow_wizard.log_panel.print_info(
+            self.tr("Prophety the settings according the models finished."),
+            LogLevel.INFO,
+        )
 
     def _load_crs_from_metaconfig(self, ili2db_metaconfig):
         srs_auth = self.srs_auth
@@ -630,7 +771,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                             ).format(referencedata_file_path),
                             LogLevel.TOPPING,
                         )
-            self.workflow_wizard.refresh_import_models()
+            self._refresh_model_data()
 
         self.workflow_wizard.busy(self, False)
 

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -21,6 +21,7 @@ import configparser
 import os
 import pathlib
 import re
+import urllib
 
 from qgis.core import QgsCoordinateReferenceSystem
 from qgis.PyQt.QtCore import QSettings, Qt
@@ -31,10 +32,12 @@ from QgisModelBaker.libs.modelbaker.ili2pytools.prophets import SettingsProphet
 from QgisModelBaker.libs.modelbaker.ili2pytools.pythonizer import BakerPyIndex
 from QgisModelBaker.libs.modelbaker.iliwrapper.globals import DbIliMode
 from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
+    IliCache,
     IliDataCache,
     IliDataFileCompleterDelegate,
     IliDataItemModel,
 )
+from QgisModelBaker.libs.modelbaker.utils import qt_utils
 from QgisModelBaker.libs.modelbaker.utils.globals import (
     MODELS_BLACKLIST,
     LogLevel,
@@ -182,6 +185,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         - Checks all checked models for CRS_PATTERNS (takes first match)
         - Calls update of ilimetaconfig cache to provide metaconfigurations
         - Calls update of ilireferencedata cache to load referenced
+        - Calls update of prophety settings to provide a good default for the ili2db options
         """
         model_list = self.model_list_view.model().checked_models()
         self.current_models = model_list
@@ -480,16 +484,28 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self.workflow_wizard.refresh_import_models()
 
     def _update_prophety_settings(self):
+        """
+        Prophety the ili2db settings according to the checked models.
+        1. Get the checked models with their source (local or repository)
+        2. For each model, get the local file path (download if necessary)
+        3. For each model, compile the model to get the imd file (if not already cached)
+        4. For each model, create a BakerPyIndex from the imd file
+        5. Create a SettingsProphet with the model indexes and the MODELS_BLACKLIST
+        6. Load the prophety settings into the ili2db_options
+        """
         checked_models = (
             self.workflow_wizard.import_models_model.checked_models_with_source()
         )
+        if checked_models is None:
+            return
 
         self.workflow_wizard.log_panel.print_info(
-            self.tr("Prophety the settings according the models: {}").format(
-                ", ".join(checked_models.keys())
-            ),
+            self.tr(
+                "Enable/disable the ili2db options according the models: {}"
+            ).format(", ".join(checked_models.keys())),
             LogLevel.INFO,
         )
+
         # multiple iteration through the (not many) models to keep the workflow structured
         model_files = {}
         for model in checked_models.keys():
@@ -509,14 +525,12 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                     ).format(model),
                     LogLevel.INFO,
                 )
-                repo, file = self.workflow_wizard.get_filepath_from_ilicache(
-                    model
-                )
+                repo, url, file = self._get_filepath_from_ilicache(model)
                 if file:
                     (
                         local_file,
                         message,
-                    ) = self.workflow_wizard.download_ilifile(repo, file)
+                    ) = self._download_ilifile(repo, url, file)
                     if local_file:
                         self.workflow_wizard.log_panel.print_info(
                             message,
@@ -538,7 +552,9 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
 
         if not model_files:
             self.workflow_wizard.log_panel.print_info(
-                self.tr("No model files found to prophety the settings..."),
+                self.tr(
+                    "No model files found to control the ili2db options..."
+                ),
                 LogLevel.INFO,
             )
             return
@@ -550,7 +566,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             )
             if os.path.exists(imd_file):
                 self.workflow_wizard.log_panel.print_info(
-                    self.tr("- Metamodel for Model {} found in cache.").format(
+                    self.tr("- Metamodel for model {} found in cache.").format(
                         model
                     ),
                     LogLevel.INFO,
@@ -559,7 +575,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                 continue
             self.workflow_wizard.log_panel.print_info(
                 self.tr(
-                    "- Metamodel for Model {} needs to be compiled..."
+                    "- Metamodel for model {} needs to be compiled..."
                 ).format(model),
                 LogLevel.INFO,
             )
@@ -576,14 +592,14 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             else:
                 self.workflow_wizard.log_panel.print_info(
                     self.tr(
-                        "  ...metamodel for Model {} successfully compiled."
+                        "  ...metamodel for model {} successfully compiled."
                     ).format(model),
                     LogLevel.INFO,
                 )
                 imd_files[model] = imd_file
         if not imd_files:
             self.workflow_wizard.log_panel.print_info(
-                self.tr("No imds found to prophety the settings..."),
+                self.tr("No imds found to control the ili2db options..."),
                 LogLevel.INFO,
             )
             return
@@ -593,7 +609,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             model_indexes[model] = BakerPyIndex.from_imd(imd_files[model])
         if not model_indexes:
             self.workflow_wizard.log_panel.print_info(
-                self.tr("No indexes found to prophety the settings..."),
+                self.tr("No indexes found to control the ili2db options..."),
                 LogLevel.INFO,
             )
             return
@@ -602,9 +618,86 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         if settings_prophet is not None:
             self.ili2db_options.load_prophethy_settings(settings_prophet)
         self.workflow_wizard.log_panel.print_info(
-            self.tr("Prophety the settings according the models finished."),
+            self.tr(
+                "Enable/disable the ili2db options according the models finished."
+            ),
             LogLevel.INFO,
         )
+
+    def _get_filepath_from_ilicache(self, model_name):
+        """
+        Check the workflow_wizard's ilicache model for the file path of the given model.
+        """
+        if self.workflow_wizard.ilicache_basemodel.rowCount() > 0:
+            indexes = self.workflow_wizard.ilicache_basemodel.match(
+                self.workflow_wizard.ilicache_basemodel.index(0, 0),
+                int(Qt.ItemDataRole.EditRole),
+                model_name,
+                1,
+                Qt.MatchFlag.MatchExactly,
+            )
+            if indexes:
+                # falsch
+                repo = indexes[0].data(
+                    int(self.workflow_wizard.ilicache_basemodel.Roles.ILIREPO)
+                )
+                file = indexes[0].data(
+                    int(self.workflow_wizard.ilicache_basemodel.Roles.FILE)
+                )
+                url = indexes[0].data(
+                    int(self.workflow_wizard.ilicache_basemodel.Roles.URL)
+                )
+                return repo, url, file
+        return None, None, None
+
+    def _download_ilifile(self, netloc, url, file):
+        if url is None:
+            file_url = file
+        elif os.path.isdir(url):
+            file_url = os.path.join(url, file)
+        else:
+            file_url = urllib.parse.urljoin(url + "/", file)
+
+        if url is None or os.path.isdir(url):
+            file_path = os.path.normpath(file_url)
+            # continue with the local file
+            if os.path.exists(file_path):
+                return file_path, self.tr(
+                    "  ...successfully found the ili file in the local repository."
+                )
+            else:
+                return None, self.tr(
+                    "  ...failed to find the ili file in the local repository."
+                )
+        else:
+            file_dir = os.path.normpath(
+                os.path.join(
+                    IliCache.CACHE_PATH, netloc, os.path.dirname(file)
+                )
+            )
+            os.makedirs(file_dir, exist_ok=True)
+
+            target_file_path = os.path.join(file_dir, os.path.basename(file))
+            if os.path.exists(target_file_path):
+                return target_file_path, self.tr(
+                    "  ...successfully found the ili file in the cache."
+                )
+
+        # in case there are backslashes in the url, remove them
+        file_url = file_url.replace("\\", "/")
+        # download ilimodels.xml
+        try:
+            qt_utils.download_file(
+                file_url,
+                target_file_path,
+            )
+            return target_file_path, self.tr(
+                "  ...successfully downloaded the ili file."
+            )
+        except Exception as e:
+            return None, self.tr(
+                "  ...failed to download the ili file. {}"
+            ).format(str(e))
 
     def _load_crs_from_metaconfig(self, ili2db_metaconfig):
         srs_auth = self.srs_auth

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -75,7 +75,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self.model_list_view.space_pressed.connect(
             self.workflow_wizard.import_models_model.check
         )
-        self.model_list_view.model().modelReset.connect(
+        self.workflow_wizard.import_models_model.model_refreshed.connect(
             self._update_models_dependent_info
         )
 
@@ -88,6 +88,15 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
 
         self.ilimetaconfigcache = IliDataCache(
             self.workflow_wizard.import_schema_configuration.base_configuration
+        )
+        self.ilimetaconfigcache.file_download_succeeded.connect(
+            lambda dataset_id, path: self._on_metaconfig_received(path)
+        )
+        self.ilimetaconfigcache.file_download_failed.connect(
+            self._on_metaconfig_failed
+        )
+        self.ilimetaconfigcache.model_refreshed.connect(
+            self._update_metaconfig_completer
         )
         self.metaconfig_delegate = IliDataFileCompleterDelegate()
         self.metaconfig = configparser.ConfigParser()
@@ -113,6 +122,11 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             self._update_linked_models
         )
 
+        self.linked_model_busy_state = False
+        self.update_metaconfig_completer_busy_state = False
+        self.load_metaconfig_busy_state = False
+        self.prophecy_settings_busy_state = False
+
     def isComplete(self):
         return self.is_complete
 
@@ -135,7 +149,6 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self._update_crs_info()
         self._crs_changed()
         self._fill_toml_file_info_label()
-        self._update_models_dependent_info()
 
     def update_configuration(self, configuration):
         # metaconfig settings
@@ -179,15 +192,44 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             "QgisModelBaker/ili2db/srs_code", updated_configuration.srs_code
         )
 
+    def _update_busy_state(self):
+        if (
+            self.linked_model_busy_state
+            or self.update_metaconfig_completer_busy_state
+            or self.load_metaconfig_busy_state
+            or self.prophecy_settings_busy_state
+        ):
+            self.workflow_wizard.busy(self, True)
+            self.setComplete(False)
+        else:
+            self.workflow_wizard.busy(self, False)
+            self.setComplete(True)
+
+    def _linked_model_busy(self, busy):
+        self.linked_model_busy_state = busy
+        self._update_busy_state()
+
+    def _update_metaconfig_completer_busy(self, busy):
+        self.update_metaconfig_completer_busy_state = busy
+        self._update_busy_state()
+
+    def _load_metaconfig_busy(self, busy):
+        self.load_metaconfig_busy_state = busy
+        self._update_busy_state()
+
+    def _prophecy_settings_busy(self, busy):
+        self.prophecy_settings_busy_state = busy
+        self._update_busy_state()
+
     def _update_models_dependent_info(self):
         """
         When something in the models model change:
         - Checks all checked models for CRS_PATTERNS (takes first match)
         - Calls update of ilimetaconfig cache to provide metaconfigurations
         - Calls update of ilireferencedata cache to load referenced
-        - Calls update of prophety settings to provide a good default for the ili2db options
+        - Calls update of prophecy settings to provide a good default for the ili2db options
         """
-        model_list = self.model_list_view.model().checked_models()
+        model_list = self.workflow_wizard.import_models_model.checked_models()
         self.current_models = model_list
         for pattern, crs in CRS_PATTERNS.items():
             if re.search(pattern, ", ".join(model_list)):
@@ -196,41 +238,35 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                 break
         self._update_ilimetaconfigcache()
         self._update_ilireferencedatacache()
-        self._update_prophety_settings()
+        self._prophecy_settings_busy(True)
+        self._update_prophecy_settings()
+        self._prophecy_settings_busy(False)
 
     def _update_ilimetaconfigcache(self):
-        self.ilimetaconfigcache = IliDataCache(
-            self.workflow_wizard.import_schema_configuration.base_configuration,
-            models=";".join(self.model_list_view.model().checked_models()),
-            datasources=["pg"]
-            if (
-                self.workflow_wizard.import_schema_configuration.tool
-                & DbIliMode.pg
+        self._update_metaconfig_completer_busy(True)
+        self.ilimetaconfigcache.filter_models = (
+            self.workflow_wizard.import_models_model.checked_models()
+        )
+        self.ilimetaconfigcache.datasources = (
+            ["pg"]
+            if self.workflow_wizard.import_schema_configuration.tool
+            & DbIliMode.pg
+            else (
+                ["gpkg"]
+                if (
+                    self.workflow_wizard.import_schema_configuration.tool
+                    & DbIliMode.gpkg
+                )
+                else None
             )
-            else ["gpkg"]
-            if (
-                self.workflow_wizard.import_schema_configuration.tool
-                & DbIliMode.gpkg
-            )
-            else None,
-        )
-        self.ilimetaconfigcache.file_download_succeeded.connect(
-            lambda dataset_id, path: self._on_metaconfig_received(path)
-        )
-        self.ilimetaconfigcache.file_download_failed.connect(
-            self._on_metaconfig_failed
-        )
-        self.ilimetaconfigcache.model_refreshed.connect(
-            self._update_metaconfig_completer
-        )
-        self.workflow_wizard.busy(
-            self, True, self.tr("Refresh repository data...")
         )
         self._refresh_ili_metaconfig_cache()
 
     def _update_ilireferencedatacache(self):
-        self.workflow_wizard.refresh_referencedata_cache(
-            self.model_list_view.model().checked_models(), "referenceData"
+        self._linked_model_busy(True)
+        self.workflow_wizard.update_referecedata_cache_model(
+            self.workflow_wizard.import_models_model.checked_models(),
+            "referenceData",
         )
 
     def _fill_toml_file_info_label(self):
@@ -332,7 +368,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         completer.popup().setItemDelegate(self.metaconfig_delegate)
         self.ili_metaconfig_line_edit.setCompleter(completer)
         self.ili_metaconfig_line_edit.setEnabled(bool(rows))
-        self.workflow_wizard.busy(self, False)
+        self._update_metaconfig_completer_busy(False)
 
     def _on_metaconfig_completer_activated(self, text=None):
         self._clean_metaconfig()
@@ -344,6 +380,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             Qt.MatchFlag.MatchExactly,
         )
         if matches:
+            self._load_metaconfig_busy(True)
             model_index = matches[0]
             metaconfig_id = self.ilimetaconfigcache.model.data(
                 model_index, int(IliDataItemModel.Roles.ID)
@@ -382,8 +419,6 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             dataset_id = self.ilimetaconfigcache.model.data(
                 model_index, int(IliDataItemModel.Roles.ID)
             )
-            # disable the next buttton
-            self.setComplete(False)
             if path:
                 self.ilimetaconfigcache.download_file(
                     repository, url, path, dataset_id
@@ -434,7 +469,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             self.workflow_wizard.log_panel.print_info(
                 self.tr("Metaconfig successfully loaded."), LogLevel.TOPPING
             )
-            self.setComplete(True)
+            self._load_metaconfig_busy(False)
 
     def _on_metaconfig_failed(self, dataset_id, error_msg):
         self.workflow_wizard.log_panel.print_info(
@@ -443,12 +478,9 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             ),
             LogLevel.TOPPING,
         )
-        # enable the next buttton
-        self.setComplete(True)
+        self._load_metaconfig_busy(False)
 
     def _update_linked_models(self):
-        self.workflow_wizard.busy(self, True, "Update linked models...")
-
         linked_models = []
 
         for r in range(
@@ -468,6 +500,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                     ]
                 )
 
+        sources_added = False
         for linked_model in linked_models:
             model_name = linked_model.split(":")[0]
             if self.workflow_wizard.source_model.add_source(
@@ -476,22 +509,27 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                 None,
                 self.tr("Linked model referenced over ilidata repository"),
             ):
-                self._refresh_model_data()
+                sources_added = True
 
-        self.workflow_wizard.busy(self, False)
+        if sources_added:
+            # we added new sources, we have to refresh the import models model
+            self._refresh_model_data()
+            return
+
+        self._linked_model_busy(False)
 
     def _refresh_model_data(self):
         self.workflow_wizard.refresh_import_models()
 
-    def _update_prophety_settings(self):
+    def _update_prophecy_settings(self):
         """
-        Prophety the ili2db settings according to the checked models.
+        prophecy the ili2db settings according to the checked models.
         1. Get the checked models with their source (local or repository)
         2. For each model, get the local file path (download if necessary)
         3. For each model, compile the model to get the imd file (if not already cached)
         4. For each model, create a BakerPyIndex from the imd file
         5. Create a SettingsProphet with the model indexes and the MODELS_BLACKLIST
-        6. Load the prophety settings into the ili2db_options
+        6. Load the prophecy settings into the ili2db_options
         """
         checked_models = (
             self.workflow_wizard.import_models_model.checked_models_with_source()
@@ -583,7 +621,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                 model_files[model], None, imd_file
             )
             if not result:
-                self.workflow_wizard.log_panel.print_error(
+                self.workflow_wizard.log_panel.print_info(
                     self.tr("  ...failed to compile model file {}: {}").format(
                         model, message
                     ),
@@ -616,7 +654,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
 
         settings_prophet = SettingsProphet(model_indexes, MODELS_BLACKLIST)
         if settings_prophet is not None:
-            self.ili2db_options.load_prophethy_settings(settings_prophet)
+            self.ili2db_options.load_prophecy_settings(settings_prophet)
         self.workflow_wizard.log_panel.print_info(
             self.tr(
                 "Enable/disable the ili2db options according the models finished."
@@ -715,7 +753,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
         self._crs_changed()
 
     def _load_metaconfig(self):
-        self.workflow_wizard.busy(self, True, "Load metaconfiguration...")
+        sources_added = False
         # load ili2db parameters to the GUI
         if "ch.ehi.ili2db" in self.metaconfig.sections():
             self.workflow_wizard.log_panel.print_info(
@@ -744,6 +782,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                         None,
                         self.tr("Model defined in metaconfigurationfile"),
                     )
+                    sources_added = True
                 self.workflow_wizard.log_panel.print_info(
                     self.tr("- Loaded models"), LogLevel.TOPPING
                 )
@@ -763,7 +802,9 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                     )
                 )
                 self.ili2db_options.load_toml_file_path(
-                    ";".join(self.model_list_view.model().checked_models()),
+                    ";".join(
+                        self.workflow_wizard.import_models_model.checked_models()
+                    ),
                     ";".join(ili_meta_attrs_file_path_list),
                 )
                 self.workflow_wizard.log_panel.print_info(
@@ -857,6 +898,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                                 "Datafile referenced in the metaconfigurationfile"
                             ),
                         )
+                        sources_added = True
                     else:
                         self.workflow_wizard.log_panel.print_info(
                             self.tr(
@@ -864,9 +906,9 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
                             ).format(referencedata_file_path),
                             LogLevel.TOPPING,
                         )
+        if sources_added:
             self._refresh_model_data()
-
-        self.workflow_wizard.busy(self, False)
+            return
 
     def help_text(self):
         logline = self.tr(

--- a/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_schema_configuration_page.py
@@ -539,7 +539,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
 
         self.workflow_wizard.log_panel.print_info(
             self.tr(
-                "Enable/disable the ili2db options according the models: {}"
+                "Enable/disable the ili2db options according to the models: {}"
             ).format(", ".join(checked_models.keys())),
             LogLevel.INFO,
         )
@@ -657,7 +657,7 @@ class ImportSchemaConfigurationPage(QWizardPage, PAGE_UI):
             self.ili2db_options.load_prophecy_settings(settings_prophet)
         self.workflow_wizard.log_panel.print_info(
             self.tr(
-                "Enable/disable the ili2db options according the models finished."
+                "Successfully enabled/disabled the ili2db options according to the models."
             ),
             LogLevel.INFO,
         )

--- a/QgisModelBaker/gui/workflow_wizard/import_source_selection_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/import_source_selection_page.py
@@ -76,6 +76,7 @@ class ImportSourceSelectionPage(QWizardPage, PAGE_UI):
         self.ilicache = IliCache(
             self.workflow_wizard.import_schema_configuration.base_configuration
         )
+        self.workflow_wizard.ilicache_basemodel = self.ilicache.model
         self.model_delegate = ModelCompleterDelegate()
         self.input_line_edit.setPlaceholderText(
             self.tr("[Browse for file or search model from repositories]")

--- a/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
+++ b/QgisModelBaker/gui/workflow_wizard/project_creation_page.py
@@ -48,6 +48,7 @@ from QgisModelBaker.libs.modelbaker.utils.qt_utils import make_file_selector
 from QgisModelBaker.utils import gui_utils
 from QgisModelBaker.utils.globals import (
     CATALOGUE_DATASETNAME,
+    ORIGINAL_MODEL_LANGUAGE,
     displayLanguages,
 )
 from QgisModelBaker.utils.gui_utils import MODELS_BLACKLIST, LogLevel
@@ -292,9 +293,7 @@ class ProjectCreationPage(QWizardPage, PAGE_UI):
             else:
                 self.translation_combo.setEnabled(False)
 
-        self.translation_combo.addItem(
-            self.tr("Original model language"), "__"
-        )
+        self.translation_combo.addItem(ORIGINAL_MODEL_LANGUAGE, "__")
 
         # Synchronize length of both comboboxes
         self.translation_combo.setMinimumSize(

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -20,12 +20,14 @@ import logging
 import os
 import pathlib
 import re
+import urllib
 
 from qgis.PyQt.QtCore import QT_VERSION_STR, QEventLoop, QSize, Qt, QTimer
 from qgis.PyQt.QtGui import QPixmap
 from qgis.PyQt.QtWidgets import QDialog, QSplitter, QVBoxLayout, QWizard
 
 import QgisModelBaker.libs.modelbaker.utils.db_utils as db_utils
+import QgisModelBaker.libs.modelbaker.utils.qt_utils as qt_utils
 from QgisModelBaker.gui.panel.log_panel import LogPanel
 from QgisModelBaker.gui.workflow_wizard.database_selection_page import (
     DatabaseSelectionPage,
@@ -60,7 +62,9 @@ from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbconfig import (
     UpdateDataConfiguration,
 )
 from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
+    IliCache,
     IliDataCache,
+    IliModelItemModel,
     IliToppingFileCache,
 )
 from QgisModelBaker.libs.modelbaker.utils.globals import DbActionType
@@ -112,14 +116,15 @@ class WorkflowWizard(QWizard):
         self.export_data_configuration.base_configuration = self.base_config
 
         # data models are keeped on top level because sometimes they need to be accessed to evaluate the wizard workflow
+        # the ilicache_basemodel keeps the nested indexes with all the model informaiton.
+        # IliCache.model is referenced on the source selection page init
+        self.ilicache_basemodel = IliModelItemModel()
         # the source_model keeps all the sources (files or repositories) used and the dataset property
         self.source_model = SourceModel()
         self.source_model.print_info.connect(self.log_panel.print_info)
-
         # the import_models_model keeps every single model as entry and a checked state
         self.import_models_model = ImportModelsModel()
         self.import_models_model.print_info.connect(self.log_panel.print_info)
-
         # the import_data_file_model keeps the filtered out transfer files (from source model) and functions to get ordered import sessions
         self.import_data_file_model = ImportDataModel()
         self.import_data_file_model.print_info.connect(
@@ -463,6 +468,7 @@ class WorkflowWizard(QWizard):
         return self.current_id
 
     def id_changed(self, new_id):
+        self.busy(self, True, self.tr("Loading page..."))
         self.current_id = new_id
 
         self.log_panel.print_info(
@@ -595,6 +601,7 @@ class WorkflowWizard(QWizard):
             self.export_data_execution_page.setup_sessions(
                 self.export_data_configuration, sessions
             )
+        self.busy(self, False)
 
     def _update_configurations(self, page):
         # update all configurations to have the same settings for all of them
@@ -664,6 +671,54 @@ class WorkflowWizard(QWizard):
         return self.import_models_model.refresh_model(
             self.source_model, db_connector, silent
         )
+
+    def get_filepath_from_ilicache(self, model_name):
+        if self.ilicache_basemodel.rowCount() > 0:
+            indexes = self.ilicache_basemodel.match(
+                self.ilicache_basemodel.index(0, 0),
+                int(Qt.ItemDataRole.EditRole),
+                model_name,
+                1,
+                Qt.MatchFlag.MatchExactly,
+            )
+            if indexes:
+                # falsch
+                repo = indexes[0].data(
+                    int(self.ilicache_basemodel.Roles.ILIREPO)
+                )
+                file = indexes[0].data(int(self.ilicache_basemodel.Roles.FILE))
+                return repo, file
+        return None, None
+
+    def download_ilifile(self, repo, file):
+        # this does not handle local repositories.
+        # For that we have to check maybe the ilidatacache download function. Let's see.
+        # To add the http statically is not supernice neither, but for now it works. We can refactor later.
+        source_url = urllib.parse.urljoin("http://" + repo + "/", file)
+        netloc_dir = os.path.join(
+            IliCache.CACHE_PATH, repo, os.path.dirname(file)
+        )
+        os.makedirs(netloc_dir, exist_ok=True)
+        target_file_path = os.path.join(netloc_dir, os.path.basename(file))
+        if os.path.exists(target_file_path):
+            return target_file_path, self.tr(
+                "  ...successfully found the ili file in the cache."
+            )
+
+        # download ilimodels.xml
+        try:
+            qt_utils.download_file(
+                source_url,
+                target_file_path,
+            )
+            return target_file_path, self.tr(
+                "  ...successfully downloaded the ili file."
+            )
+
+        except Exception as e:
+            return None, self.tr(
+                "  ...failed to download the ili file. {}"
+            ).format(str(e))
 
     def get_topping_file_list(self, id_list):
         topping_file_model = self.get_topping_file_model(id_list)

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -20,14 +20,12 @@ import logging
 import os
 import pathlib
 import re
-import urllib
 
 from qgis.PyQt.QtCore import QT_VERSION_STR, QEventLoop, QSize, Qt, QTimer
 from qgis.PyQt.QtGui import QPixmap
 from qgis.PyQt.QtWidgets import QDialog, QSplitter, QVBoxLayout, QWizard
 
 import QgisModelBaker.libs.modelbaker.utils.db_utils as db_utils
-import QgisModelBaker.libs.modelbaker.utils.qt_utils as qt_utils
 from QgisModelBaker.gui.panel.log_panel import LogPanel
 from QgisModelBaker.gui.workflow_wizard.database_selection_page import (
     DatabaseSelectionPage,
@@ -62,7 +60,6 @@ from QgisModelBaker.libs.modelbaker.iliwrapper.ili2dbconfig import (
     UpdateDataConfiguration,
 )
 from QgisModelBaker.libs.modelbaker.iliwrapper.ilicache import (
-    IliCache,
     IliDataCache,
     IliModelItemModel,
     IliToppingFileCache,
@@ -671,54 +668,6 @@ class WorkflowWizard(QWizard):
         return self.import_models_model.refresh_model(
             self.source_model, db_connector, silent
         )
-
-    def get_filepath_from_ilicache(self, model_name):
-        if self.ilicache_basemodel.rowCount() > 0:
-            indexes = self.ilicache_basemodel.match(
-                self.ilicache_basemodel.index(0, 0),
-                int(Qt.ItemDataRole.EditRole),
-                model_name,
-                1,
-                Qt.MatchFlag.MatchExactly,
-            )
-            if indexes:
-                # falsch
-                repo = indexes[0].data(
-                    int(self.ilicache_basemodel.Roles.ILIREPO)
-                )
-                file = indexes[0].data(int(self.ilicache_basemodel.Roles.FILE))
-                return repo, file
-        return None, None
-
-    def download_ilifile(self, repo, file):
-        # this does not handle local repositories.
-        # For that we have to check maybe the ilidatacache download function. Let's see.
-        # To add the http statically is not supernice neither, but for now it works. We can refactor later.
-        source_url = urllib.parse.urljoin("http://" + repo + "/", file)
-        netloc_dir = os.path.join(
-            IliCache.CACHE_PATH, repo, os.path.dirname(file)
-        )
-        os.makedirs(netloc_dir, exist_ok=True)
-        target_file_path = os.path.join(netloc_dir, os.path.basename(file))
-        if os.path.exists(target_file_path):
-            return target_file_path, self.tr(
-                "  ...successfully found the ili file in the cache."
-            )
-
-        # download ilimodels.xml
-        try:
-            qt_utils.download_file(
-                source_url,
-                target_file_path,
-            )
-            return target_file_path, self.tr(
-                "  ...successfully downloaded the ili file."
-            )
-
-        except Exception as e:
-            return None, self.tr(
-                "  ...failed to download the ili file. {}"
-            ).format(str(e))
 
     def get_topping_file_list(self, id_list):
         topping_file_model = self.get_topping_file_model(id_list)

--- a/QgisModelBaker/ui/ili2db_options.ui
+++ b/QgisModelBaker/ui/ili2db_options.ui
@@ -17,6 +17,9 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
    <item row="4" column="1">
     <widget class="QGroupBox" name="create_gpkg_multigeom_groupbox">
      <property name="title">
@@ -37,7 +40,7 @@
     </widget>
    </item>
    <item row="1" column="1">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="create_basket_groupbox">
      <property name="title">
       <string>Create Basket Column</string>
      </property>
@@ -56,7 +59,7 @@
     </widget>
    </item>
    <item row="7" column="1">
-    <widget class="QFrame" name="frame">
+    <widget class="QFrame" name="toml_frame">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
      </property>
@@ -95,7 +98,7 @@
     </widget>
    </item>
    <item row="5" column="1">
-    <widget class="QGroupBox" name="groupBox_3">
+    <widget class="QGroupBox" name="stroke_arcs_groupbox">
      <property name="title">
       <string>Stroke arcs</string>
      </property>
@@ -114,7 +117,7 @@
     </widget>
    </item>
    <item row="6" column="1">
-    <widget class="QGroupBox" name="groupBox_4">
+    <widget class="QGroupBox" name="script_groupbbox">
      <property name="title">
       <string>SQL scripts</string>
      </property>
@@ -280,7 +283,7 @@
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QGroupBox" name="enumeration_group_box">
+    <widget class="QGroupBox" name="enumeration_groupbox">
      <property name="title">
       <string>Enumeration Handling</string>
      </property>
@@ -322,7 +325,7 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QGroupBox" name="inheritance_group_box">
+    <widget class="QGroupBox" name="inheritance_groupbox">
      <property name="title">
       <string>Inheritance type</string>
      </property>

--- a/QgisModelBaker/utils/globals.py
+++ b/QgisModelBaker/utils/globals.py
@@ -56,6 +56,10 @@ displayLanguages = {
     "es": QCoreApplication.translate("QgisModelBaker", "Spanish"),
 }
 
+ORIGINAL_MODEL_LANGUAGE = QCoreApplication.translate(
+    "QgisModelBaker", "Original model language"
+)
+
 
 class AdministrativeDBActionTypes(Enum):
     """Defines constants for modelbaker actions that require superuser login"""

--- a/QgisModelBaker/utils/globals.py
+++ b/QgisModelBaker/utils/globals.py
@@ -53,6 +53,7 @@ displayLanguages = {
     "fr": QCoreApplication.translate("QgisModelBaker", "French"),
     "it": QCoreApplication.translate("QgisModelBaker", "Italian"),
     "rm": QCoreApplication.translate("QgisModelBaker", "Romansh"),
+    "es": QCoreApplication.translate("QgisModelBaker", "Spanish"),
 }
 
 

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -518,6 +518,8 @@ class ImportModelsModel(SourceModel):
     Inherits SourceModel to use functions and signals like print_info etc.
     """
 
+    model_refreshed = pyqtSignal()
+
     def __init__(self):
         super().__init__()
         self._checked_models = {}
@@ -675,6 +677,7 @@ class ImportModelsModel(SourceModel):
                                 data_file_path,
                             )
                         )
+        self.model_refreshed.emit()
         return self.rowCount()
 
     def _transfer_file_models(self, data_file_path):
@@ -897,6 +900,7 @@ class ImportModelsModel(SourceModel):
                     Qt.ItemDataRole.CheckStateRole,
                     Qt.CheckState.Checked,
                 )
+        self.model_refreshed.emit()
 
     def _relevant_type_source(self, info_list):
         # when one type is ili, we take this path (because user selected file on purpose) otherwise repository

--- a/QgisModelBaker/utils/gui_utils.py
+++ b/QgisModelBaker/utils/gui_utils.py
@@ -927,6 +927,17 @@ class ImportModelsModel(SourceModel):
                 sessions[source]["models"] = models
         return sessions
 
+    def checked_models_with_source(self):
+        models_with_source = {}
+        for r in range(0, self.rowCount()):
+            item = self.index(r, 0)
+            model = item.data(int(SourceModel.Roles.NAME))
+            if self._checked_models[model] == Qt.CheckState.Checked:
+                info = item.data(int(SourceModel.Roles.INFO))
+                type, source = self._relevant_type_source(info)
+                models_with_source[model] = {"type": type, "source": source}
+        return models_with_source
+
     def checked_models(self):
         # return a list of the model names
         return [


### PR DESCRIPTION
Requires https://github.com/opengisch/QgisModelBakerLibrary/pull/175

## Add libs for ili2py
Because ili2py is using absolute import paths, we need to add the lib path of the modelbaker library to the sys path.

## Settings Prophet

In the `ImportSchemaConfigurationPage` the models model is reloaded (means by entering the page or activating/deactivating a model or receiving an additional model (by metaconfig or by dependency)), we do the following:
1. Get the checked models with their source (local or repository)
2. For each model, get the local file path (download if necessary)
3. For each model, compile the model to get the imd file (if not already cached)
4. For each model, create a BakerPyIndex from the imd file
5. Create a SettingsProphet with the model indexes and the MODELS_BLACKLIST
6. Load the prophety settings into the ili2db_options

### Actions in the ili2db pptions:
- Hides/unhides the Basket Column Setting depending on whether a basket column is required.
- Sets the Basket Column Setting depending on whether a basket column is required. If it is not required, it does not touch the setting (meaning it does not unset it).
- Hides/unhides the StrokeArcs Setting depending on whether arcs are found in the model.
- Hides/unhides the Multiple Geometry Columns Setting depending on whether multiple columns are found in a class of the model.
- Hides/unhides the Multiple Enumeration Setting depending on whether enums are found in the model.
- Hides/unhides EnumTabs option if extended enums are found in the model and smart1 is chosen -> this is interactive, see below. 
- Hides/unhides the Translation Setting if it detects the model as a translated model.

### EnumTabs with Smart1 and extended enumerations

Extended enumerations cannot be handled with smart1 inheritance strategy and enumTabs option. This means we have to avoid this combination.

https://github.com/user-attachments/assets/6acafbc0-b3d1-42ad-b19c-ab5dc666577a

When changing to smart1, it hides enumtabs, and if enumtabs was currently active, it jumps to singleenumtab. When changing back to smart2 it remains on singleenumtab (meaning it does not set it back - this is because otherwise it would be too confusing).

### Examples

|  `KbS_V1_5`  | Settings |
| :--- | :--- |
| <ul><li>has no BASKET OID definition and no extended topics</li><li>has no arc geometries</li><li>has multiple geometries in one class</li><li>has enumerations (but not extended ones)</li><li>it's not a translated model</li></ul> | <img width="530" height="652" alt="image" src="https://github.com/user-attachments/assets/1bb2e518-b3b9-4d46-b66b-500e9d7136a5" /> |

|  `Nutzungsplanung_V1_2`  | Settings |
| :--- | :--- |
| <ul><li>has BASKET OID definition and no extended topics</li><li>has arc geometries</li><li>has no multiple geometries in one class</li><li>has enumerations (but not extended ones)</li><li>it's not a translated model</li></ul> | <img width="530" height="578" alt="image" src="https://github.com/user-attachments/assets/1a58bab5-4091-441b-9a73-59542f74617b" /> |

|  `PlansDAffectation_V1_2`  | Settings |
| :--- | :--- |
| <ul><li>has BASKET OID definition and no extended topics</li><li>has arc geometries</li><li>has no multiple geometries in one class</li><li>has enumerations (but not extended ones)</li><li>it's a translated model</li></ul> | <img width="666" height="655" alt="image" src="https://github.com/user-attachments/assets/576293cf-0bea-4369-bf81-2e7c16eb87dc" />|

|  `KT_ArcInfrastruktur_V1`  \* | Settings |
| :--- | :--- |
| <ul><li>has no BASKET OID definition but extended topics</li><li>has arc geometries</li><li>has multiple geometries in one class</li><li>has no enumerations</li><li>it's not a translated model</li></ul> | <img width="420" height="520" alt="image" src="https://github.com/user-attachments/assets/4109ef37-3b66-421a-b123-edd5c0d27ae0" /> |

|  `Colors_V2`  \* | Settings |
| :--- | :--- |
| <ul><li>has no BASKET OID definition and no extended topics</li><li>has no arc geometries</li><li>has no multiple geometries in one class</li><li>has extended enumerations</li><li>it's not a translated model</li></ul> | <img width="530" height="578" alt="image" src="https://github.com/user-attachments/assets/033129aa-7f4a-42b3-8ecc-08f838459fda" /> |

-> see above (EnumTabs with Smart1 and exteded enumations) what would happen on `Colors_V2` on changing to smart1.

\* test models from the [modelbaker library ](https://github.com/opengisch/QgisModelBakerLibrary)

## Fix inconsequential busy and inactive state

On receiving the model list, it does:
- check for referenced data (e.g. catalogues and find the models there: if so, it triggeres the whole thing again)
- check for available metaconfig files
- prophesy the settings

And on selecting a metaconfig file, it might find additional models, what would trigger the whole thing again as well.

See more otes in [comment here](https://github.com/opengisch/QgisModelBaker/pull/1148#issuecomment-5021168280) might be refactored once anyway, but for now I just improved the behavior like this: Avoided multiple connected slots, updating even when no models found and improved the busy state to have one busy phase instead of multiple small ones here 1785de5f707a417994cddcda3983b589886432cb

## Sponsors

QGIS Model Baker Group :v:
