### PR TITLE
Security Round 2

### DIFF
--- a/QgisModelBaker/gui/panel/dataset_selector.py
+++ b/QgisModelBaker/gui/panel/dataset_selector.py
@@ -102,7 +102,7 @@ class DatasetSelector(QComboBox):
                     self.set_default_project_variables(schema_identificator)
                 except:
                     # let it pass, it will have no entries what is okay
-                    pass
+                    pass  # nosec
 
         if QT_VERSION_STR < "5.12.0":
             self.filtered_model.setFilterRegExp(

--- a/QgisModelBaker/gui/panel/export_models_panel.py
+++ b/QgisModelBaker/gui/panel/export_models_panel.py
@@ -41,7 +41,8 @@ class ExportModelsPanel(QWidget, WIDGET_UI):
                 self.items_view.clicked.disconnect()
                 self.items_view.space_pressed.disconnect()
             except Exception:
-                pass
+                # let it pass when having no connections
+                pass  # nosec
 
             self.items_view.setModel(self.parent.current_export_models_model)
             self.items_view.clicked.connect(self.items_view.model().check)

--- a/QgisModelBaker/gui/panel/filter_data_panel.py
+++ b/QgisModelBaker/gui/panel/filter_data_panel.py
@@ -41,7 +41,8 @@ class FilterDataPanel(QWidget, WIDGET_UI):
             try:
                 self.filter_combobox.currentIndexChanged.disconnect()
             except Exception:
-                pass
+                # let it pass when having no connections
+                pass  # nosec
 
             self._refresh_filter_combobox(basket_handling)
 
@@ -93,7 +94,8 @@ class FilterDataPanel(QWidget, WIDGET_UI):
             self.items_view.space_pressed.disconnect()
             self.items_view.model().dataChanged.disconnect()
         except Exception:
-            pass
+            # let it pass when having no connections
+            pass  # nosec
 
         self.items_view.setModel(model)
         self.items_view.clicked.connect(self.items_view.model().check)

--- a/QgisModelBaker/gui/validate.py
+++ b/QgisModelBaker/gui/validate.py
@@ -123,7 +123,9 @@ class FixedDelegate(QStyledItemDelegate):
             font = option.font
             font.setStrikeOut(True)
             option.font = font
-            option.palette.setColor(option.palette.Text, QColor(Qt.gray))
+            option.palette.setColor(
+                option.palette.Text, QColor(Qt.GlobalColor.gray)
+            )
         super().paint(painter, option, index)
 
 

--- a/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
+++ b/QgisModelBaker/gui/workflow_wizard/workflow_wizard.py
@@ -720,15 +720,13 @@ class WorkflowWizard(QWizard):
             for downloaded_file_id in topping_file_cache.downloaded_files:
                 if downloaded_file_id in missing_file_ids:
                     missing_file_ids.remove(downloaded_file_id)
-            try:
-                self.log_panel.print_info(
-                    self.tr(
-                        "- - Some topping files where not successfully downloaded: {}"
-                    ).format(" ".join(missing_file_ids)),
-                    LogLevel.TOPPING,
-                )
-            except Exception:
-                pass
+
+            self.log_panel.print_info(
+                self.tr(
+                    "- - Some topping files where not successfully downloaded: {}"
+                ).format(" ".join(missing_file_ids)),
+                LogLevel.TOPPING,
+            )
 
         return topping_file_cache.model
 

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 LIBS_DIR="QgisModelBaker/libs"
 
-MODELBAKER_LIBRARY=("modelbaker" "3.2.0")
-PACKAGING=("packaging" "21.3")
+MODELBAKER_LIBRARY=("modelbaker" "3.2.1")
 
 PACKAGES=(
   MODELBAKER_LIBRARY[@]
-  PACKAGING[@]
 )
 
 #create lib folder


### PR DESCRIPTION
In plugin

Error Type | Line | File | Code Snippet
-- | -- | -- | --
B110:try_except_pass | 103 | ./gui/panel/dataset_selector.py | except:
B110:try_except_pass | 43 | ./gui/panel/export_models_panel.py | except Exception:
B110:try_except_pass | 43 | ./gui/panel/filter_data_panel.py | except Exception:
B110:try_except_pass | 95 | ./gui/panel/filter_data_panel.py | except Exception:
B110:try_except_pass | 730 | ./gui/workflow_wizard/workflow_wizard.py | except Exception:

In library

Error Type | Line | File | Code Snippet
-- | -- | -- | --
B105:hardcoded_password_string | 27 | ./libs/modelbaker/iliwrapper/ili2dbconfig.py | self.super_pg_password = "postgres"
B404:blacklist | 19 | ./libs/modelbaker/iliwrapper/ili2dbutils.py | import subprocess
B110:try_except_pass | 277 | ./libs/modelbaker/iliwrapper/ili2dbutils.py | except Exception:
B603:subprocess_without_shell_equals_true | 317 | ./libs/modelbaker/iliwrapper/ili2dbutils.py | p = subprocess.Popen([java_path, "-version"], ...)
B105:hardcoded_password_string | 77 | ./libs/modelbaker/processing/ili2db_algorithm.py | PASSWORD = "PASSWORD"
B105:hardcoded_password_string | 50 | ./libs/modelbaker/processing/util_layersourceparsing.py | PASSWORD = "PASSWORD"

In packaging

Error Type | Line | File | Code Snippet
-- | -- | -- | --
B101:assert_used | 146 | ./libs/packaging/_manylinux.py | assert version_string is not None
B404:blacklist | 13 | ./libs/packaging/_musllinux.py | import subprocess
B603:subprocess_without_shell_equals_true | 106 | ./libs/packaging/_musllinux.py | proc = subprocess.run([ld], stderr=subprocess.PIPE,...)
B101:assert_used | 130 | ./libs/packaging/_musllinux.py | assert plat.startswith("linux-"), "not linux"
B101:assert_used | 152 | ./libs/packaging/markers.py | assert isinstance(marker, (list, tuple, str))
B101:assert_used | 226 | ./libs/packaging/markers.py | assert isinstance(marker, (list, tuple, str))
B101:assert_used | 242 | ./libs/packaging/markers.py | assert marker in ["and", "or"]

In libraries packaging

Error Type | Line | File | Code Snippet
-- | -- | -- | --
B101:assert_used | 97 | ./libs/modelbaker/libs/packaging/_manylinux.py | assert version_string is not None
B404:blacklist | 11 | ./libs/modelbaker/libs/packaging/_musllinux.py | import subprocess
B603:subprocess_without_shell_equals_true | 52 | ./libs/modelbaker/libs/packaging/_musllinux.py | proc = subprocess.run([ld], check=False, ...)
B101:assert_used | 79 | ./libs/modelbaker/libs/packaging/_musllinux.py | assert plat.startswith("linux-"), "not linux"
B101:assert_used | 121 | ./libs/modelbaker/libs/packaging/_tokenizer.py | assert self.next_token is None, (...)
B101:assert_used | 124 | ./libs/modelbaker/libs/packaging/_tokenizer.py | assert name in self.rules, f"Unknown token name..."
B101:assert_used | 147 | ./libs/modelbaker/libs/packaging/_tokenizer.py | assert token is not None
B105:hardcoded_password_string | 130 | ./libs/modelbaker/libs/packaging/licenses/__init__.py | elif token == "with":
B105:hardcoded_password_string | 133 | ./libs/modelbaker/libs/packaging/licenses/__init__.py | token == "("
B105:hardcoded_password_string | 136 | ./libs/modelbaker/libs/packaging/licenses/__init__.py | ) or (token == ")" and python_tokens and ...
B101:assert_used | 179 | ./libs/modelbaker/libs/packaging/markers.py | assert isinstance(marker, (list, tuple, str))
B101:assert_used | 241 | ./libs/modelbaker/libs/packaging/markers.py | assert isinstance(rhs, str), "extra value must be..."
B101:assert_used | 274 | ./libs/modelbaker/libs/packaging/markers.py | assert isinstance(lhs_value, str), "lhs must be..."
B101:assert_used | 228 | ./libs/modelbaker/libs/packaging/metadata.py | assert isinstance(payload, str)
B101:assert_used | 234 | ./libs/modelbaker/libs/packaging/metadata.py | assert isinstance(bpayload, bytes)
B101:assert_used | 380 | ./libs/modelbaker/libs/packaging/metadata.py | assert isinstance(h, (email.header.Header, str))
B101:assert_used | 630 | ./libs/modelbaker/libs/packaging/specifiers.py | assert spec_version is not None
B404:blacklist | 12 | ./libs/modelbaker/libs/packaging/tags.py | import subprocess
B603:subprocess_without_shell_equals_true | 608 | ./libs/modelbaker/libs/packaging/tags.py | version_str = subprocess.run([...]).stdout

